### PR TITLE
Add fantasy folk reptilians

### DIFF
--- a/Library/Banestorm/Banestorm Traits.adq
+++ b/Library/Banestorm/Banestorm Traits.adq
@@ -96,12 +96,23 @@
 			"id": "t50RYqFLKGRMdD6rL",
 			"name": "Social Stigma (Barbarian)",
 			"reference": "BS186",
-			"local_notes": "-2 Reaction from others; +2 Reaction by Barbarians",
 			"tags": [
 				"Disadvantage",
 				"Social"
 			],
 			"base_points": -10,
+			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from other Barbarians",
+					"amount": 2
+				},
+				{
+					"type": "reaction_bonus",
+					"situation": "from civilized folk",
+					"amount": -2
+				}
+			],
 			"calc": {
 				"points": -10
 			}

--- a/Library/Banestorm/Races/Reptile Man.gct
+++ b/Library/Banestorm/Races/Reptile Man.gct
@@ -521,25 +521,6 @@
 					}
 				},
 				{
-					"id": "tJgARlt6JnnnCJo8t",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Basic Set/Basic Set Traits.adq",
-						"id": "thdJ55ghf__io9AQa"
-					},
-					"name": "Longevity",
-					"reference": "B66",
-					"local_notes": "You fail aging rolls only on a 17 or 18, or only on an 18 if your modified HT is 17 or better",
-					"tags": [
-						"Advantage",
-						"Physical"
-					],
-					"base_points": 2,
-					"calc": {
-						"points": 2
-					}
-				},
-				{
 					"id": "tUQRaYM9CEHQlerXa",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
@@ -659,33 +640,6 @@
 					],
 					"calc": {
 						"points": 1
-					}
-				},
-				{
-					"id": "t2jPVDteyGbPci4ws",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Basic Set/Basic Set Traits.adq",
-						"id": "touwUIFalnae02BUl"
-					},
-					"name": "Temperature Tolerance",
-					"reference": "B93",
-					"tags": [
-						"Advantage",
-						"Physical"
-					],
-					"modifiers": [
-						{
-							"id": "mcudjICLYtCDUFhSG",
-							"name": "Centered at 80 degrees"
-						}
-					],
-					"points_per_level": 1,
-					"can_level": true,
-					"levels": 5,
-					"calc": {
-						"points": 5,
-						"current_level": 5
 					}
 				},
 				{
@@ -845,38 +799,238 @@
 					}
 				},
 				{
-					"id": "tsdqKTf9i1fFUfWi6",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Banestorm/Banestorm Traits.adq",
-						"id": "t50RYqFLKGRMdD6rL"
+					"id": "TuU5uczKLuhknfCVr",
+					"name": "Yrth or Dungeon Fantasy",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
 					},
-					"name": "Social Stigma (Barbarian)",
-					"reference": "BS186",
-					"tags": [
-						"Disadvantage",
-						"Social"
-					],
-					"base_points": -10,
-					"features": [
+					"children": [
 						{
-							"type": "reaction_bonus",
-							"situation": "from other Barbarians",
-							"amount": 2
+							"id": "TK8BPNp0-0KwO0IwB",
+							"name": "Banestorm Reptile Folk",
+							"children": [
+								{
+									"id": "tJgARlt6JnnnCJo8t",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "thdJ55ghf__io9AQa"
+									},
+									"name": "Longevity",
+									"reference": "B66",
+									"local_notes": "You fail aging rolls only on a 17 or 18, or only on an 18 if your modified HT is 17 or better",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"base_points": 2,
+									"calc": {
+										"points": 2
+									}
+								},
+								{
+									"id": "t2jPVDteyGbPci4ws",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "touwUIFalnae02BUl"
+									},
+									"name": "Temperature Tolerance",
+									"reference": "B93",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mcudjICLYtCDUFhSG",
+											"name": "Centered at 80 degrees"
+										}
+									],
+									"points_per_level": 1,
+									"can_level": true,
+									"levels": 5,
+									"calc": {
+										"points": 5,
+										"current_level": 5
+									}
+								},
+								{
+									"id": "tsdqKTf9i1fFUfWi6",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Banestorm/Banestorm Traits.adq",
+										"id": "t50RYqFLKGRMdD6rL"
+									},
+									"name": "Social Stigma (Barbarian)",
+									"reference": "BS186",
+									"tags": [
+										"Disadvantage",
+										"Social"
+									],
+									"base_points": -10,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from other Barbarians",
+											"amount": 2
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from civilized folk",
+											"amount": -2
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								}
+							],
+							"calc": {
+								"points": -3
+							}
 						},
 						{
-							"type": "reaction_bonus",
-							"situation": "from civilized folk",
-							"amount": -2
+							"id": "TwVCFajT3Qgh_ZG-H",
+							"name": "Dungeon Fantasy Reptile Folk",
+							"reference": "FFRR15",
+							"children": [
+								{
+									"id": "tXsaPwFTE1USRt9bH",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "touwUIFalnae02BUl"
+									},
+									"name": "Temperature Tolerance",
+									"reference": "B93",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mUCSvFnSvXy4x3qBD",
+											"name": "Centered at 80 degrees"
+										}
+									],
+									"points_per_level": 1,
+									"can_level": true,
+									"levels": 4,
+									"calc": {
+										"points": 4,
+										"current_level": 4
+									}
+								},
+								{
+									"id": "t4iNBJC34r4lXV2Yl",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tADHt96N0YvzBBqMQ"
+									},
+									"name": "Social Stigma (Monster)",
+									"reference": "B155",
+									"tags": [
+										"Disadvantage",
+										"Social"
+									],
+									"base_points": -15,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "intimidation"
+											},
+											"amount": 1
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from others",
+											"amount": -3
+										}
+									],
+									"calc": {
+										"points": -15
+									}
+								}
+							],
+							"calc": {
+								"points": -11
+							}
 						}
 					],
 					"calc": {
-						"points": -10
+						"points": -14
+					}
+				},
+				{
+					"id": "TGnUZcfu2zjHJY_b0",
+					"name": "In some settings and periods, all Reptile Men have this trait",
+					"reference": "FFRR15",
+					"reference_highlight": "Savage Reptile Men",
+					"template_picker": {
+						"type": "count"
+					},
+					"children": [
+						{
+							"id": "thC8PjBRz2Jytz_1e",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t49qcxpm53kg-OdPj"
+							},
+							"name": "Odious Personal Habit",
+							"reference": "B22",
+							"local_notes": "@Habit@",
+							"tags": [
+								"Disadvantage",
+								"Physical"
+							],
+							"replacements": {
+								"Habit": "Eats other sapients"
+							},
+							"modifiers": [
+								{
+									"id": "mgGwv8UWHM6fqaecs",
+									"name": "-1 Reaction",
+									"reference": "B22",
+									"cost_adj": "-5",
+									"disabled": true
+								},
+								{
+									"id": "mW_5I5ntLWj-nPG76",
+									"name": "-2 Reaction",
+									"reference": "B22",
+									"cost_adj": "-10",
+									"disabled": true
+								},
+								{
+									"id": "mx3N7zTmdDSMMNJul",
+									"name": "-3 Reaction",
+									"reference": "B22",
+									"cost_adj": "-15"
+								}
+							],
+							"calc": {
+								"points": -15,
+								"resolved_notes": "Eats other sapients"
+							}
+						}
+					],
+					"calc": {
+						"points": -15
 					}
 				}
 			],
 			"calc": {
-				"points": 55
+				"points": 29
 			}
 		}
 	],

--- a/Library/Banestorm/Races/Reptile Man.gct
+++ b/Library/Banestorm/Races/Reptile Man.gct
@@ -6,167 +6,288 @@
 			"id": "TOPetM-64McteANpJ",
 			"name": "Reptile Man",
 			"reference": "BS197",
-			"local_notes": "Features: Can't learn most other languages beyond the Accented level.",
 			"children": [
 				{
-					"id": "T8940gSdniXdrpLg2",
-					"name": "Attributes",
-					"children": [
+					"id": "tUOlCDbUUYIbnHEYG",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tpuWKQ-QR0MKnmxCx"
+					},
+					"name": "Taboo Trait (@Trait@)",
+					"reference": "B261",
+					"tags": [
+						"Exotic",
+						"Mental",
+						"Physical",
+						"Taboo Trait"
+					],
+					"replacements": {
+						"Trait": "Can't learn most other languages beyond the Accented level"
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tyQSmZssSLEBFj2Rv",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tqha9GlDBU9P-Wg-6"
+					},
+					"name": "Increased Strength",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
 						{
-							"id": "tDisVRCp2aCfYVCR1",
-							"name": "Decreased Intelligence",
+							"id": "myvr36UPMIPd6ligE",
+							"name": "No Fine Manipulators",
 							"reference": "B15",
-							"tags": [
-								"Attribute",
-								"Disadvantage",
-								"Mental"
-							],
-							"points_per_level": -20,
-							"features": [
-								{
-									"type": "attribute_bonus",
-									"attribute": "iq",
-									"amount": -1,
-									"per_level": true
-								}
-							],
-							"can_level": true,
-							"levels": 1,
-							"calc": {
-								"points": -20,
-								"current_level": 1
-							}
+							"cost_adj": "-40%",
+							"disabled": true
 						},
 						{
-							"id": "t0wnmvWaEYmRGit8V",
-							"name": "Increased Health",
-							"reference": "B14",
-							"tags": [
-								"Advantage",
-								"Attribute",
-								"Physical"
-							],
-							"points_per_level": 10,
-							"features": [
-								{
-									"type": "attribute_bonus",
-									"attribute": "ht",
-									"amount": 1,
-									"per_level": true
-								}
-							],
-							"can_level": true,
-							"levels": 2,
-							"calc": {
-								"points": 20,
-								"current_level": 2
-							}
+							"id": "mugd01M3LCGJZ43KS",
+							"name": "Size",
+							"reference": "B15",
+							"cost_adj": "-10%",
+							"levels": 1
 						},
 						{
-							"id": "t3lmyR2j-NwaMr3vi",
-							"name": "Increased Strength",
-							"reference": "B14",
-							"tags": [
-								"Advantage",
-								"Attribute",
-								"Physical"
-							],
-							"modifiers": [
+							"id": "mLpKPGich8YPxm0Au",
+							"name": "Super-Effort",
+							"reference": "SU24",
+							"cost_adj": "300%",
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 4,
+					"calc": {
+						"points": 36,
+						"current_level": 4
+					}
+				},
+				{
+					"id": "t_x8wGNb1EZirs6iK",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t50ZzyORV0rTiYwnb"
+					},
+					"name": "Decreased Intelligence",
+					"reference": "B15",
+					"tags": [
+						"Attribute",
+						"Disadvantage",
+						"Mental"
+					],
+					"points_per_level": -20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "iq",
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": -20,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "t-3mr9Y8Z-QYMxoam",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 20,
+						"current_level": 2
+					}
+				},
+				{
+					"id": "ti2ki9Zry39OwoS8D",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGpcVbjudWqlXl_xf"
+					},
+					"name": "Increased Size Modifier",
+					"reference": "B19",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "sm",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 0,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "tmeY3WLJy1X8NgUzW",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tj66NHKyO_GObgGsj"
+					},
+					"name": "Sharp Claws",
+					"reference": "B42",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 5,
+					"weapons": [
+						{
+							"id": "wCg3RMhW7j5vGstLv",
+							"sv": 1,
+							"damage": {
+								"type": "cut",
+								"st": "thr",
+								"base": "-1"
+							},
+							"usage": "Slash",
+							"reach": "C",
+							"parry": "0",
+							"defaults": [
 								{
-									"id": "mQ4tLdjQ30cgQswcU",
-									"name": "No Fine Manipulators",
-									"reference": "B15",
-									"cost_adj": "-40%",
-									"disabled": true
+									"type": "dx"
 								},
 								{
-									"id": "mbnby07kezlBcXiAF",
-									"name": "Size",
-									"reference": "B15",
-									"cost_adj": "-10%",
-									"levels": 1
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
-									"id": "meMzWwr7BkMisfPUT",
-									"name": "Super-Effort",
-									"reference": "SU24",
-									"cost_adj": "300%",
-									"disabled": true
-								}
-							],
-							"points_per_level": 10,
-							"features": [
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Boxing"
+									}
+								},
 								{
-									"type": "attribute_bonus",
-									"attribute": "st",
-									"amount": 1,
-									"per_level": true
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Karate"
+									}
 								}
 							],
-							"can_level": true,
-							"levels": 4,
 							"calc": {
-								"points": 36,
-								"current_level": 4
+								"damage": "thr-1 cut"
 							}
 						},
 						{
-							"id": "tVImKhoyy6pNCX7Rc",
-							"name": "Increased Size Modifier",
-							"tags": [
-								"Physical"
-							],
-							"features": [
+							"id": "wgktxdbmi5mbsvj44",
+							"sv": 1,
+							"damage": {
+								"type": "cut",
+								"st": "thr"
+							},
+							"usage": "Kick",
+							"reach": "C,1",
+							"defaults": [
 								{
-									"type": "attribute_bonus",
-									"attribute": "sm",
-									"amount": 1,
-									"per_level": true
+									"type": "dx",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Karate"
+									},
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"modifier": -2
 								}
 							],
-							"can_level": true,
-							"levels": 1,
 							"calc": {
-								"points": 0,
-								"current_level": 1
+								"damage": "thr cut"
 							}
 						}
 					],
 					"calc": {
-						"points": 36
+						"points": 5
 					}
 				},
 				{
-					"id": "T5VGSu-YFqEVz2ZGi",
-					"name": "Racial Advantage",
-					"children": [
+					"id": "tch9H2_QbUf3lF11N",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tBmSJ3pNE53c4IRUU"
+					},
+					"name": "Damage Resistance",
+					"reference": "B46,B47,P45,MA43,PSI14",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
 						{
-							"id": "tXub9p0N5KqK7NEAh",
-							"name": "Damage Resistance",
-							"reference": "B47",
-							"tags": [
-								"Advantage",
-								"Exotic",
-								"Physical"
-							],
-							"modifiers": [
+							"id": "Mn_c7iYE0eWP6c7vP",
+							"name": "Special Enhancements",
+							"children": [
 								{
-									"id": "mtvI8ZAHCcoILRGov",
-									"name": "Force Field",
-									"reference": "B47",
-									"cost_adj": "20%",
-									"disabled": true
-								},
-								{
-									"id": "mV3Xj56VvNI3eAnK7",
-									"name": "Hardened",
-									"reference": "B47",
-									"cost_adj": "20%",
-									"levels": 1,
-									"disabled": true
-								},
-								{
-									"id": "m7K01yxqR3cL0X4Fl",
+									"id": "mPkYESBvKLMZGOV7T",
 									"name": "Absorption",
 									"reference": "B46",
 									"local_notes": "Enhances @Trait@",
@@ -174,7 +295,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mtgSKca__ZGs67uq8",
+									"id": "mSBNM6gwZUT9hDbgE",
 									"name": "Absorption",
 									"reference": "B46",
 									"local_notes": "Healing only",
@@ -182,7 +303,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mK08K1aIOuS3CL1AG",
+									"id": "mfrNwAyyXTZ69P_zE",
 									"name": "Absorption",
 									"reference": "B46",
 									"local_notes": "Enhances any trait",
@@ -190,38 +311,73 @@
 									"disabled": true
 								},
 								{
-									"id": "m0p-JAMvs0sIVmlKM",
+									"id": "mPU8qkjyjmH3ttYt0",
+									"name": "Force Field",
+									"reference": "B47",
+									"cost_adj": "20%",
+									"disabled": true
+								},
+								{
+									"id": "mTkWi73Y6jUiWEFP7",
+									"name": "Hardened",
+									"reference": "B47",
+									"local_notes": "Reduces armor divisor by @Hardened level@ step(s): \"ignores DR\"→100→10→5→3→2→\"no divisor\"",
+									"cost_adj": "20%",
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "meNm-WM0ef38JmC59",
+									"name": "Laminate",
+									"reference": "RSWL18",
+									"cost_adj": "10%",
+									"disabled": true
+								},
+								{
+									"id": "msTZ4Q5IRLsMGaezu",
+									"name": "Malediction-Proof",
+									"reference": "PSI14",
+									"cost_adj": "50%",
+									"disabled": true
+								},
+								{
+									"id": "m6cYkcP4QlQ9CFrOx",
+									"name": "Maledictions Only",
+									"reference": "PSI14",
+									"disabled": true
+								},
+								{
+									"id": "mi6VKSgPlimnxsWsO",
 									"name": "Reflection",
 									"reference": "B47",
 									"cost_adj": "100%",
 									"disabled": true
 								},
 								{
-									"id": "m8neIVDjgNBkMkKr5",
-									"name": "Bane",
-									"reference": "H14",
-									"local_notes": "@Rare@",
-									"cost_adj": "-1",
+									"id": "mPv-DnUyRsIne-7a6",
+									"name": "Mental Resilience",
+									"reference": "PY103:8",
+									"tags": [
+										"Mad as Bones"
+									],
+									"cost_adj": "+100%",
+									"disabled": true
+								}
+							]
+						},
+						{
+							"id": "MkcXA38Hwz9adr-IO",
+							"name": "Special Limitations",
+							"children": [
+								{
+									"id": "mhwzOKeS15U0qlaUE",
+									"name": "Ablative",
+									"reference": "B47",
+									"cost_adj": "-80%",
 									"disabled": true
 								},
 								{
-									"id": "mbIhcHicX5TWMfJwS",
-									"name": "Bane",
-									"reference": "H14",
-									"local_notes": "@Occasional@",
-									"cost_adj": "-5%",
-									"disabled": true
-								},
-								{
-									"id": "mSPvfegKP7BqV9B-Z",
-									"name": "Bane",
-									"reference": "H14",
-									"local_notes": "@Common@",
-									"cost_adj": "-10%",
-									"disabled": true
-								},
-								{
-									"id": "mZU2Fmg6QScgEC2QM",
+									"id": "mVm2hPuu2atYe3Cxm",
 									"name": "Bane",
 									"reference": "H14",
 									"local_notes": "@Very Common@",
@@ -229,7 +385,38 @@
 									"disabled": true
 								},
 								{
-									"id": "maA_wgYli_bIYcOjp",
+									"id": "mDLZ8hsjqMxPMdeh1",
+									"name": "Bane",
+									"reference": "H14",
+									"local_notes": "@Common@",
+									"cost_adj": "-10%",
+									"disabled": true
+								},
+								{
+									"id": "mkBu8jr4bJqXiH962",
+									"name": "Bane",
+									"reference": "H14",
+									"local_notes": "@Occasional@",
+									"cost_adj": "-5%",
+									"disabled": true
+								},
+								{
+									"id": "mrHnfbd-YLDhBs1pR",
+									"name": "Bane",
+									"reference": "H14",
+									"local_notes": "@Rare@",
+									"cost_adj": "-1",
+									"disabled": true
+								},
+								{
+									"id": "mMAe5HI80ER7wC0j_",
+									"name": "Can't wear armor",
+									"reference": "B47",
+									"cost_adj": "-40%",
+									"disabled": true
+								},
+								{
+									"id": "maOxSvPCO6leQ5q_Q",
 									"name": "Directional",
 									"reference": "B47",
 									"local_notes": "Front",
@@ -237,36 +424,7 @@
 									"disabled": true
 								},
 								{
-									"id": "m8YifUlRZ8gIaOo--",
-									"name": "Flexible",
-									"reference": "B47",
-									"cost_adj": "-20%",
-									"disabled": true
-								},
-								{
-									"id": "mDl40aA6iZ3gcegcN",
-									"name": "Limited",
-									"reference": "B46",
-									"local_notes": "@Very Common Attack Form@",
-									"cost_adj": "-20%",
-									"disabled": true
-								},
-								{
-									"id": "mrNAQiFM9n7AFqV78",
-									"name": "Semi-Ablative",
-									"reference": "B47",
-									"cost_adj": "-20%",
-									"disabled": true
-								},
-								{
-									"id": "mvKTZPi7WbJ_FE6c4",
-									"name": "Can't wear armor",
-									"reference": "B47",
-									"cost_adj": "-40%",
-									"disabled": true
-								},
-								{
-									"id": "mRtOFTYmCquhFvF2c",
+									"id": "m-QffuWm8Pi5LJ5Rm",
 									"name": "Directional",
 									"reference": "B47",
 									"local_notes": "@Direction: Back, Right, Left, Top or Underside@",
@@ -274,7 +432,22 @@
 									"disabled": true
 								},
 								{
-									"id": "mhtzlQjyOM_zyi4sm",
+									"id": "mOzLF0d1ej9XDB7KS",
+									"name": "Flexible",
+									"reference": "B47",
+									"cost_adj": "-20%",
+									"disabled": true
+								},
+								{
+									"id": "mkrNZbnT3IqCz9A6S",
+									"name": "Limited",
+									"reference": "B46",
+									"local_notes": "@Very Common Attack Form@",
+									"cost_adj": "-20%",
+									"disabled": true
+								},
+								{
+									"id": "m4BK_cE0gA2wQ_vIi",
 									"name": "Limited",
 									"reference": "B46",
 									"local_notes": "@Common Attack Form@",
@@ -282,13 +455,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mn9C404EB8qf07nsJ",
-									"name": "Tough Skin",
-									"local_notes": "Effects that just require skin contact or a scratch ignore this DR",
-									"cost_adj": "-40%"
-								},
-								{
-									"id": "mtUgNewN7UatY4lQa",
+									"id": "moPVHbfgIof8klazb",
 									"name": "Limited",
 									"reference": "B46",
 									"local_notes": "@Occasional Attack Form@",
@@ -296,14 +463,7 @@
 									"disabled": true
 								},
 								{
-									"id": "mNqnoLH7RhX7aw0cq",
-									"name": "Ablative",
-									"reference": "B47",
-									"cost_adj": "-80%",
-									"disabled": true
-								},
-								{
-									"id": "m7Fo0F4UEgU5SNyBS",
+									"id": "mJT4QSap3Ty2oME30",
 									"name": "Limited",
 									"reference": "B46",
 									"local_notes": "@Rare Attack Form@",
@@ -311,771 +471,407 @@
 									"disabled": true
 								},
 								{
-									"id": "mYV1GZF0488NRZFta",
-									"name": "Laminate",
-									"reference": "RSWL18",
-									"cost_adj": "10%",
+									"id": "m1gMi2Tskg-XiO6U7",
+									"name": "Partial (@Location, 1 level per -1 Per Hit Modifier, Torso is -10% thus level 1@)",
+									"reference": "B47",
+									"cost_adj": "-10%",
 									"disabled": true
-								}
-							],
-							"points_per_level": 5,
-							"features": [
-								{
-									"type": "dr_bonus",
-									"locations": [
-										"eye"
-									],
-									"amount": 1,
-									"per_level": true
 								},
 								{
-									"type": "dr_bonus",
-									"locations": [
-										"skull"
-									],
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "dr_bonus",
-									"locations": [
-										"face"
-									],
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "dr_bonus",
-									"locations": [
-										"neck"
-									],
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "dr_bonus",
-									"locations": [
-										"torso"
-									],
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "dr_bonus",
-									"locations": [
-										"vitals"
-									],
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "dr_bonus",
-									"locations": [
-										"groin"
-									],
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "dr_bonus",
-									"locations": [
-										"arm"
-									],
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "dr_bonus",
-									"locations": [
-										"hand"
-									],
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "dr_bonus",
-									"locations": [
-										"leg"
-									],
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "dr_bonus",
-									"locations": [
-										"foot"
-									],
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "dr_bonus",
-									"locations": [
-										"tail"
-									],
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "dr_bonus",
-									"locations": [
-										"wing"
-									],
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "dr_bonus",
-									"locations": [
-										"fin"
-									],
-									"amount": 1,
-									"per_level": true
-								},
-								{
-									"type": "dr_bonus",
-									"locations": [
-										"brain"
-									],
-									"amount": 1,
-									"per_level": true
-								}
-							],
-							"can_level": true,
-							"levels": 1,
-							"calc": {
-								"points": 3,
-								"current_level": 1
-							}
-						},
-						{
-							"id": "t4K_LfCSp3yhbOSeL",
-							"name": "Longevity",
-							"reference": "B66",
-							"tags": [
-								"Advantage",
-								"Physical"
-							],
-							"base_points": 2,
-							"calc": {
-								"points": 2
-							}
-						},
-						{
-							"id": "tnEjNwdyhM4xk7Esk",
-							"name": "Nictitating Membrane",
-							"reference": "B71",
-							"tags": [
-								"Advantage",
-								"Exotic",
-								"Physical"
-							],
-							"points_per_level": 1,
-							"can_level": true,
-							"levels": 3,
-							"calc": {
-								"points": 3,
-								"current_level": 3
-							}
-						},
-						{
-							"id": "tfHP7nJtDRJjw0-vL",
-							"name": "Peripheral Vision",
-							"reference": "B74",
-							"tags": [
-								"Advantage",
-								"Physical"
-							],
-							"modifiers": [
-								{
-									"id": "mdxnRraKnO5zkX6EY",
-									"name": "Easy to Hit",
-									"reference": "B75",
-									"local_notes": "Others can target your eyes at only -6 to hit",
+									"id": "mr_5KH_KuPwOvTJhP",
+									"name": "Semi-Ablative",
+									"reference": "B47",
 									"cost_adj": "-20%",
 									"disabled": true
-								}
-							],
-							"base_points": 15,
-							"calc": {
-								"points": 15
-							}
-						},
-						{
-							"id": "t_k5UQnaLyI_i3chX",
-							"name": "Claws, Sharp (Hands)",
-							"reference": "B42",
-							"local_notes": "Only pay for hands or feet, not both",
-							"tags": [
-								"Advantage",
-								"Physical"
-							],
-							"base_points": 5,
-							"weapons": [
+								},
 								{
-									"id": "wP5_8klS75Plt308f",
-									"sv": 1,
-									"damage": {
-										"type": "cut",
-										"st": "thr",
-										"base": "-1"
-									},
-									"usage": "Slash",
-									"reach": "C",
-									"parry": "0",
-									"defaults": [
-										{
-											"type": "dx"
-										},
-										{
-											"type": "skill",
-											"name": "Brawling"
-										},
-										{
-											"type": "skill",
-											"name": "Boxing"
-										},
-										{
-											"type": "skill",
-											"name": "Karate"
-										}
-									],
-									"calc": {
-										"damage": "thr-1 cut"
-									}
+									"id": "m-q8P975JqHkV571J",
+									"name": "Tough Skin",
+									"reference": "B47",
+									"local_notes": "Effects that just require skin contact or a scratch ignore this DR",
+									"cost_adj": "-40%"
 								}
-							],
-							"calc": {
-								"points": 5
-							}
-						},
-						{
-							"id": "tQhf9uamXAP-vZKNO",
-							"name": "Teeth, Sharp",
-							"reference": "B91",
-							"tags": [
-								"Exotic",
-								"Perk",
-								"Physical"
-							],
-							"base_points": 1,
-							"weapons": [
-								{
-									"id": "wCb-6qZ-mgEtVTqu6",
-									"sv": 1,
-									"damage": {
-										"type": "cut",
-										"st": "thr",
-										"base": "-1"
-									},
-									"usage": "Bite",
-									"reach": "C",
-									"defaults": [
-										{
-											"type": "skill",
-											"name": "Brawling"
-										},
-										{
-											"type": "dx"
-										}
-									],
-									"calc": {
-										"damage": "thr-1 cut"
-									}
-								}
-							],
-							"calc": {
-								"points": 1
-							}
-						},
-						{
-							"id": "tfPt9n-SRbfEYfuK_",
-							"name": "Temperature Tolerance",
-							"reference": "B93",
-							"local_notes": "Centered at 80 degrees",
-							"tags": [
-								"Advantage",
-								"Physical"
-							],
-							"points_per_level": 1,
-							"can_level": true,
-							"levels": 5,
-							"calc": {
-								"points": 5,
-								"current_level": 5
-							}
+							]
 						}
 					],
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"all"
+							],
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
 					"calc": {
-						"points": 34
+						"points": 3,
+						"current_level": 1
 					}
 				},
 				{
-					"id": "Tc6SZYQX67_nGd63h",
-					"name": "Racial Disadvantage",
-					"children": [
+					"id": "tJgARlt6JnnnCJo8t",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "thdJ55ghf__io9AQa"
+					},
+					"name": "Longevity",
+					"reference": "B66",
+					"local_notes": "You fail aging rolls only on a 17 or 18, or only on an 18 if your modified HT is 17 or better",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 2,
+					"calc": {
+						"points": 2
+					}
+				},
+				{
+					"id": "tUQRaYM9CEHQlerXa",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tWNGzCluuu3S1L8jv"
+					},
+					"name": "Nictitating Membrane",
+					"reference": "B71",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 1,
+					"features": [
 						{
-							"id": "tqcVr3XgVtpeI24yc",
-							"name": "Shyness",
-							"reference": "B154",
-							"tags": [
-								"Disadvantage",
-								"Mental"
+							"type": "conditional_modifier",
+							"situation": "to all HT rolls concerned with eye damage",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
 							],
-							"modifiers": [
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 3,
+						"current_level": 3
+					}
+				},
+				{
+					"id": "tVF06qfN05DT5oWNA",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tc74I5tb8McOGp5nr"
+					},
+					"name": "Peripheral Vision",
+					"reference": "B74,P87",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mgtc8-ZA26tsm0Sac",
+							"name": "Easy to Hit",
+							"reference": "B75",
+							"local_notes": "Others can target your eyes at only -6 to hit",
+							"cost_adj": "-20%",
+							"disabled": true
+						}
+					],
+					"base_points": 15,
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tka9Mecw3Y8ybnz8L",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tK9Ov0WtlrhnJFy5n"
+					},
+					"name": "Sharp Teeth",
+					"reference": "B91",
+					"tags": [
+						"Exotic",
+						"Perk",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "m5YowtSCBTOXSpYxy",
+							"name": "Provided by Vampiric Bite",
+							"reference": "B96",
+							"cost_adj": "-1",
+							"disabled": true
+						}
+					],
+					"base_points": 1,
+					"weapons": [
+						{
+							"id": "wBxib9d8DHAphZZ21",
+							"sv": 1,
+							"damage": {
+								"type": "cut",
+								"st": "thr",
+								"base": "-1"
+							},
+							"usage": "Bite",
+							"reach": "C",
+							"defaults": [
 								{
-									"id": "mtPmkaSuOMo1Qgu9f",
-									"name": "Mild",
-									"reference": "B154",
-									"cost_adj": "-5",
-									"features": [
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "acting"
-											},
-											"amount": -1
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "carousing"
-											},
-											"amount": -1
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "diplomacy"
-											},
-											"amount": -1
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "fast-talk"
-											},
-											"amount": -1
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "intimidation"
-											},
-											"amount": -1
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "leadership"
-											},
-											"amount": -1
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "merchant"
-											},
-											"amount": -1
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "panhandling"
-											},
-											"amount": -1
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "performance"
-											},
-											"amount": -1
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "politics"
-											},
-											"amount": -1
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "public speaking"
-											},
-											"amount": -1
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "contains",
-												"qualifier": "savoir-faire"
-											},
-											"amount": -1
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "sex appeal"
-											},
-											"amount": -1
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "streetwise"
-											},
-											"amount": -1
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "teaching"
-											},
-											"amount": -1
-										}
-									]
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
-									"id": "mMsZyXoyY3eUc-T9D",
-									"name": "Severe",
-									"reference": "B154",
-									"cost_adj": "-10",
-									"features": [
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "acting"
-											},
-											"amount": -2
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "carousing"
-											},
-											"amount": -2
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "diplomacy"
-											},
-											"amount": -2
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "fast-talk"
-											},
-											"amount": -2
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "intimidation"
-											},
-											"amount": -2
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "leadership"
-											},
-											"amount": -2
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "merchant"
-											},
-											"amount": -2
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "panhandling"
-											},
-											"amount": -2
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "performance"
-											},
-											"amount": -2
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "politics"
-											},
-											"amount": -2
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "public speaking"
-											},
-											"amount": -2
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "contains",
-												"qualifier": "savoir-faire"
-											},
-											"amount": -2
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "sex appeal"
-											},
-											"amount": -2
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "streetwise"
-											},
-											"amount": -2
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "teaching"
-											},
-											"amount": -2
-										}
-									],
-									"disabled": true
-								},
-								{
-									"id": "mkgnOdv4E8oVYCMW1",
-									"name": "Crippling",
-									"reference": "B154",
-									"cost_adj": "-20",
-									"features": [
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "acting"
-											},
-											"amount": -4
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "carousing"
-											},
-											"amount": -4
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "diplomacy"
-											},
-											"amount": -4
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "fast-talk"
-											},
-											"amount": -4
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "intimidation"
-											},
-											"amount": -4
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "leadership"
-											},
-											"amount": -4
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "merchant"
-											},
-											"amount": -4
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "panhandling"
-											},
-											"amount": -4
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "performance"
-											},
-											"amount": -4
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "politics"
-											},
-											"amount": -4
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "public speaking"
-											},
-											"amount": -4
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "contains",
-												"qualifier": "savoir-faire"
-											},
-											"amount": -4
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "sex appeal"
-											},
-											"amount": -4
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "streetwise"
-											},
-											"amount": -4
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "teaching"
-											},
-											"amount": -4
-										}
-									],
-									"disabled": true
+									"type": "dx"
 								}
 							],
 							"calc": {
-								"points": -5
-							}
-						},
-						{
-							"id": "tAoFjfFiMN_WKU4de",
-							"name": "Social Stigma (Barbarian)",
-							"reference": "BS186",
-							"local_notes": "-2 Reaction from others; +2 Reaction by Barbarians",
-							"tags": [
-								"Disadvantage",
-								"Social"
-							],
-							"base_points": -10,
-							"calc": {
-								"points": -10
+								"damage": "thr-1 cut"
 							}
 						}
 					],
 					"calc": {
-						"points": -15
+						"points": 1
+					}
+				},
+				{
+					"id": "t2jPVDteyGbPci4ws",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "touwUIFalnae02BUl"
+					},
+					"name": "Temperature Tolerance",
+					"reference": "B93",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mcudjICLYtCDUFhSG",
+							"name": "Centered at 80 degrees"
+						}
+					],
+					"points_per_level": 1,
+					"can_level": true,
+					"levels": 5,
+					"calc": {
+						"points": 5,
+						"current_level": 5
+					}
+				},
+				{
+					"id": "t1n6QNpJSmNqcX217",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tfujsOp4WL4ZholTv"
+					},
+					"name": "Mild Shyness",
+					"reference": "B154",
+					"local_notes": "You are uneasy with strangers, especially assertive or attractive ones.",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"base_points": -5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Acting"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Carousing"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Diplomacy"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Fast-Talk"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Intimidation"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Leadership"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Merchant"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Panhandling"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Performance"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Politics"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Public Speaking"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Savoir-Faire"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Sex Appeal"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Streetwise"
+							},
+							"amount": -1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Teaching"
+							},
+							"amount": -1
+						}
+					],
+					"calc": {
+						"points": -5
+					}
+				},
+				{
+					"id": "tsdqKTf9i1fFUfWi6",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Banestorm/Banestorm Traits.adq",
+						"id": "t50RYqFLKGRMdD6rL"
+					},
+					"name": "Social Stigma (Barbarian)",
+					"reference": "BS186",
+					"tags": [
+						"Disadvantage",
+						"Social"
+					],
+					"base_points": -10,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from other Barbarians",
+							"amount": 2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from civilized folk",
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -10
 					}
 				}
 			],
@@ -1087,11 +883,16 @@
 	"skills": [
 		{
 			"id": "SmZgtdjExvSbGhsZ2",
-			"name": "Reptile Men",
+			"name": "Reptile Man",
 			"reference": "BS197",
 			"children": [
 				{
-					"id": "sTq0w0pC4Nds5MOXT",
+					"id": "sAIGTQNo8bDdgMnnD",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Skills.skl",
+						"id": "sKtd60c-jdtMDfOIt"
+					},
 					"name": "Camouflage",
 					"reference": "B183",
 					"tags": [
@@ -1107,14 +908,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Survival",
+							"name": {
+								"compare": "is",
+								"qualifier": "Survival"
+							},
 							"modifier": -2
 						}
 					],
 					"points": 1
 				},
 				{
-					"id": "sjhg9yb2plLPLD3DW",
+					"id": "sxCwyir7fylDvj_gr",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Skills.skl",
+						"id": "ssRqX3yoUzXbHyiJE"
+					},
 					"name": "Survival",
 					"reference": "B223",
 					"tags": [
@@ -1130,49 +939,94 @@
 						},
 						{
 							"type": "skill",
-							"name": "Naturalist",
+							"name": {
+								"compare": "is",
+								"qualifier": "Naturalist"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Survival",
-							"specialization": "Arctic",
+							"name": {
+								"compare": "is",
+								"qualifier": "Survival"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Arctic"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Survival",
-							"specialization": "Island/Beach",
+							"name": {
+								"compare": "is",
+								"qualifier": "Survival"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Island/Beach"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Survival",
-							"specialization": "Jungle",
+							"name": {
+								"compare": "is",
+								"qualifier": "Survival"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Jungle"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Survival",
-							"specialization": "Mountain",
+							"name": {
+								"compare": "is",
+								"qualifier": "Survival"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Mountain"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Survival",
-							"specialization": "Plains",
+							"name": {
+								"compare": "is",
+								"qualifier": "Survival"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Plains"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Survival",
-							"specialization": "Swampland",
+							"name": {
+								"compare": "is",
+								"qualifier": "Survival"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Swampland"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Survival",
-							"specialization": "Woodlands",
+							"name": {
+								"compare": "is",
+								"qualifier": "Survival"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Woodlands"
+							},
 							"modifier": -3
 						}
 					],

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -1910,8 +1910,9 @@
 		},
 		{
 			"id": "tqyRvrXKWtUMlIEQe",
-			"name": "Alternate Form",
+			"name": "Alternate Form (@Form@)",
 			"reference": "B83",
+			"local_notes": "<script>entity.exists ? \"\" : \"Set levels equal to how much more the form costs than your base form, if it's your most expensive form\"</script>",
 			"tags": [
 				"Advantage",
 				"Exotic",
@@ -1919,7 +1920,16 @@
 			],
 			"modifiers": [
 				{
-					"id": "mpY0iLP8m3hJ-j7E9",
+					"id": "mhWix3XezU6yjuhRe",
+					"name": "Only one alternate form",
+					"reference": "B84",
+					"reference_highlight": "If you have a single Alternate Form",
+					"cost_adj": "-10%",
+					"affects": "levels_only",
+					"disabled": true
+				},
+				{
+					"id": "mz87VPNn5Q7CVrEob",
 					"name": "Cosmetic",
 					"reference": "B84",
 					"cost_adj": "-50%",
@@ -1987,8 +1997,12 @@
 				}
 			],
 			"base_points": 15,
+			"points_per_level": 1,
+			"can_level": true,
 			"calc": {
-				"points": 15
+				"points": 15,
+				"resolved_notes": "Set levels equal to how much more the form costs than your base form, if it's your most expensive form",
+				"current_level": 0
 			}
 		},
 		{

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -32504,15 +32504,60 @@
 			"id": "touwUIFalnae02BUl",
 			"name": "Temperature Tolerance",
 			"reference": "B93",
+			"local_notes": "<script>\nif (entity.exists) {\n  var degreesHotter = 0;\n  var degreesColder = 0;\n  const hotMod = self.findActiveModifier(\"Hot\");\n  const coldMod = self.findActiveModifier(\"Cold\");\n  const degreesHotterMod = self.findActiveModifier(\"Degrees Hotter\");\n  const degreesColderMod = self.findActiveModifier(\"Degrees Colder\");\n  if (hotMod) {\n    degreesHotter = $ht * self.level;\n  }\n  if (coldMod) {\n    degreesColder = $ht *self.level;\n  } \n  if (degreesHotterMod) {\n    degreesHotter = degreesHotterMod.level;\n  }\n  if (degreesColderMod) {\n    degreesColder = degreesColderMod.level;\n  }\n  if (degreesHotter == 0 && degreesColder == 0) {\n    degreesHotter = $ht *self.level / 2;\n    degreesColder = $ht *self.level / 2;\n  }\n  var strings = [];\n  if (degreesHotter != 0) {\n    strings.push(degreesHotter + \"° hotter\");\n  }\n  if (degreesColder != 0) {\n    strings.push(degreesColder +\"° colder\");;\n  }\n  strings.join(\" and \")\n} else {\n  \"Will calculate how much the comfort zone is expanded when added to a character sheet\"\n}\n</script>",
 			"tags": [
 				"Advantage",
 				"Physical"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "script_prereq",
+						"script": "var msgs = [];\nvar modifierCount = 0;\nconst hotMod = self.findActiveModifier(\"Hot\");\nconst coldMod = self.findActiveModifier(\"Cold\");\nconst degreesHotterMod = self.findActiveModifier(\"Degrees Hotter\");\nconst degreesColderMod = self.findActiveModifier(\"Degrees Colder\");\nif (hotMod) {\n  modifierCount++;\n}\nif (coldMod) {\n  modifierCount++;\n}\nif (degreesHotterMod || degreesColderMod) {\n  modifierCount++;\n}\nif (modifierCount > 1) {\n  msgs.push(\"Hot, Cold, and Degrees Hotter/Colder must not be mixed\")\n}\nif (entity.exists) {\n  const expectedLevels = $ht * self.level;\n  var foundLevels = 0;\n  if (degreesHotterMod) {\n    foundLevels += degreesHotterMod.level;\n  }\n  if (degreesColderMod) {\n    foundLevels += degreesColderMod.level;\n  }\n  if (foundLevels != 0 && expectedLevels != foundLevels) {\n    msgs.push(`Total levels of Degrees Hotter and Degrees Colder should be ${expectedLevels} not ${foundLevels}`)\n  }\n}\nmsgs.join(\"\\n* \")"
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "MI1VcdSeblizJBfA0",
+					"name": "Choose how to distribute degrees to the character's comfort zone",
+					"reference": "B93",
+					"reference_highlight": "Each level of TemperatureTolerance adds HT degrees to yourcomfort zone, distributed in any wayyou wish between the “cold” and “hot”ends of the zone.",
+					"local_notes": "Cold means it all goes to tolerating colder temperatures, Hot means it all goes to tolerating hotter temperatures, and Degrees Hotter and Degrees Colder allocate degrees to expanding the temperature range manually. If no modifiers are picked then degrees are distributed evenly",
+					"children": [
+						{
+							"id": "mvjyobEJOxYbZW4m6",
+							"name": "Hot",
+							"disabled": true
+						},
+						{
+							"id": "mPS-5mvnutZR3JDmq",
+							"name": "Cold",
+							"disabled": true
+						},
+						{
+							"id": "mHi-iuFBpG3_YxV-6",
+							"name": "Degrees Hotter",
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "m8AT5TarZDUhOwxBf",
+							"name": "Degrees Colder",
+							"levels": 1,
+							"disabled": true
+						}
+					]
+				}
 			],
 			"points_per_level": 1,
 			"can_level": true,
 			"levels": 1,
 			"calc": {
 				"points": 1,
+				"resolved_notes": "Will calculate how much the comfort zone is expanded when added to a character sheet",
 				"current_level": 1
 			}
 		},

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -59,8 +59,8 @@
 			"reference": "B100, PU2:13",
 			"reference_highlight": "Perks",
 			"tags": [
-				"Physical",
-				"Perk"
+				"Perk",
+				"Physical"
 			],
 			"base_points": 1,
 			"calc": {
@@ -73,8 +73,8 @@
 			"reference": "B100, PU2:17",
 			"reference_highlight": "Perks",
 			"tags": [
-				"Social",
-				"Perk"
+				"Perk",
+				"Social"
 			],
 			"base_points": 1,
 			"calc": {
@@ -87,8 +87,8 @@
 			"reference": "B100, PU2:19",
 			"reference_highlight": "Perks",
 			"tags": [
-				"Supernatural",
-				"Perk"
+				"Perk",
+				"Supernatural"
 			],
 			"base_points": 1,
 			"calc": {
@@ -129,8 +129,8 @@
 			"reference": "B162, PU6:32",
 			"reference_highlight": "Quirks",
 			"tags": [
-				"Social",
-				"Quirk"
+				"Quirk",
+				"Social"
 			],
 			"base_points": -1,
 			"calc": {
@@ -143,8 +143,8 @@
 			"reference": "B162, PU6:33",
 			"reference_highlight": "Quirks",
 			"tags": [
-				"Supernatural",
-				"Quirk"
+				"Quirk",
+				"Supernatural"
 			],
 			"base_points": -1,
 			"calc": {
@@ -447,7 +447,7 @@
 		},
 		{
 			"id": "tAZ31tXG_HzDmVCRp",
-			"name": "Acute Taste \u0026 Smell",
+			"name": "Acute Taste & Smell",
 			"reference": "B35",
 			"tags": [
 				"Advantage",
@@ -1404,13 +1404,16 @@
 					"damage": {
 						"type": "aff"
 					},
-					"usage_notes": "Resist at \u003cscript\u003eformatNum(1-self.attachedTo.level, false, true)\u003c/script\u003e",
+					"usage_notes": "Resist at <script>formatNum(1-self.attachedTo.level, false, true)</script>",
 					"reach": "C",
 					"parry": "0",
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -1427,7 +1430,7 @@
 					"damage": {
 						"type": "aff"
 					},
-					"usage_notes": "Resist at \u003cscript\u003eformatNum(1-self.attachedTo.level, false, true)\u003c/script\u003e",
+					"usage_notes": "Resist at <script>formatNum(1-self.attachedTo.level, false, true)</script>",
 					"accuracy": "3",
 					"range": "10/100",
 					"rate_of_fire": "1",
@@ -1435,12 +1438,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -3364,7 +3376,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -3389,12 +3404,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -3503,15 +3527,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -3535,12 +3568,18 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling",
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Karate",
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							},
 							"modifier": -2
 						}
 					],
@@ -5670,7 +5709,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -5856,7 +5898,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -8184,7 +8229,7 @@
 							"id": "mnmgUy__PpxcSuWvG",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\\\u003e150% of your starting points",
+							"local_notes": "\\>150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},
@@ -9318,7 +9363,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -11357,12 +11405,18 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling",
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Karate",
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							},
 							"modifier": -2
 						}
 					],
@@ -11759,7 +11813,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -11850,7 +11907,7 @@
 				"prereqs": [
 					{
 						"type": "script_prereq",
-						"script": "if (entity.exists) {\n  var points = 0;\n  for (const skill of entity.findSkills(\"@Skill@\")) {\n    points += skill.points;\n  }\n  if (points \u003e 0) {\n    \"No points are invested in @Skill@\"\n  } else {\n    \"\"\n  }\n} else {\n  \"\"\n}"
+						"script": "if (entity.exists) {\n  var points = 0;\n  for (const skill of entity.findSkills(\"@Skill@\")) {\n    points += skill.points;\n  }\n  if (points > 0) {\n    \"No points are invested in @Skill@\"\n  } else {\n    \"\"\n  }\n} else {\n  \"\"\n}"
 					}
 				]
 			},
@@ -12410,7 +12467,7 @@
 					"id": "mWZ94aEkMmxYd7uwx",
 					"name": "Homogenous",
 					"reference": "B60",
-					"local_notes": "Altered wound modifiers: imp \u0026 pi++ are x1/2, pi+ is x1/3, pi is x1/5, pi- is x1/10",
+					"local_notes": "Altered wound modifiers: imp & pi++ are x1/2, pi+ is x1/3, pi is x1/5, pi- is x1/10",
 					"cost_adj": "40",
 					"disabled": true
 				},
@@ -12466,7 +12523,7 @@
 					"id": "m_m2GNV0JSNZjPj-C",
 					"name": "Unliving",
 					"reference": "B61",
-					"local_notes": "Altered wound modifiers: imp \u0026 pi++ are x1, pi+ is x1/2, pi is x1/3, pi- is x1/5",
+					"local_notes": "Altered wound modifiers: imp & pi++ are x1, pi+ is x1/2, pi is x1/3, pi- is x1/5",
 					"cost_adj": "20",
 					"disabled": true
 				}
@@ -13026,7 +13083,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -13051,12 +13111,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -13620,7 +13689,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -13645,12 +13717,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -14121,7 +14202,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -14146,12 +14230,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -14623,7 +14716,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -14648,12 +14744,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -15249,7 +15354,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -15274,12 +15382,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -15750,7 +15867,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -15775,12 +15895,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -16251,7 +16380,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -16276,12 +16408,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -16767,7 +16908,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -16792,12 +16936,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -17283,7 +17436,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -17308,12 +17464,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -17785,7 +17950,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -17810,12 +17978,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -18386,7 +18563,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -18411,12 +18591,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -19671,7 +19860,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -20019,15 +20211,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -20052,15 +20253,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -22395,7 +22605,7 @@
 			"id": "tc2Bw-0JpkS5K2zxY",
 			"name": "Multimillionaire",
 			"reference": "B25, DFRC2:49, DW33",
-			"local_notes": "Starting wealth is \u003cscript\u003e\n// Partial Multimillionaire Levels (SS2:26) allows Multimillionaire level to be any multiple of 0.2.\nlet whole = Math.trunc(self.level), partial = Math.round((self.level - whole)* 10) || 1;\nformatNum(10 ** ( whole + 2) * partial, true, false)\n\u003c/script\u003ex normal",
+			"local_notes": "Starting wealth is <script>\n// Partial Multimillionaire Levels (SS2:26) allows Multimillionaire level to be any multiple of 0.2.\nlet whole = Math.trunc(self.level), partial = Math.round((self.level - whole)* 10) || 1;\nformatNum(10 ** ( whole + 2) * partial, true, false)\n</script>x normal",
 			"tags": [
 				"Advantage",
 				"Social",
@@ -22407,7 +22617,7 @@
 				"prereqs": [
 					{
 						"type": "script_prereq",
-						"script": "const statusModifier = self.findActiveModifier(\"Wealth grants Status\");\nif (statusModifier \u0026\u0026 statusModifier.level == 2 \u0026\u0026 (self.level \u003c 1 || self.level \u003e= 2)) {\n  \"Multimillionaire level must be at least 1 and less than 2 for Wealth grants Status 2\"\n} else if (statusModifier \u0026\u0026 statusModifier.level == 3 \u0026\u0026 self.level \u003c 2) {\n  \"Multimillionaire level must be at least 2 for Wealth grants Status 3\"\n} else { \n  \"\"\n}"
+						"script": "const statusModifier = self.findActiveModifier(\"Wealth grants Status\");\nif (statusModifier && statusModifier.level == 2 && (self.level < 1 || self.level >= 2)) {\n  \"Multimillionaire level must be at least 1 and less than 2 for Wealth grants Status 2\"\n} else if (statusModifier && statusModifier.level == 3 && self.level < 2) {\n  \"Multimillionaire level must be at least 2 for Wealth grants Status 3\"\n} else { \n  \"\"\n}"
 					},
 					{
 						"type": "trait_prereq",
@@ -24421,7 +24631,7 @@
 			"id": "t7a13kFVl53ZfbkrK",
 			"name": "Payload",
 			"reference": "B74",
-			"local_notes": "\u003cscript\u003e\nif(entity.exists) {\n  measure.formatWeight(\n    self.level * entity.encumbrance.basicLift / 10,\n    entity.displayWeightUnits,\n  )\n} else {\n  \"Payload will be calculated when added to a character sheet\"\n}\n\u003c/script\u003e",
+			"local_notes": "<script>\nif(entity.exists) {\n  measure.formatWeight(\n    self.level * entity.encumbrance.basicLift / 10,\n    entity.displayWeightUnits,\n  )\n} else {\n  \"Payload will be calculated when added to a character sheet\"\n}\n</script>",
 			"tags": [
 				"Advantage",
 				"Exotic",
@@ -24868,7 +25078,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -27438,7 +27651,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -27477,15 +27693,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -27508,12 +27733,18 @@
 						},
 						{
 							"type": "skill",
-							"name": "Karate",
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Brawling",
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							},
 							"modifier": -2
 						}
 					],
@@ -27559,7 +27790,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -29291,7 +29525,7 @@
 					"id": "mLKT6nC2M9dezueCh",
 					"name": "One Attack Only effects",
 					"reference": "P79",
-					"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"enable me if One Attack Only is used\"\u003c/script\u003e",
+					"local_notes": "<script>self.attachedTo ? \"\" : \"enable me if One Attack Only is used\"</script>",
 					"cost_adj": "+0",
 					"use_level_from_trait": true,
 					"features": [
@@ -29314,9 +29548,7 @@
 						}
 					],
 					"disabled": true,
-					"calc": {
-						"resolved_notes": "enable me if One Attack Only is used"
-					}
+					"calc": {}
 				},
 				{
 					"id": "m-UVJk8SZQN5VL4ns",
@@ -31790,15 +32022,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -31822,15 +32063,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -34176,7 +34426,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {

--- a/Library/Dragons/Draconic Lizardman.gct
+++ b/Library/Dragons/Draconic Lizardman.gct
@@ -1,0 +1,603 @@
+{
+	"version": 5,
+	"id": "BqDjLChfD38VNWMG8",
+	"traits": [
+		{
+			"id": "Tt80TxoFjoypdJA38",
+			"name": "Draconis Lizardman",
+			"reference": "DR144, FFRR13",
+			"reference_highlight": "Draconic Lizardmen",
+			"ancestry": "Human",
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tuD6LAy52-STD3JMV",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGWOSEE6SmBHACE6Y"
+					},
+					"name": "Increased Dexterity",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "dx",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "t1Sbi4q022FPArLSA",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t1w1RFcFceKR2T9_e"
+					},
+					"name": "Increased Intelligence",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Mental"
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "iq",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 40,
+						"current_level": 2
+					}
+				},
+				{
+					"id": "tikPrUGMGodSVq75j",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "tZRAucXGkEl6yFF8H",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tBmSJ3pNE53c4IRUU"
+					},
+					"name": "Damage Resistance",
+					"reference": "B46,B47,P45,MA43,PSI14",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"all"
+							],
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 5,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "tWx_25FCCIFVU82u1",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tQa3EUrs4Hjt9gxK6"
+					},
+					"name": "Fearlessness",
+					"reference": "B55,MA44",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Fearfulness"
+								}
+							}
+						]
+					},
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 4,
+						"current_level": 2
+					}
+				},
+				{
+					"id": "tU_rsbSH9WRTx-rnw",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "teRggYn926_I1YeWO"
+					},
+					"name": "High Pain Threshold",
+					"reference": "B59",
+					"local_notes": "Never suffer shock penalties when injured",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 10,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "on all HT rolls to avoid knockdown and stunning",
+							"amount": 3
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to resist torture",
+							"amount": 3
+						}
+					],
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tHF09onu7WP3Tr1wO",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tpnv8EEpAS6Er2pwK"
+					},
+					"name": "Magery",
+					"reference": "B66",
+					"tags": [
+						"Advantage",
+						"Mental",
+						"Supernatural"
+					],
+					"base_points": 5,
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "spell_bonus",
+							"match": "all_colleges",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "thaumatology"
+							},
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 25,
+						"current_level": 2
+					}
+				},
+				{
+					"id": "tbevT2UaCy7PocruC",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tWNGzCluuu3S1L8jv"
+					},
+					"name": "Nictitating Membrane",
+					"reference": "B71",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to all HT rolls concerned with eye damage",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 1,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "tAYMvOY64lGfFw7Yl",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tc74I5tb8McOGp5nr"
+					},
+					"name": "Peripheral Vision",
+					"reference": "B74,P87",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 15,
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tWOY5SNF_D0jchM5g",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tK9Ov0WtlrhnJFy5n"
+					},
+					"name": "Sharp Teeth",
+					"reference": "B91",
+					"tags": [
+						"Exotic",
+						"Perk",
+						"Physical"
+					],
+					"base_points": 1,
+					"weapons": [
+						{
+							"id": "wPaXzsoJt0Agbmg-E",
+							"sv": 1,
+							"damage": {
+								"type": "cut",
+								"st": "thr",
+								"base": "-1"
+							},
+							"usage": "Bite",
+							"reach": "C",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
+								},
+								{
+									"type": "dx"
+								}
+							],
+							"calc": {
+								"damage": "thr-1 cut"
+							}
+						}
+					],
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "t4AGRcSFhpctvBBAs",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "touwUIFalnae02BUl"
+					},
+					"name": "Temperature Tolerance",
+					"reference": "B93",
+					"local_notes": "<script>\nif (entity.exists) {\n  var degreesHotter = 0;\n  var degreesColder = 0;\n  const hotMod = self.findActiveModifier(\"Hot\");\n  const coldMod = self.findActiveModifier(\"Cold\");\n  const degreesHotterMod = self.findActiveModifier(\"Degrees Hotter\");\n  const degreesColderMod = self.findActiveModifier(\"Degrees Colder\");\n  if (hotMod) {\n    degreesHotter = $ht * self.level;\n  }\n  if (coldMod) {\n    degreesColder = $ht *self.level;\n  } \n  if (degreesHotterMod) {\n    degreesHotter = degreesHotterMod.level;\n  }\n  if (degreesColderMod) {\n    degreesColder = degreesColderMod.level;\n  }\n  if (degreesHotter == 0 && degreesColder == 0) {\n    degreesHotter = $ht *self.level / 2;\n    degreesColder = $ht *self.level / 2;\n  }\n  var strings = [];\n  if (degreesHotter != 0) {\n    strings.push(degreesHotter + \"° hotter\");\n  }\n  if (degreesColder != 0) {\n    strings.push(degreesColder +\"° colder\");;\n  }\n  strings.join(\" and \")\n} else {\n  \"Will calculate how much the comfort zone is expanded when added to a character sheet\"\n}\n</script>",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "script_prereq",
+								"script": "var msgs = [];\nvar modifierCount = 0;\nconst hotMod = self.findActiveModifier(\"Hot\");\nconst coldMod = self.findActiveModifier(\"Cold\");\nconst degreesHotterMod = self.findActiveModifier(\"Degrees Hotter\");\nconst degreesColderMod = self.findActiveModifier(\"Degrees Colder\");\nif (hotMod) {\n  modifierCount++;\n}\nif (coldMod) {\n  modifierCount++;\n}\nif (degreesHotterMod || degreesColderMod) {\n  modifierCount++;\n}\nif (modifierCount > 1) {\n  msgs.push(\"Hot, Cold, and Degrees Hotter/Colder must not be mixed\")\n}\nif (entity.exists) {\n  const expectedLevels = $ht * self.level;\n  var foundLevels = 0;\n  if (degreesHotterMod) {\n    foundLevels += degreesHotterMod.level;\n  }\n  if (degreesColderMod) {\n    foundLevels += degreesColderMod.level;\n  }\n  if (expectedLevels != foundLevels) {\n    msgs.push(`Total levels of Degrees Hotter and Degrees Colder should be ${expectedLevels} not ${foundLevels}`)\n  }\n}\nmsgs.join(\"\\n* \")"
+							}
+						]
+					},
+					"modifiers": [
+						{
+							"id": "MI2V6uttGcSCvMXZl",
+							"name": "Choose how to distribute degrees to the character's comfort zone",
+							"reference": "B93",
+							"reference_highlight": "Each level of TemperatureTolerance adds HT degrees to yourcomfort zone, distributed in any wayyou wish between the “cold” and “hot”ends of the zone.",
+							"local_notes": "Cold means it all goes to tolerating colder temperatures, Hot means it all goes to tolerating hotter temperatures, and Degrees Hotter and Degrees Colder allocate degrees to expanding the temperature range manually. If no modifiers are picked then degrees are distributed evenly",
+							"children": [
+								{
+									"id": "mpb6jxSSu9A7usE_B",
+									"name": "Degrees Hotter",
+									"levels": 22
+								},
+								{
+									"id": "mLba-42Q6CVONpuMo",
+									"name": "Degrees Colder",
+									"levels": 11
+								}
+							]
+						}
+					],
+					"points_per_level": 1,
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 3,
+						"resolved_notes": "Will calculate how much the comfort zone is expanded when added to a character sheet",
+						"current_level": 3
+					}
+				},
+				{
+					"id": "tDv1sveMcjtZo_7In",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tHa_LwEUawGsB_vO2"
+					},
+					"name": "Disturbing Voice",
+					"reference": "B132",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "voice"
+								}
+							}
+						]
+					},
+					"base_points": -10,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "diplomacy"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "fast-talk"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "performance"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "public speaking"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "sex appeal"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "singing"
+							},
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "tGP_NC5UZHq20YqYN",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tAFhfFoZosiPCFUhy"
+					},
+					"name": "No Sense of Humor",
+					"reference": "B146",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"base_points": -10,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from others in any situation where No Sense of Humor becomes evident",
+							"amount": -2
+						}
+					],
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "tvrhx1ME2cg00pRaW",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t49qcxpm53kg-OdPj"
+					},
+					"name": "Odious Personal Habit",
+					"reference": "B22",
+					"local_notes": "@Habit@",
+					"tags": [
+						"Disadvantage",
+						"Physical"
+					],
+					"replacements": {
+						"Habit": "Willfully enigmatic and rarely volunteer information"
+					},
+					"modifiers": [
+						{
+							"id": "m5tL1xCstOqDXN2Ey",
+							"name": "-1 Reaction",
+							"reference": "B22",
+							"cost_adj": "-5"
+						},
+						{
+							"id": "mpH7DqxvdPvuPC8O4",
+							"name": "-2 Reaction",
+							"reference": "B22",
+							"cost_adj": "-10",
+							"disabled": true
+						},
+						{
+							"id": "mZgFD5OBCJKDb-z87",
+							"name": "-3 Reaction",
+							"reference": "B22",
+							"cost_adj": "-15",
+							"disabled": true
+						}
+					],
+					"calc": {
+						"points": -5,
+						"resolved_notes": "Willfully enigmatic and rarely volunteer information"
+					}
+				},
+				{
+					"id": "tNiw5uKTs8pDuCWJm",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t5Qs23yaRu3D4T_hM"
+					},
+					"name": "Attentive",
+					"reference": "B163",
+					"tags": [
+						"Mental",
+						"Quirk"
+					],
+					"base_points": -1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to skill rolls when working on lengthy tasks, but -3 to notice any important interruption",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": -1
+					}
+				}
+			],
+			"calc": {
+				"points": 108
+			}
+		}
+	]
+}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 3/Dungeon Fantasy 3 Traits.adq
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 3/Dungeon Fantasy 3 Traits.adq
@@ -266,7 +266,7 @@
 			"id": "tgAqCI7HqhE5fY1qM",
 			"name": "Social Stigma (Monster)",
 			"reference": "DF3:11",
-			"local_notes": "-3 reaction; -6 to skills; Denied entry to town on 9 or less",
+			"local_notes": "Denied entry to town on 9 or less",
 			"tags": [
 				"Disadvantage",
 				"Social"
@@ -274,13 +274,23 @@
 			"base_points": -15,
 			"features": [
 				{
+					"type": "reaction_bonus",
+					"situation": "from non-monsters",
+					"amount": -3
+				},
+				{
+					"type": "conditional_modifier",
+					"situation": "to skill rolls for social activities in town and mundane or magical attempts to disguise them",
+					"amount": -6
+				},
+				{
 					"type": "skill_bonus",
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
 						"qualifier": "intimidation"
 					},
-					"amount": 1
+					"amount": 3
 				}
 			],
 			"calc": {

--- a/Library/Dungeon Fantasy/Races/Dragon-Blooded.gct
+++ b/Library/Dungeon Fantasy/Races/Dragon-Blooded.gct
@@ -5,12 +5,96 @@
 		{
 			"id": "Tn45VK_dsAdKxNqax",
 			"name": "Dragon-Blooded",
-			"reference": "DF3:15",
+			"reference": "DF3:15, FFRR12",
 			"ancestry": "Human",
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "tV2X5seSurK2SOogw",
+					"id": "tBcUHNUxqresA19GM",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tqha9GlDBU9P-Wg-6"
+					},
+					"name": "Increased Strength",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mTjUJDbahylj9Q5D1",
+							"name": "No Fine Manipulators",
+							"reference": "B15",
+							"cost_adj": "-40%",
+							"disabled": true
+						},
+						{
+							"id": "mYt8iI6Xgw48eh6b9",
+							"name": "Size",
+							"reference": "B15",
+							"cost_adj": "-10%",
+							"levels": 1,
+							"disabled": true
+						},
+						{
+							"id": "muhSjfsmRY2ToFV7t",
+							"name": "Super-Effort",
+							"reference": "SU24",
+							"cost_adj": "300%",
+							"disabled": true
+						}
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "tk9eb6DbyC3lH2YwR",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "trWrmtbEGN_531Rnv",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Martial Arts/Martial Arts Traits.adq",
@@ -41,51 +125,13 @@
 					}
 				},
 				{
-					"id": "tMWMTojYPWMkXiL3R",
-					"name": "Claws, Sharp (Feet)",
-					"reference": "B42",
-					"tags": [
-						"Advantage",
-						"Physical"
-					],
-					"weapons": [
-						{
-							"id": "wi0jg1vD8iPk8gL3r",
-							"sv": 1,
-							"damage": {
-								"type": "cut",
-								"st": "thr"
-							},
-							"usage": "Kick",
-							"reach": "C,1",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -2
-								},
-								{
-									"type": "skill",
-									"name": "Brawling",
-									"modifier": -2
-								},
-								{
-									"type": "skill",
-									"name": "Karate",
-									"modifier": -2
-								}
-							],
-							"calc": {
-								"damage": "thr cut"
-							}
-						}
-					],
-					"calc": {
-						"points": 0
-					}
-				},
-				{
-					"id": "t2Wd69Q4PtXxD04D3",
-					"name": "Claws, Sharp (Hands)",
+					"id": "tLx-xt3oslIYPiicz",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tj66NHKyO_GObgGsj"
+					},
+					"name": "Sharp Claws",
 					"reference": "B42",
 					"tags": [
 						"Advantage",
@@ -94,7 +140,7 @@
 					"base_points": 5,
 					"weapons": [
 						{
-							"id": "wCM2T6U-lyYTQ4ZEY",
+							"id": "wT9HZec-x2w9RUmDD",
 							"sv": 1,
 							"damage": {
 								"type": "cut",
@@ -110,19 +156,63 @@
 								},
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Boxing"
+									"name": {
+										"compare": "is",
+										"qualifier": "Boxing"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Karate"
+									"name": {
+										"compare": "is",
+										"qualifier": "Karate"
+									}
 								}
 							],
 							"calc": {
 								"damage": "thr-1 cut"
+							}
+						},
+						{
+							"id": "wR-zd12n5chZeGtR0",
+							"sv": 1,
+							"damage": {
+								"type": "cut",
+								"st": "thr"
+							},
+							"usage": "Kick",
+							"reach": "C,1",
+							"defaults": [
+								{
+									"type": "dx",
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Karate"
+									},
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"modifier": -2
+								}
+							],
+							"calc": {
+								"damage": "thr cut"
 							}
 						}
 					],
@@ -131,9 +221,14 @@
 					}
 				},
 				{
-					"id": "tjcVl0BnmwiR1qXVk",
+					"id": "tw_5r25zBtuyDO19F",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tBmSJ3pNE53c4IRUU"
+					},
 					"name": "Damage Resistance",
-					"reference": "B47",
+					"reference": "B46,B47,P45,MA43,PSI14",
 					"tags": [
 						"Advantage",
 						"Exotic",
@@ -141,125 +236,215 @@
 					],
 					"modifiers": [
 						{
-							"id": "mJF_V2u6iisOMAmsK",
-							"name": "Ablative",
-							"reference": "B47",
-							"cost_adj": "-80%",
-							"disabled": true
+							"id": "MLTKfUsAWpO1jP14m",
+							"name": "Special Enhancements",
+							"children": [
+								{
+									"id": "mQCekQXRSbZC21E1j",
+									"name": "Absorption",
+									"reference": "B46",
+									"local_notes": "Enhances @Trait@",
+									"cost_adj": "80%",
+									"disabled": true
+								},
+								{
+									"id": "mXR6TfKLXYmf56fsF",
+									"name": "Absorption",
+									"reference": "B46",
+									"local_notes": "Healing only",
+									"cost_adj": "80%",
+									"disabled": true
+								},
+								{
+									"id": "m5qCwjMwJlnedLVs6",
+									"name": "Absorption",
+									"reference": "B46",
+									"local_notes": "Enhances any trait",
+									"cost_adj": "100%",
+									"disabled": true
+								},
+								{
+									"id": "mAe3gtHmAZ_V6bFoC",
+									"name": "Force Field",
+									"reference": "B47",
+									"cost_adj": "20%",
+									"disabled": true
+								},
+								{
+									"id": "mGp4iYb0sqHBJYV6n",
+									"name": "Hardened",
+									"reference": "B47",
+									"local_notes": "Reduces armor divisor by @Hardened level@ step(s): \"ignores DR\"→100→10→5→3→2→\"no divisor\"",
+									"cost_adj": "20%",
+									"levels": 1,
+									"disabled": true
+								},
+								{
+									"id": "mPi8StGmDMEwdooaa",
+									"name": "Laminate",
+									"reference": "RSWL18",
+									"cost_adj": "10%",
+									"disabled": true
+								},
+								{
+									"id": "mNhZqNMb3E3I3G8vK",
+									"name": "Malediction-Proof",
+									"reference": "PSI14",
+									"cost_adj": "50%",
+									"disabled": true
+								},
+								{
+									"id": "muK9Gq9u-c973lSgM",
+									"name": "Maledictions Only",
+									"reference": "PSI14",
+									"disabled": true
+								},
+								{
+									"id": "mN1BFLIu7qZ-ig734",
+									"name": "Reflection",
+									"reference": "B47",
+									"cost_adj": "100%",
+									"disabled": true
+								},
+								{
+									"id": "mopoQFH9et7SeO4W7",
+									"name": "Mental Resilience",
+									"reference": "PY103:8",
+									"tags": [
+										"Mad as Bones"
+									],
+									"cost_adj": "+100%",
+									"disabled": true
+								}
+							]
 						},
 						{
-							"id": "miBP1tcKMFfA-mBdC",
-							"name": "Absorption",
-							"reference": "B46",
-							"local_notes": "Enhances @Trait@",
-							"cost_adj": "80%",
-							"disabled": true
-						},
-						{
-							"id": "muGmIQPpmDWQOqOMf",
-							"name": "Absorption",
-							"reference": "B46",
-							"local_notes": "Enhances any trait",
-							"cost_adj": "100%",
-							"disabled": true
-						},
-						{
-							"id": "mwF5mz3hzjT0OoloK",
-							"name": "Absorption",
-							"reference": "B46",
-							"local_notes": "Healing only",
-							"cost_adj": "80%",
-							"disabled": true
-						},
-						{
-							"id": "m6Ur8NznH86YBHxse",
-							"name": "Can't wear armor",
-							"reference": "B47",
-							"cost_adj": "-40%",
-							"disabled": true
-						},
-						{
-							"id": "m7pHsNLgrLn6IF4Qv",
-							"name": "Directional",
-							"reference": "B47",
-							"local_notes": "@Direction: Back, Right, Left, Top or Underside@",
-							"cost_adj": "-40%",
-							"disabled": true
-						},
-						{
-							"id": "m3tshxWSkTSMHRoGZ",
-							"name": "Directional",
-							"reference": "B47",
-							"local_notes": "Front",
-							"cost_adj": "-20%",
-							"disabled": true
-						},
-						{
-							"id": "msI9c-1ycnt36NrcL",
-							"name": "Flexible",
-							"reference": "B47",
-							"cost_adj": "-20%",
-							"disabled": true
-						},
-						{
-							"id": "mqRXSQYLPVzg5QbVc",
-							"name": "Hardened",
-							"reference": "B47",
-							"cost_adj": "20%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mlt89JFXi_qzxzKh3",
-							"name": "Limited",
-							"reference": "B46",
-							"local_notes": "@Common Attack Form@",
-							"cost_adj": "-40%",
-							"disabled": true
-						},
-						{
-							"id": "mGaCMNdgooD1LJvin",
-							"name": "Limited",
-							"reference": "B46",
-							"local_notes": "@Occasional Attack Form@",
-							"cost_adj": "-60%",
-							"disabled": true
-						},
-						{
-							"id": "mERCYAVzJQfIUD0pW",
-							"name": "Limited",
-							"reference": "B46",
-							"local_notes": "@Rare Attack Form@",
-							"cost_adj": "-80%",
-							"disabled": true
-						},
-						{
-							"id": "mVDzyUsRyLPCOOILf",
-							"name": "Limited",
-							"reference": "B46",
-							"local_notes": "@Very Common Attack Form@",
-							"cost_adj": "-20%",
-							"disabled": true
-						},
-						{
-							"id": "m1Gmw_dy4pGRpTGDG",
-							"name": "Reflection",
-							"reference": "B47",
-							"cost_adj": "100%",
-							"disabled": true
-						},
-						{
-							"id": "mjmMDurwn3ih2Lk9f",
-							"name": "Semi-Ablative",
-							"reference": "B47",
-							"cost_adj": "-20%",
-							"disabled": true
-						},
-						{
-							"id": "mCvgoh6Mpp2PWslTR",
-							"name": "Tough Skin",
-							"reference": "B47",
-							"cost_adj": "-40%"
+							"id": "MX3ErVEDAx7bNTlZH",
+							"name": "Special Limitations",
+							"children": [
+								{
+									"id": "mM3ubvPPGDGLq-ueg",
+									"name": "Ablative",
+									"reference": "B47",
+									"cost_adj": "-80%",
+									"disabled": true
+								},
+								{
+									"id": "mlDyobB8Zl5otb4gS",
+									"name": "Bane",
+									"reference": "H14",
+									"local_notes": "@Very Common@",
+									"cost_adj": "-15%",
+									"disabled": true
+								},
+								{
+									"id": "mvA0V17xRjU5Dnw0m",
+									"name": "Bane",
+									"reference": "H14",
+									"local_notes": "@Common@",
+									"cost_adj": "-10%",
+									"disabled": true
+								},
+								{
+									"id": "mIMjBTCnuyTiH_BhK",
+									"name": "Bane",
+									"reference": "H14",
+									"local_notes": "@Occasional@",
+									"cost_adj": "-5%",
+									"disabled": true
+								},
+								{
+									"id": "mYBUBAPIszDGkPP7m",
+									"name": "Bane",
+									"reference": "H14",
+									"local_notes": "@Rare@",
+									"cost_adj": "-1",
+									"disabled": true
+								},
+								{
+									"id": "mTiwHpmAx3Rjts4qU",
+									"name": "Can't wear armor",
+									"reference": "B47",
+									"cost_adj": "-40%",
+									"disabled": true
+								},
+								{
+									"id": "mUy7iWRYKuZsMZ3gP",
+									"name": "Directional",
+									"reference": "B47",
+									"local_notes": "Front",
+									"cost_adj": "-20%",
+									"disabled": true
+								},
+								{
+									"id": "maSH7_MUbCN3r8Acf",
+									"name": "Directional",
+									"reference": "B47",
+									"local_notes": "@Direction: Back, Right, Left, Top or Underside@",
+									"cost_adj": "-40%",
+									"disabled": true
+								},
+								{
+									"id": "mF8-AC_3Y3LLpp21h",
+									"name": "Flexible",
+									"reference": "B47",
+									"cost_adj": "-20%",
+									"disabled": true
+								},
+								{
+									"id": "m7ep019BceFI0vMA0",
+									"name": "Limited",
+									"reference": "B46",
+									"local_notes": "@Very Common Attack Form@",
+									"cost_adj": "-20%",
+									"disabled": true
+								},
+								{
+									"id": "mk-QNstBYgaTAorve",
+									"name": "Limited",
+									"reference": "B46",
+									"local_notes": "@Common Attack Form@",
+									"cost_adj": "-40%",
+									"disabled": true
+								},
+								{
+									"id": "mnUYpMs2ibj-ksPgm",
+									"name": "Limited",
+									"reference": "B46",
+									"local_notes": "@Occasional Attack Form@",
+									"cost_adj": "-60%",
+									"disabled": true
+								},
+								{
+									"id": "mXa28mtfv8edECqBw",
+									"name": "Limited",
+									"reference": "B46",
+									"local_notes": "@Rare Attack Form@",
+									"cost_adj": "-80%",
+									"disabled": true
+								},
+								{
+									"id": "mTpiezy3US8FBlZPU",
+									"name": "Partial (@Location, 1 level per -1 Per Hit Modifier, Torso is -10% thus level 1@)",
+									"reference": "B47",
+									"cost_adj": "-10%",
+									"disabled": true
+								},
+								{
+									"id": "mkSr4wBGHWhEPq3A6",
+									"name": "Semi-Ablative",
+									"reference": "B47",
+									"cost_adj": "-20%",
+									"disabled": true
+								},
+								{
+									"id": "m1KLIAIVzJ06OLO_N",
+									"name": "Tough Skin",
+									"reference": "B47",
+									"local_notes": "Effects that just require skin contact or a scratch ignore this DR",
+									"cost_adj": "-40%"
+								}
+							]
 						}
 					],
 					"points_per_level": 5,
@@ -267,7 +452,7 @@
 						{
 							"type": "dr_bonus",
 							"locations": [
-								"skull"
+								"all"
 							],
 							"amount": 1,
 							"per_level": true
@@ -275,105 +460,9 @@
 						{
 							"type": "dr_bonus",
 							"locations": [
-								"face"
+								"eye"
 							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"neck"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"torso"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"vitals"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"groin"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"arm"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"hand"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"leg"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"foot"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"tail"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"wing"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"fin"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"brain"
-							],
-							"amount": 1,
+							"amount": -1,
 							"per_level": true
 						}
 					],
@@ -385,7 +474,12 @@
 					}
 				},
 				{
-					"id": "ts5PRSCvK6ODI8WZX",
+					"id": "tZScSkWfkrVZeFkMk",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tHa_LwEUawGsB_vO2"
+					},
 					"name": "Disturbing Voice",
 					"reference": "B132",
 					"tags": [
@@ -407,8 +501,465 @@
 						]
 					},
 					"base_points": -10,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "diplomacy"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "fast-talk"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "performance"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "public speaking"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "sex appeal"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "singing"
+							},
+							"amount": -2
+						}
+					],
 					"calc": {
 						"points": -10
+					}
+				},
+				{
+					"id": "t0DGAv8Q4ag4m25UE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tuvstBu3EtRU0qAa9"
+					},
+					"name": "Innate Attack (Burn)",
+					"reference": "B61,P53,MA45",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"Attack Type": "Breath"
+					},
+					"modifiers": [
+						{
+							"id": "m5f_B993gQpJbpgoU",
+							"name": "Jet",
+							"features": [
+								{
+									"type": "weapon_max_range_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": -90
+								},
+								{
+									"type": "weapon_half_damage_range_bonus",
+									"percent": true,
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"level": {
+										"compare": "at_least"
+									},
+									"amount": -50
+								}
+							]
+						}
+					],
+					"points_per_level": 5,
+					"weapons": [
+						{
+							"id": "wt0yi3P681L83frOE",
+							"sv": 1,
+							"damage": {
+								"type": "burn",
+								"base_leveled": "1d"
+							},
+							"reach": "C",
+							"parry": "0",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
+								},
+								{
+									"type": "dx"
+								}
+							],
+							"hide": true,
+							"calc": {
+								"damage": "1d per level  burn"
+							}
+						},
+						{
+							"id": "W4jJpCTXpNN93WmrI",
+							"sv": 1,
+							"damage": {
+								"type": "burn",
+								"base_leveled": "1d"
+							},
+							"accuracy": "3",
+							"range": "10/100",
+							"rate_of_fire": "1",
+							"recoil": "1",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "@Attack Type@"
+									}
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									},
+									"modifier": -2
+								},
+								{
+									"type": "dx",
+									"modifier": -4
+								}
+							],
+							"calc": {
+								"damage": "1d per level  burn"
+							}
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 5,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "t8IqTP-C5n4IotFwD",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tWNGzCluuu3S1L8jv"
+					},
+					"name": "Nictitating Membrane",
+					"reference": "B71",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"points_per_level": 1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to all HT rolls concerned with eye damage",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 2,
+						"current_level": 2
+					}
+				},
+				{
+					"id": "tuMm9rygf_jjxQnk9",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tc74I5tb8McOGp5nr"
+					},
+					"name": "Peripheral Vision",
+					"reference": "B74,P87",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mKj_rWRHxNbmOmdG5",
+							"name": "Easy to Hit",
+							"reference": "B75",
+							"local_notes": "Others can target your eyes at only -6 to hit",
+							"cost_adj": "-20%",
+							"disabled": true
+						}
+					],
+					"base_points": 15,
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tGIR3uneB5RM1yM8Y",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "ta04iFiZ_Kw0s0juj"
+					},
+					"name": "Good Reputation",
+					"reference": "B26,MA54",
+					"tags": [
+						"Advantage",
+						"Social"
+					],
+					"replacements": {
+						"Small class of people": "Dragons"
+					},
+					"modifiers": [
+						{
+							"id": "mFfBSAs-OvzaYUF1p",
+							"name": "People Affected",
+							"reference": "B27",
+							"local_notes": "Almost everyone",
+							"cost_adj": "x1",
+							"disabled": true
+						},
+						{
+							"id": "mH_kF-5DK5PM-SpCa",
+							"name": "People Affected",
+							"reference": "B27",
+							"local_notes": "Almost everyone except @large class of people@",
+							"cost_adj": "x2/3",
+							"disabled": true
+						},
+						{
+							"id": "mHn0UgeL8HFg9JV8m",
+							"name": "People Affected",
+							"reference": "B27",
+							"local_notes": "@Large class of people@",
+							"cost_adj": "x0.5",
+							"disabled": true
+						},
+						{
+							"id": "mF2w7kK-z_zGL_Yd-",
+							"name": "People Affected",
+							"reference": "B27",
+							"local_notes": "@Small class of people@",
+							"cost_adj": "x1/3",
+							"calc": {
+								"resolved_notes": "Dragons"
+							}
+						},
+						{
+							"id": "mp_rpDnW7GNU4QZAs",
+							"name": "Recognized all the time",
+							"reference": "B28",
+							"cost_adj": "x1"
+						},
+						{
+							"id": "m0Vgk9aWOIYg6TcHD",
+							"name": "Recognized sometimes",
+							"reference": "B28",
+							"local_notes": "10-",
+							"cost_adj": "x0.5",
+							"disabled": true
+						},
+						{
+							"id": "m7snqCa6At7I9wIQA",
+							"name": "Recognized occasionally",
+							"reference": "B28",
+							"local_notes": "7-",
+							"cost_adj": "x1/3",
+							"disabled": true
+						}
+					],
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from others aware of your reputation",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"round_down": true,
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 5,
+						"current_level": 3
+					}
+				},
+				{
+					"id": "tFjdox5WpCBcOWrVm",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy/Dungeon Fantasy 3/Dungeon Fantasy 3 Traits.adq",
+						"id": "tgAqCI7HqhE5fY1qM"
+					},
+					"name": "Social Stigma (Monster)",
+					"reference": "DF3:11",
+					"local_notes": "Denied entry to town on 9 or less",
+					"tags": [
+						"Disadvantage",
+						"Social"
+					],
+					"base_points": -15,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from non-monsters",
+							"amount": -3
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to skill rolls for social activities in town and mundane or magical attempts to disguise them",
+							"amount": -6
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "intimidation"
+							},
+							"amount": 3
+						}
+					],
+					"calc": {
+						"points": -15
+					}
+				},
+				{
+					"id": "tVIO4zm80lV7lGinD",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tK9Ov0WtlrhnJFy5n"
+					},
+					"name": "Sharp Teeth",
+					"reference": "B91",
+					"tags": [
+						"Exotic",
+						"Perk",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "mD6ApprhfUOOOXrfK",
+							"name": "Provided by Vampiric Bite",
+							"reference": "B96",
+							"cost_adj": "-1",
+							"disabled": true
+						}
+					],
+					"base_points": 1,
+					"weapons": [
+						{
+							"id": "ww7ulimxAWLJxlpd_",
+							"sv": 1,
+							"damage": {
+								"type": "cut",
+								"st": "thr",
+								"base": "-1"
+							},
+							"usage": "Bite",
+							"reach": "C",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
+								},
+								{
+									"type": "dx"
+								}
+							],
+							"calc": {
+								"damage": "thr-1 cut"
+							}
+						}
+					],
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tvEi5LvlhqMQAOG-m",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tbRcx49SumN2nrk62"
+					},
+					"name": "Vow",
+					"reference": "B165",
+					"local_notes": "@Subject@",
+					"tags": [
+						"Mental",
+						"Quirk"
+					],
+					"replacements": {
+						"Subject": "Never attack a Dragon"
+					},
+					"base_points": -1,
+					"calc": {
+						"points": -1,
+						"resolved_notes": "Never attack a Dragon"
 					}
 				},
 				{
@@ -442,561 +993,6 @@
 					],
 					"calc": {
 						"points": 0
-					}
-				},
-				{
-					"id": "tXkIyczVKJOAgY0jg",
-					"name": "Increased Health",
-					"reference": "B14",
-					"tags": [
-						"Advantage",
-						"Attribute",
-						"Physical"
-					],
-					"points_per_level": 10,
-					"features": [
-						{
-							"type": "attribute_bonus",
-							"attribute": "ht",
-							"amount": 1,
-							"per_level": true
-						}
-					],
-					"can_level": true,
-					"levels": 1,
-					"calc": {
-						"points": 10,
-						"current_level": 1
-					}
-				},
-				{
-					"id": "tNPzAJ1mTLIt-BStq",
-					"name": "Increased Strength",
-					"reference": "B14",
-					"tags": [
-						"Advantage",
-						"Attribute",
-						"Physical"
-					],
-					"modifiers": [
-						{
-							"id": "mPyzesANVffkgw0Ce",
-							"name": "No Fine Manipulators",
-							"reference": "B15",
-							"cost_adj": "-40%",
-							"disabled": true
-						},
-						{
-							"id": "mKvLj7x89zz_zrV9P",
-							"name": "Size",
-							"reference": "B15",
-							"cost_adj": "-10%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mBdm3SLbpWeMx-ZSo",
-							"name": "Super-Effort",
-							"reference": "SU24",
-							"cost_adj": "300%",
-							"disabled": true
-						}
-					],
-					"points_per_level": 10,
-					"features": [
-						{
-							"type": "attribute_bonus",
-							"attribute": "st",
-							"amount": 1,
-							"per_level": true
-						}
-					],
-					"can_level": true,
-					"levels": 1,
-					"calc": {
-						"points": 10,
-						"current_level": 1
-					}
-				},
-				{
-					"id": "t48NiUdHcMJkxHTah",
-					"name": "Innate Attack (Burn)",
-					"reference": "B61",
-					"tags": [
-						"Advantage",
-						"Exotic",
-						"Physical"
-					],
-					"modifiers": [
-						{
-							"id": "monq3NcH_FwRb7ox2",
-							"name": "Cyclic",
-							"reference": "B103",
-							"local_notes": "1 sec",
-							"cost_adj": "100%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mtLh7_7rt4i-2UME3",
-							"name": "Cyclic",
-							"reference": "B103",
-							"local_notes": "10 sec",
-							"cost_adj": "50%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mJJn3LGLH0cPNy7pw",
-							"name": "Cyclic",
-							"reference": "B103",
-							"local_notes": "1 min",
-							"cost_adj": "40%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mKBd5l21wODbLnYr1",
-							"name": "Cyclic",
-							"reference": "B103",
-							"local_notes": "1 hr",
-							"cost_adj": "20%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mEdwP6sOSRCzDi7FF",
-							"name": "Cyclic",
-							"reference": "B103",
-							"local_notes": "1 day",
-							"cost_adj": "10%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mEQsSmPxsox5bgHnm",
-							"name": "Cyclic",
-							"reference": "B103",
-							"local_notes": "1 sec; Resistible",
-							"cost_adj": "50%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mrU6lO-j4K2VhP3bP",
-							"name": "Cyclic",
-							"reference": "B103",
-							"local_notes": "10 sec; Resistible",
-							"cost_adj": "25%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mlHqPxGeMTOFThTt3",
-							"name": "Cyclic",
-							"reference": "B103",
-							"local_notes": "1 min; Resistible",
-							"cost_adj": "20%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mFF8r0bgQyWBbpIzW",
-							"name": "Cyclic",
-							"reference": "B103",
-							"local_notes": "1 hr; Resistible",
-							"cost_adj": "10%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mMDnZ9qQV_s9bt9n6",
-							"name": "Cyclic",
-							"reference": "B103",
-							"local_notes": "1 day; Resistible",
-							"cost_adj": "5%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mKXNgVHysOXk4kWdU",
-							"name": "Contagious",
-							"reference": "B103",
-							"local_notes": "Mildly",
-							"cost_adj": "20%",
-							"disabled": true
-						},
-						{
-							"id": "mCHksQlC46geNRjQI",
-							"name": "Contagious",
-							"reference": "B103",
-							"local_notes": "Highly",
-							"cost_adj": "50%",
-							"disabled": true
-						},
-						{
-							"id": "m3n2VIov30MpBqIDd",
-							"name": "Double Blunt Trauma",
-							"reference": "B104",
-							"local_notes": "1HP per 10 dmg",
-							"cost_adj": "20%",
-							"disabled": true
-						},
-						{
-							"id": "mghOLvAIo8NTT9K6_",
-							"name": "Explosion",
-							"reference": "B104",
-							"cost_adj": "50%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mhxAtP3jBnZcoZdOx",
-							"name": "Fragmentation",
-							"reference": "B104",
-							"cost_adj": "15%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "m-1wau-T59dJZW9Ql",
-							"name": "Fragmentation",
-							"reference": "B104",
-							"local_notes": "Hot",
-							"cost_adj": "15%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mPO42QnXnv2XDc6Xf",
-							"name": "Radiation",
-							"reference": "B104",
-							"cost_adj": "100%",
-							"disabled": true
-						},
-						{
-							"id": "mA9pHI_SyuOEI29hY",
-							"name": "Surge",
-							"reference": "B104",
-							"cost_adj": "20%",
-							"disabled": true
-						},
-						{
-							"id": "mBDYMBCuujwZCFq7L",
-							"name": "Armor Divisor",
-							"reference": "B102",
-							"local_notes": "2",
-							"cost_adj": "50%",
-							"disabled": true
-						},
-						{
-							"id": "msNF4BoBwfSIFPO42",
-							"name": "Armor Divisor",
-							"reference": "B102",
-							"local_notes": "3",
-							"cost_adj": "100%",
-							"disabled": true
-						},
-						{
-							"id": "mh-FzGGJdc5BMse0I",
-							"name": "Armor Divisor",
-							"reference": "B102",
-							"local_notes": "5",
-							"cost_adj": "150%",
-							"disabled": true
-						},
-						{
-							"id": "mMDVBr028mNKJ1yyP",
-							"name": "Armor Divisor",
-							"reference": "B102",
-							"local_notes": "10",
-							"cost_adj": "200%",
-							"disabled": true
-						},
-						{
-							"id": "mdLU-miTEnMWmNsYo",
-							"name": "Side Effect",
-							"reference": "B109",
-							"local_notes": "@Effect@",
-							"disabled": true
-						},
-						{
-							"id": "mt7OXBVo55S2nS-sn",
-							"name": "Symptoms",
-							"reference": "B109",
-							"local_notes": "@Effect@",
-							"disabled": true
-						},
-						{
-							"id": "m_NSOWDp46BAX00Ve",
-							"name": "Armor Divisor",
-							"reference": "B110",
-							"local_notes": "0.5",
-							"cost_adj": "-30%",
-							"disabled": true
-						},
-						{
-							"id": "mh0GzI8SJbNtQ4Czf",
-							"name": "Armor Divisor",
-							"reference": "B110",
-							"local_notes": "0.2",
-							"cost_adj": "-50%",
-							"disabled": true
-						},
-						{
-							"id": "mOJ50DVGIJhDzCo1l",
-							"name": "Armor Divisor",
-							"reference": "B110",
-							"local_notes": "0.1",
-							"cost_adj": "-70%",
-							"disabled": true
-						},
-						{
-							"id": "mDgUfr1D6KnhGYhws",
-							"name": "No Wounding",
-							"reference": "B111",
-							"cost_adj": "-50%",
-							"disabled": true
-						},
-						{
-							"id": "m3FWOjaqk0D61VBLr",
-							"name": "Jet"
-						}
-					],
-					"points_per_level": 5,
-					"weapons": [
-						{
-							"id": "WLFiYNfeyPRK5pSEg",
-							"sv": 1,
-							"damage": {
-								"type": "burn",
-								"base_leveled": "1d"
-							},
-							"usage": "Jet",
-							"range": "5",
-							"defaults": [
-								{
-									"type": "skill",
-									"name": "Innate Attack",
-									"specialization": "Breath"
-								},
-								{
-									"type": "skill",
-									"name": "Innate Attack",
-									"modifier": -2
-								},
-								{
-									"type": "dx",
-									"modifier": -4
-								}
-							],
-							"calc": {
-								"damage": "1d per level  burn"
-							}
-						}
-					],
-					"can_level": true,
-					"levels": 1,
-					"calc": {
-						"points": 5,
-						"current_level": 1
-					}
-				},
-				{
-					"id": "tPwU4Q1x6hjQdrm_D",
-					"name": "Nictitating Membrane",
-					"reference": "B71",
-					"tags": [
-						"Advantage",
-						"Exotic",
-						"Physical"
-					],
-					"points_per_level": 1,
-					"can_level": true,
-					"levels": 2,
-					"calc": {
-						"points": 2,
-						"current_level": 2
-					}
-				},
-				{
-					"id": "teTNag0Yz-Xged0sl",
-					"name": "Peripheral Vision",
-					"reference": "B74",
-					"tags": [
-						"Advantage",
-						"Physical"
-					],
-					"modifiers": [
-						{
-							"id": "mjbAH4mDrW5K9-YCp",
-							"name": "Easy to Hit",
-							"reference": "B75",
-							"local_notes": "Others can target your eyes at only -6 to hit",
-							"cost_adj": "-20%",
-							"disabled": true
-						}
-					],
-					"base_points": 15,
-					"calc": {
-						"points": 15
-					}
-				},
-				{
-					"id": "tZc2HuoggHJ-7i0Zy",
-					"name": "Reputation",
-					"reference": "B26",
-					"tags": [
-						"Advantage",
-						"Social"
-					],
-					"modifiers": [
-						{
-							"id": "mOMOvdWTZBOfXZlCo",
-							"name": "People Affected",
-							"reference": "B27",
-							"local_notes": "Almost everyone",
-							"cost_adj": "x1",
-							"disabled": true
-						},
-						{
-							"id": "m791mlN5ruMS5-ok9",
-							"name": "People Affected",
-							"reference": "B27",
-							"local_notes": "Almost everyone except @large class of people@",
-							"cost_adj": "x2/3",
-							"disabled": true
-						},
-						{
-							"id": "m1vbQ1dUoTQoW7RvQ",
-							"name": "People Affected",
-							"reference": "B27",
-							"local_notes": "@Large class of people@",
-							"cost_adj": "x0.5",
-							"disabled": true
-						},
-						{
-							"id": "m-etTbakh7VjSHknD",
-							"name": "People Affected",
-							"reference": "B27",
-							"local_notes": "Dragons",
-							"cost_adj": "x1/3"
-						},
-						{
-							"id": "mDh-LN97l9JclMv_4",
-							"name": "Recognized all the time",
-							"reference": "B28",
-							"cost_adj": "x1"
-						},
-						{
-							"id": "mPfzrfY5dg4m2xt81",
-							"name": "Recognized sometimes",
-							"reference": "B28",
-							"local_notes": "10-",
-							"cost_adj": "x0.5",
-							"disabled": true
-						},
-						{
-							"id": "m9wGuvPet25V68yDN",
-							"name": "Recognized occasionally",
-							"reference": "B28",
-							"local_notes": "7-",
-							"cost_adj": "x1/3",
-							"disabled": true
-						},
-						{
-							"id": "mQKq8EKekDflb9Bdv",
-							"name": "Recognized occasionally",
-							"reference": "B28",
-							"local_notes": "7-",
-							"cost_adj": "x1/3",
-							"disabled": true
-						}
-					],
-					"points_per_level": 5,
-					"can_level": true,
-					"levels": 3,
-					"calc": {
-						"points": 5,
-						"current_level": 3
-					}
-				},
-				{
-					"id": "tfLa2L_bbR9V2NdXq",
-					"name": "Social Stigma (Monster)",
-					"reference": "DF3:11",
-					"local_notes": "-3 reaction; -6 to skills; Denied entry to town on 9 or less",
-					"tags": [
-						"Disadvantage",
-						"Social"
-					],
-					"base_points": -15,
-					"features": [
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "intimidation"
-							},
-							"amount": 1
-						}
-					],
-					"calc": {
-						"points": -15
-					}
-				},
-				{
-					"id": "tCDcACUndk1DNlkYm",
-					"name": "Teeth, Sharp",
-					"reference": "B91",
-					"tags": [
-						"Exotic",
-						"Perk",
-						"Physical"
-					],
-					"base_points": 1,
-					"weapons": [
-						{
-							"id": "wyqV5EQ0x3lWGMaZ-",
-							"sv": 1,
-							"damage": {
-								"type": "cut",
-								"st": "thr",
-								"base": "-1"
-							},
-							"usage": "Bite",
-							"reach": "C",
-							"defaults": [
-								{
-									"type": "skill",
-									"name": "Brawling"
-								},
-								{
-									"type": "dx"
-								}
-							],
-							"calc": {
-								"damage": "thr-1 cut"
-							}
-						}
-					],
-					"calc": {
-						"points": 1
-					}
-				},
-				{
-					"id": "tpWR5udXTxICB-eoT",
-					"name": "Vow",
-					"reference": "B165",
-					"local_notes": "Never attack a Dragon",
-					"tags": [
-						"Mental",
-						"Quirk"
-					],
-					"base_points": -1,
-					"calc": {
-						"points": -1
 					}
 				}
 			],

--- a/Library/Dungeon Fantasy/Races/Dragon-Blooded.gct
+++ b/Library/Dungeon Fantasy/Races/Dragon-Blooded.gct
@@ -844,46 +844,6 @@
 					}
 				},
 				{
-					"id": "tFjdox5WpCBcOWrVm",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy/Dungeon Fantasy 3/Dungeon Fantasy 3 Traits.adq",
-						"id": "tgAqCI7HqhE5fY1qM"
-					},
-					"name": "Social Stigma (Monster)",
-					"reference": "DF3:11",
-					"local_notes": "Denied entry to town on 9 or less",
-					"tags": [
-						"Disadvantage",
-						"Social"
-					],
-					"base_points": -15,
-					"features": [
-						{
-							"type": "reaction_bonus",
-							"situation": "from non-monsters",
-							"amount": -3
-						},
-						{
-							"type": "conditional_modifier",
-							"situation": "to skill rolls for social activities in town and mundane or magical attempts to disguise them",
-							"amount": -6
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "intimidation"
-							},
-							"amount": 3
-						}
-					],
-					"calc": {
-						"points": -15
-					}
-				},
-				{
 					"id": "tVIO4zm80lV7lGinD",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
@@ -994,10 +954,316 @@
 					"calc": {
 						"points": 0
 					}
+				},
+				{
+					"id": "TPgT8CMheSyQxkW68",
+					"name": "Dungeon Fantasy or Yrth",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "TFBzJtgDAMumkB0_i",
+							"name": "Dungeon Fantasy Dragon-Blooded",
+							"children": [
+								{
+									"id": "tFjdox5WpCBcOWrVm",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 3/Dungeon Fantasy 3 Traits.adq",
+										"id": "tgAqCI7HqhE5fY1qM"
+									},
+									"name": "Social Stigma (Monster)",
+									"reference": "DF3:11",
+									"local_notes": "Denied entry to town on 9 or less",
+									"tags": [
+										"Disadvantage",
+										"Social"
+									],
+									"base_points": -15,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from non-monsters",
+											"amount": -3
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to skill rolls for social activities in town and mundane or magical attempts to disguise them",
+											"amount": -6
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "intimidation"
+											},
+											"amount": 3
+										}
+									],
+									"calc": {
+										"points": -15
+									}
+								}
+							],
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "TqYSC6wjO5VyH0vtS",
+							"name": "Yrth Dragon-Blooded",
+							"reference": "FFRR13",
+							"children": [
+								{
+									"id": "tXdYTnjWqcYQBT9qi",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Banestorm/Banestorm Traits.adq",
+										"id": "t50RYqFLKGRMdD6rL"
+									},
+									"name": "Social Stigma (Barbarian)",
+									"reference": "BS186",
+									"tags": [
+										"Disadvantage",
+										"Social"
+									],
+									"base_points": -10,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from other Barbarians",
+											"amount": 2
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from civilized folk",
+											"amount": -2
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								}
+							],
+							"calc": {
+								"points": -10
+							}
+						}
+					],
+					"calc": {
+						"points": -25
+					}
+				},
+				{
+					"id": "T94_jMlT8UFJXt1-s",
+					"name": "Some might be shapeshifters and/or sorcerers",
+					"reference": "FFRR13",
+					"reference_highlight": "Shapeshifting Dragon-Blooded",
+					"template_picker": {
+						"type": "count"
+					},
+					"children": [
+						{
+							"id": "t7rnYhJwUT4YO-mV3",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tqyRvrXKWtUMlIEQe"
+							},
+							"name": "Alternate Form (@Form@)",
+							"reference": "B83",
+							"local_notes": "<script>entity.exists ? \"\" : \"Set levels equal to the point cost of the form (usually 90% of how much more it costs than your base form)\"</script>",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Physical"
+							],
+							"replacements": {
+								"Form": "Human"
+							},
+							"modifiers": [
+								{
+									"id": "mXe23lnt5czdYQpl8",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Powers/Powers Modifiers.adm",
+										"id": "mTvkmxweTpZMphMq8"
+									},
+									"name": "Magical",
+									"reference": "P27",
+									"local_notes": "Requires ambient Mana, and vulnerable to anti-powers.",
+									"cost_adj": "-10%"
+								},
+								{
+									"id": "mqpLn5v8XiohZ1QcM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm",
+										"id": "mEPw3arucLNUneQGC"
+									},
+									"name": "Reliable",
+									"reference": "PU4:16",
+									"cost_adj": "5%",
+									"levels": 2
+								}
+							],
+							"base_points": 15,
+							"points_per_level": 1,
+							"can_level": true,
+							"calc": {
+								"points": 15,
+								"resolved_notes": "Set levels equal to the point cost of the form (usually 90% of how much more it costs than your base form)",
+								"current_level": 0
+							}
+						},
+						{
+							"id": "tWo6OgNBkWltTZ0nP",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tpnv8EEpAS6Er2pwK"
+							},
+							"name": "Magery",
+							"reference": "B66",
+							"tags": [
+								"Advantage",
+								"Mental",
+								"Supernatural"
+							],
+							"modifiers": [
+								{
+									"id": "m2iUgkgY7e3VoccAJ",
+									"name": "Dance",
+									"cost_adj": "-40%",
+									"affects": "levels_only",
+									"disabled": true
+								},
+								{
+									"id": "mMuQkOVFVP_XekDFq",
+									"name": "Dark-Aspected",
+									"cost_adj": "-50%",
+									"affects": "levels_only",
+									"disabled": true
+								},
+								{
+									"id": "mb8QuIXSnkfrgYMH9",
+									"name": "Day-Aspected",
+									"cost_adj": "-40%",
+									"affects": "levels_only",
+									"disabled": true
+								},
+								{
+									"id": "mTeBWQV7-_NdzJXI7",
+									"name": "Musical",
+									"cost_adj": "-50%",
+									"affects": "levels_only",
+									"disabled": true
+								},
+								{
+									"id": "m6GfGjqLPOmIESvQ7",
+									"name": "Night-Aspected",
+									"cost_adj": "-40%",
+									"affects": "levels_only",
+									"disabled": true
+								},
+								{
+									"id": "mcsxvcbuYmdSGnVd3",
+									"name": "One College",
+									"local_notes": "@College@",
+									"cost_adj": "-40%",
+									"affects": "levels_only",
+									"disabled": true
+								},
+								{
+									"id": "mQ3zPLB1hoDO8DJOX",
+									"name": "Solitary",
+									"cost_adj": "-40%",
+									"affects": "levels_only",
+									"disabled": true
+								},
+								{
+									"id": "mmb5H2uRajbgQJXkQ",
+									"name": "Song",
+									"cost_adj": "-40%",
+									"affects": "levels_only",
+									"disabled": true
+								}
+							],
+							"base_points": 5,
+							"points_per_level": 10,
+							"features": [
+								{
+									"type": "spell_bonus",
+									"match": "all_colleges",
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "thaumatology"
+									},
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"calc": {
+								"points": 5,
+								"current_level": 0
+							}
+						}
+					],
+					"calc": {
+						"points": 20
+					}
 				}
 			],
 			"calc": {
-				"points": 30
+				"points": 40
+			}
+		},
+		{
+			"id": "TaNSOu-m8swkw5VJz",
+			"name": "Dragon-Blooded Human Form",
+			"disabled": true,
+			"ancestry": "Human",
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tRO5p2WXS1kKU4OWy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tbRcx49SumN2nrk62"
+					},
+					"name": "Vow",
+					"reference": "B165",
+					"local_notes": "@Subject@",
+					"tags": [
+						"Mental",
+						"Quirk"
+					],
+					"replacements": {
+						"Subject": "Never attack a Dragon"
+					},
+					"base_points": -1,
+					"calc": {
+						"points": 0,
+						"resolved_notes": "Never attack a Dragon"
+					}
+				}
+			],
+			"calc": {
+				"points": 0
 			}
 		}
 	]

--- a/Library/Dungeon Fantasy/Races/Lizard Man.gct
+++ b/Library/Dungeon Fantasy/Races/Lizard Man.gct
@@ -6,6 +6,7 @@
 			"id": "Tq3GqhrgONhXoz6US",
 			"name": "Lizard Man",
 			"reference": "DF3:15, FFRR:13",
+			"reference_highlight": "Lizard Men",
 			"ancestry": "Human",
 			"container_type": "ancestry",
 			"children": [
@@ -630,27 +631,6 @@
 					}
 				},
 				{
-					"id": "tJbmJhL9oFSNgSAH8",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Basic Set/Basic Set Traits.adq",
-						"id": "touwUIFalnae02BUl"
-					},
-					"name": "Temperature Tolerance",
-					"reference": "B93",
-					"tags": [
-						"Advantage",
-						"Physical"
-					],
-					"points_per_level": 1,
-					"can_level": true,
-					"levels": 3,
-					"calc": {
-						"points": 3,
-						"current_level": 3
-					}
-				},
-				{
 					"id": "tvvEs1kdhrdnnxfxf",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
@@ -673,48 +653,311 @@
 					}
 				},
 				{
-					"id": "tDS0dUkpMlAy9g5_O",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Dungeon Fantasy/Dungeon Fantasy 3/Dungeon Fantasy 3 Traits.adq",
-						"id": "tgAqCI7HqhE5fY1qM"
+					"id": "TxKguZKkp53vKUwaQ",
+					"name": "Lizard Men Variants",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
 					},
-					"name": "Social Stigma (Monster)",
-					"reference": "DF3:11",
-					"local_notes": "Denied entry to town on 9 or less",
-					"tags": [
-						"Disadvantage",
-						"Social"
-					],
-					"base_points": -15,
-					"features": [
+					"children": [
 						{
-							"type": "reaction_bonus",
-							"situation": "from non-monsters",
-							"amount": -3
+							"id": "TcNosde4KjwHlasR3",
+							"name": "Lizard Man",
+							"children": [
+								{
+									"id": "tJbmJhL9oFSNgSAH8",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "touwUIFalnae02BUl"
+									},
+									"name": "Temperature Tolerance",
+									"reference": "B93",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"points_per_level": 1,
+									"can_level": true,
+									"levels": 3,
+									"calc": {
+										"points": 3,
+										"current_level": 3
+									}
+								}
+							],
+							"calc": {
+								"points": 3
+							}
 						},
 						{
-							"type": "conditional_modifier",
-							"situation": "to skill rolls for social activities in town and mundane or magical attempts to disguise them",
-							"amount": -6
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "intimidation"
-							},
-							"amount": 3
+							"id": "TMySumV28RGEDuOK5",
+							"name": "Killer Newt",
+							"reference": "FFRR14",
+							"children": [
+								{
+									"id": "tCpQvP6Y0wi1h_-RX",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tS-7-nKXlxWatBXhg"
+									},
+									"name": "Amphibious",
+									"reference": "B40,P42",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"base_points": 10,
+									"calc": {
+										"points": 10
+									}
+								},
+								{
+									"id": "t11zAXz15SE9eTqI2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUX_zxoB4sWyeNpHi"
+									},
+									"name": "Doesn't Breathe",
+									"reference": "B49",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mwv2jFbfOWmymr3Xx",
+											"name": "Gills",
+											"reference": "B49",
+											"cost_adj": "-50%"
+										}
+									],
+									"base_points": 20,
+									"calc": {
+										"points": 10
+									}
+								},
+								{
+									"id": "tDaqKeik0Ig3pguL0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tMqEixhnLpc_4A1IO"
+									},
+									"name": "Slippery",
+									"reference": "B85",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": 2,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "escape"
+											},
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 3,
+									"calc": {
+										"points": 6,
+										"current_level": 3
+									}
+								},
+								{
+									"id": "tlTWkLY3WshnabFLL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t0ro1CL8F4OznP2Iq"
+									},
+									"name": "Cold-Blooded",
+									"reference": "B127",
+									"local_notes": "Under 65-degrees",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"base_points": -10,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to HT to resist the effects of temperature",
+											"amount": 2
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tbQ68Nx8n9GCchD8r",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tgZ_USe8H3_wWhOHm"
+									},
+									"name": "Vulnerability",
+									"reference": "B161",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"replacements": {
+										"Common attack": "Heat and Fire damage"
+									},
+									"modifiers": [
+										{
+											"id": "m1M7hbyuPcE-m6vAp",
+											"name": "@Common attack@",
+											"reference": "B161",
+											"cost_adj": "-15"
+										},
+										{
+											"id": "mmWme8LitW-wNqqpR",
+											"name": "Wounding x2",
+											"reference": "B161",
+											"cost_adj": "x2"
+										}
+									],
+									"calc": {
+										"points": -30
+									}
+								}
+							],
+							"calc": {
+								"points": -14
+							}
 						}
 					],
 					"calc": {
-						"points": -15
+						"points": -11
+					}
+				},
+				{
+					"id": "TR1NsbkQcLeP348KJ",
+					"name": "Dungeon Fantasy or Yrth",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "Tp0NFoEEAvchnFkY4",
+							"name": "Dungeon Fantasy Lizard Folks",
+							"children": [
+								{
+									"id": "tDS0dUkpMlAy9g5_O",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 3/Dungeon Fantasy 3 Traits.adq",
+										"id": "tgAqCI7HqhE5fY1qM"
+									},
+									"name": "Social Stigma (Monster)",
+									"reference": "DF3:11",
+									"local_notes": "Denied entry to town on 9 or less",
+									"tags": [
+										"Disadvantage",
+										"Social"
+									],
+									"base_points": -15,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from non-monsters",
+											"amount": -3
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to skill rolls for social activities in town and mundane or magical attempts to disguise them",
+											"amount": -6
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "intimidation"
+											},
+											"amount": 3
+										}
+									],
+									"calc": {
+										"points": -15
+									}
+								}
+							],
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "TolmI2HqcQ_1lK0cu",
+							"name": "Yrth Lizard Folk",
+							"reference": "FFRR14",
+							"children": [
+								{
+									"id": "t8O2o_i1rlYlZ3-KI",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Banestorm/Banestorm Traits.adq",
+										"id": "t50RYqFLKGRMdD6rL"
+									},
+									"name": "Social Stigma (Barbarian)",
+									"reference": "BS186",
+									"tags": [
+										"Disadvantage",
+										"Social"
+									],
+									"base_points": -10,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from other Barbarians",
+											"amount": 2
+										},
+										{
+											"type": "reaction_bonus",
+											"situation": "from civilized folk",
+											"amount": -2
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								}
+							],
+							"calc": {
+								"points": -10
+							}
+						}
+					],
+					"calc": {
+						"points": -25
 					}
 				}
 			],
 			"calc": {
-				"points": 31
+				"points": 7
 			}
 		}
 	]

--- a/Library/Dungeon Fantasy/Races/Lizard Man.gct
+++ b/Library/Dungeon Fantasy/Races/Lizard Man.gct
@@ -5,7 +5,7 @@
 		{
 			"id": "Tq3GqhrgONhXoz6US",
 			"name": "Lizard Man",
-			"reference": "DF3:15",
+			"reference": "DF3:15, FFRR:13",
 			"ancestry": "Human",
 			"container_type": "ancestry",
 			"children": [
@@ -41,67 +41,52 @@
 					}
 				},
 				{
-					"id": "tIRloS4rVQRkbSmQz",
-					"name": "Claws, Sharp (Feet)",
-					"reference": "B42",
+					"id": "taNStpQb_wrnXjMWg",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "ty02wIs3SOt8DoIC7"
+					},
+					"name": "Crushing Striker (@Body Part@)",
+					"reference": "B88,MA47",
 					"tags": [
 						"Advantage",
+						"Exotic",
 						"Physical"
 					],
-					"weapons": [
+					"replacements": {
+						"Body Part": "Tail"
+					},
+					"modifiers": [
 						{
-							"id": "w2VvifRRgE5F1z-RJ",
-							"sv": 1,
-							"damage": {
-								"type": "cut",
-								"st": "thr"
-							},
-							"usage": "Kick",
-							"reach": "C,1",
-							"defaults": [
+							"id": "m5zSTulLAO4trLBs4",
+							"name": "Clumsy",
+							"reference": "B88",
+							"cost_adj": "-20%",
+							"features": [
 								{
-									"type": "dx",
-									"modifier": -2
-								},
-								{
-									"type": "skill",
-									"name": "Brawling",
-									"modifier": -2
-								},
-								{
-									"type": "skill",
-									"name": "Karate",
-									"modifier": -2
+									"type": "skill_bonus",
+									"selection_type": "this_weapon",
+									"name": {
+										"compare": "is"
+									},
+									"amount": -1,
+									"per_level": true
 								}
 							],
-							"calc": {
-								"damage": "thr cut"
-							}
+							"levels": 1
 						}
-					],
-					"calc": {
-						"points": 0
-					}
-				},
-				{
-					"id": "tg3VNTRMTeXISTLSI",
-					"name": "Claws, Sharp (Hands)",
-					"reference": "B42",
-					"tags": [
-						"Advantage",
-						"Physical"
 					],
 					"base_points": 5,
 					"weapons": [
 						{
-							"id": "w2a3W2biIFF8768jx",
+							"id": "w9qteQV_HsMFX1cW9",
 							"sv": 1,
 							"damage": {
-								"type": "cut",
+								"type": "cr",
 								"st": "thr",
-								"base": "-1"
+								"modifier_per_die": 1
 							},
-							"usage": "Slash",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
@@ -110,30 +95,30 @@
 								},
 								{
 									"type": "skill",
-									"name": "Brawling"
-								},
-								{
-									"type": "skill",
-									"name": "Boxing"
-								},
-								{
-									"type": "skill",
-									"name": "Karate"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								}
 							],
 							"calc": {
-								"damage": "thr-1 cut"
+								"damage": "thr (+1 per die) cr"
 							}
 						}
 					],
 					"calc": {
-						"points": 5
+						"points": 4
 					}
 				},
 				{
-					"id": "toW7CuwRKOAUyU1k3",
+					"id": "tK9OXg2_L2sm7Gxxr",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tBmSJ3pNE53c4IRUU"
+					},
 					"name": "Damage Resistance",
-					"reference": "B47",
+					"reference": "B46,B47,P45,MA43,PSI14",
 					"tags": [
 						"Advantage",
 						"Exotic",
@@ -141,125 +126,17 @@
 					],
 					"modifiers": [
 						{
-							"id": "mMjT0mDVd607KrcUb",
-							"name": "Ablative",
-							"reference": "B47",
-							"cost_adj": "-80%",
-							"disabled": true
-						},
-						{
-							"id": "mmozU-SKQi_WTKYQZ",
-							"name": "Absorption",
-							"reference": "B46",
-							"local_notes": "Enhances @Trait@",
-							"cost_adj": "80%",
-							"disabled": true
-						},
-						{
-							"id": "mGZLRw25G-rgLuK3S",
-							"name": "Absorption",
-							"reference": "B46",
-							"local_notes": "Enhances any trait",
-							"cost_adj": "100%",
-							"disabled": true
-						},
-						{
-							"id": "mN2X-AA35q6XvzbAK",
-							"name": "Absorption",
-							"reference": "B46",
-							"local_notes": "Healing only",
-							"cost_adj": "80%",
-							"disabled": true
-						},
-						{
-							"id": "mRyuwAaWkf0j521N2",
-							"name": "Can't wear armor",
-							"reference": "B47",
-							"cost_adj": "-40%",
-							"disabled": true
-						},
-						{
-							"id": "msolvI0aQlPOY0SH9",
-							"name": "Directional",
-							"reference": "B47",
-							"local_notes": "@Direction: Back, Right, Left, Top or Underside@",
-							"cost_adj": "-40%",
-							"disabled": true
-						},
-						{
-							"id": "m792vb7gmNl-mSY71",
-							"name": "Directional",
-							"reference": "B47",
-							"local_notes": "Front",
-							"cost_adj": "-20%",
-							"disabled": true
-						},
-						{
-							"id": "mY3GqYxp5XX-50evY",
-							"name": "Flexible",
-							"reference": "B47",
-							"cost_adj": "-20%",
-							"disabled": true
-						},
-						{
-							"id": "m9LHJ8M9EYE-9M2kY",
-							"name": "Hardened",
-							"reference": "B47",
-							"cost_adj": "20%",
-							"levels": 1,
-							"disabled": true
-						},
-						{
-							"id": "mMS6MuiE4dW4iHNFU",
-							"name": "Limited",
-							"reference": "B46",
-							"local_notes": "@Common Attack Form@",
-							"cost_adj": "-40%",
-							"disabled": true
-						},
-						{
-							"id": "mUwCOcirX7fEI3-5s",
-							"name": "Limited",
-							"reference": "B46",
-							"local_notes": "@Occasional Attack Form@",
-							"cost_adj": "-60%",
-							"disabled": true
-						},
-						{
-							"id": "mUU6tD6qtn8CPAs3p",
-							"name": "Limited",
-							"reference": "B46",
-							"local_notes": "@Rare Attack Form@",
-							"cost_adj": "-80%",
-							"disabled": true
-						},
-						{
-							"id": "mka4ojT-AWCyeTAo2",
-							"name": "Limited",
-							"reference": "B46",
-							"local_notes": "@Very Common Attack Form@",
-							"cost_adj": "-20%",
-							"disabled": true
-						},
-						{
-							"id": "mkIBg7SGMAJgxSjlN",
-							"name": "Reflection",
-							"reference": "B47",
-							"cost_adj": "100%",
-							"disabled": true
-						},
-						{
-							"id": "mbW2B1c5RZzUhaaFG",
-							"name": "Semi-Ablative",
-							"reference": "B47",
-							"cost_adj": "-20%",
-							"disabled": true
-						},
-						{
-							"id": "mP8L1I0r1nZQ7GLVk",
-							"name": "Tough Skin",
-							"reference": "B47",
-							"cost_adj": "-40%"
+							"id": "MrPoOwXgHJahfyh42",
+							"name": "Special Limitations",
+							"children": [
+								{
+									"id": "mwHpO4LMprzutj--O",
+									"name": "Tough Skin",
+									"reference": "B47",
+									"local_notes": "Effects that just require skin contact or a scratch ignore this DR",
+									"cost_adj": "-40%"
+								}
+							]
 						}
 					],
 					"points_per_level": 5,
@@ -267,7 +144,7 @@
 						{
 							"type": "dr_bonus",
 							"locations": [
-								"skull"
+								"all"
 							],
 							"amount": 1,
 							"per_level": true
@@ -275,105 +152,9 @@
 						{
 							"type": "dr_bonus",
 							"locations": [
-								"face"
+								"eye"
 							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"neck"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"torso"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"vitals"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"groin"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"arm"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"hand"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"leg"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"foot"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"tail"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"wing"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"fin"
-							],
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "dr_bonus",
-							"locations": [
-								"brain"
-							],
-							"amount": 1,
+							"amount": -1,
 							"per_level": true
 						}
 					],
@@ -385,7 +166,12 @@
 					}
 				},
 				{
-					"id": "tDZxJWsFSHsVTLIS2",
+					"id": "tczujV5nzZHVJprER",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t50ZzyORV0rTiYwnb"
+					},
 					"name": "Decreased Intelligence",
 					"reference": "B15",
 					"tags": [
@@ -410,7 +196,12 @@
 					}
 				},
 				{
-					"id": "t3_k-STDGQIwnMQ_w",
+					"id": "te56egRVirODPsjlI",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tHa_LwEUawGsB_vO2"
+					},
 					"name": "Disturbing Voice",
 					"reference": "B132",
 					"tags": [
@@ -432,6 +223,62 @@
 						]
 					},
 					"base_points": -10,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "diplomacy"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "fast-talk"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "performance"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "public speaking"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "sex appeal"
+							},
+							"amount": -2
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "singing"
+							},
+							"amount": -2
+						}
+					],
 					"calc": {
 						"points": -10
 					}
@@ -460,7 +307,7 @@
 				},
 				{
 					"id": "tqiBUi7nLcz22oAqS",
-					"name": "Feature: Head armor not interchangeable with humans.",
+					"name": "Feature: Armor not interchangeable with humans.",
 					"reference": "DF3:15",
 					"tags": [
 						"Physical"
@@ -470,9 +317,17 @@
 					}
 				},
 				{
-					"id": "t0zW0pP86l55BIrmA",
+					"id": "tw3HtTd271jW1AK4b",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tCgsJ0W9A8mHTtc-e"
+					},
 					"name": "Increased Basic Move",
+					"reference": "B17",
 					"tags": [
+						"Advantage",
+						"Attribute",
 						"Physical"
 					],
 					"points_per_level": 5,
@@ -492,7 +347,12 @@
 					}
 				},
 				{
-					"id": "tLh4SiNY4tZlMLx4a",
+					"id": "tIa3FN5MtMon4DtwE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
 					"name": "Increased Health",
 					"reference": "B14",
 					"tags": [
@@ -517,7 +377,12 @@
 					}
 				},
 				{
-					"id": "tadi_0WrRROCYYeVi",
+					"id": "tW3_amvvW4hmkcXIP",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tqha9GlDBU9P-Wg-6"
+					},
 					"name": "Increased Strength",
 					"reference": "B14",
 					"tags": [
@@ -527,14 +392,14 @@
 					],
 					"modifiers": [
 						{
-							"id": "mCRQyd7z4ssSGfxP0",
+							"id": "mM0yq0A4FOX5AbFAP",
 							"name": "No Fine Manipulators",
 							"reference": "B15",
 							"cost_adj": "-40%",
 							"disabled": true
 						},
 						{
-							"id": "mEmnBAWI7JRT1l5ez",
+							"id": "m-iNiMen1oZilK0YV",
 							"name": "Size",
 							"reference": "B15",
 							"cost_adj": "-10%",
@@ -542,7 +407,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mpoeWuERX94kNX_FD",
+							"id": "mg7KaGklfstleiFNa",
 							"name": "Super-Effort",
 							"reference": "SU24",
 							"cost_adj": "300%",
@@ -566,7 +431,12 @@
 					}
 				},
 				{
-					"id": "tkJR8HkTh_UzM-HZh",
+					"id": "tfkv4_4_YUU41Guws",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tWNGzCluuu3S1L8jv"
+					},
 					"name": "Nictitating Membrane",
 					"reference": "B71",
 					"tags": [
@@ -575,6 +445,22 @@
 						"Physical"
 					],
 					"points_per_level": 1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to all HT rolls concerned with eye damage",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": 1,
+							"per_level": true
+						}
+					],
 					"can_level": true,
 					"levels": 2,
 					"calc": {
@@ -583,22 +469,17 @@
 					}
 				},
 				{
-					"id": "tWiZDhnb1_FrT3c1w",
+					"id": "tXrCpvU5Hy3uSq2wP",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tc74I5tb8McOGp5nr"
+					},
 					"name": "Peripheral Vision",
-					"reference": "B74",
+					"reference": "B74,P87",
 					"tags": [
 						"Advantage",
 						"Physical"
-					],
-					"modifiers": [
-						{
-							"id": "ma9kS_d7EOh12h9SN",
-							"name": "Easy to Hit",
-							"reference": "B75",
-							"local_notes": "Others can target your eyes at only -6 to hit",
-							"cost_adj": "-20%",
-							"disabled": true
-						}
 					],
 					"base_points": 15,
 					"calc": {
@@ -606,59 +487,70 @@
 					}
 				},
 				{
-					"id": "t1RcCrOSynwVbMntN",
-					"name": "Social Stigma (Monster)",
-					"reference": "DF3:11",
-					"local_notes": "-3 reaction; -6 to skills; Denied entry to town on 9 or less",
-					"tags": [
-						"Disadvantage",
-						"Social"
-					],
-					"base_points": -15,
-					"features": [
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "intimidation"
-							},
-							"amount": 1
-						}
-					],
-					"calc": {
-						"points": -15
-					}
-				},
-				{
-					"id": "tNt-GEeiRIpxei-zJ",
-					"name": "Striker, Crushing (Tail)",
-					"reference": "B88",
+					"id": "tAfZpWerz4bY9rBpc",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tj66NHKyO_GObgGsj"
+					},
+					"name": "Sharp Claws",
+					"reference": "B42",
 					"tags": [
 						"Advantage",
-						"Exotic",
 						"Physical"
-					],
-					"modifiers": [
-						{
-							"id": "m4OYupZMrCyi0ES37",
-							"name": "Clumsy",
-							"cost_adj": "-20%",
-							"levels": 2
-						}
 					],
 					"base_points": 5,
 					"weapons": [
 						{
-							"id": "wGV-Fw_wJGlnOwR0u",
+							"id": "wz5E-GK7KWywdv8r2",
 							"sv": 1,
 							"damage": {
-								"type": "cr",
+								"type": "cut",
 								"st": "thr",
-								"modifier_per_die": 1
+								"base": "-1"
 							},
+							"usage": "Slash",
 							"reach": "C",
 							"parry": "0",
+							"defaults": [
+								{
+									"type": "dx"
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Boxing"
+									}
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Karate"
+									}
+								}
+							],
+							"calc": {
+								"damage": "thr-1 cut"
+							}
+						},
+						{
+							"id": "wGT16IXc_SJLqRni8",
+							"sv": 1,
+							"damage": {
+								"type": "cut",
+								"st": "thr"
+							},
+							"usage": "Kick",
+							"reach": "C,1",
 							"defaults": [
 								{
 									"type": "dx",
@@ -666,22 +558,38 @@
 								},
 								{
 									"type": "skill",
-									"name": "Brawling",
+									"name": {
+										"compare": "is",
+										"qualifier": "Karate"
+									},
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
 									"modifier": -2
 								}
 							],
 							"calc": {
-								"damage": "thr (+1 per die) cr"
+								"damage": "thr cut"
 							}
 						}
 					],
 					"calc": {
-						"points": 3
+						"points": 5
 					}
 				},
 				{
-					"id": "taM5klJkIZVBhA8Wq",
-					"name": "Teeth, Sharp",
+					"id": "tBXfFd9KPQrJN2aiK",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tK9Ov0WtlrhnJFy5n"
+					},
+					"name": "Sharp Teeth",
 					"reference": "B91",
 					"tags": [
 						"Exotic",
@@ -691,7 +599,7 @@
 					"base_points": 1,
 					"weapons": [
 						{
-							"id": "w9UbcayNmeymhho7O",
+							"id": "wBBnsVx5hWoKlFcto",
 							"sv": 1,
 							"damage": {
 								"type": "cut",
@@ -703,7 +611,10 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -719,7 +630,12 @@
 					}
 				},
 				{
-					"id": "tI0COv1Dgw13AAcTv",
+					"id": "tJbmJhL9oFSNgSAH8",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "touwUIFalnae02BUl"
+					},
 					"name": "Temperature Tolerance",
 					"reference": "B93",
 					"tags": [
@@ -735,38 +651,70 @@
 					}
 				},
 				{
-					"id": "tO6xweylcr_HTrs54",
-					"name": "Terrain Adaptation (@Sand or Swamp@)",
-					"reference": "B93",
+					"id": "tvvEs1kdhrdnnxfxf",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tZw_ze3n_bPxiK86s"
+					},
+					"name": "Terrain Adaptation (@Terrain Type@)",
+					"reference": "B93,P83",
 					"tags": [
 						"Advantage",
 						"Exotic",
 						"Physical"
 					],
-					"modifiers": [
-						{
-							"id": "mLHio78JC8ekY1-X8",
-							"name": "Unstable on solid ground",
-							"reference": "B93",
-							"cost_adj": "-5",
-							"disabled": true
-						},
-						{
-							"id": "m1bEUz_mz62stTIw7",
-							"name": "Active",
-							"reference": "P84",
-							"cost_adj": "300%",
-							"disabled": true
-						}
-					],
+					"replacements": {
+						"Terrain Type": "@Sand or Swamp@"
+					},
 					"base_points": 5,
 					"calc": {
 						"points": 5
 					}
+				},
+				{
+					"id": "tDS0dUkpMlAy9g5_O",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy/Dungeon Fantasy 3/Dungeon Fantasy 3 Traits.adq",
+						"id": "tgAqCI7HqhE5fY1qM"
+					},
+					"name": "Social Stigma (Monster)",
+					"reference": "DF3:11",
+					"local_notes": "Denied entry to town on 9 or less",
+					"tags": [
+						"Disadvantage",
+						"Social"
+					],
+					"base_points": -15,
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from non-monsters",
+							"amount": -3
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to skill rolls for social activities in town and mundane or magical attempts to disguise them",
+							"amount": -6
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "intimidation"
+							},
+							"amount": 3
+						}
+					],
+					"calc": {
+						"points": -15
+					}
 				}
 			],
 			"calc": {
-				"points": 30
+				"points": 31
 			}
 		}
 	]

--- a/Library/Fantasy Folk/The Reptilian Races/README.md
+++ b/Library/Fantasy Folk/The Reptilian Races/README.md
@@ -4,7 +4,9 @@ Not all racial templates in The Reptilian Races are kept in this folder.
 
 * [Dragon-Blooded](../../Dungeon%20Fantasy/Races/Dragon-Blooded.gct) from [Page 13](FFRR13)
   were originally from [Dungeon Fantasy 3: The Next Level](DF3:15).
-* [Lizard Man](../../Dungeon%20Fantasy/Races/Lizard%20Man.gct) from [Page 13](FFRR13)
+* [Draconic Lizardmen](../../Dragons/Draconic%20Lizardman.gct) from [Page 13](FFRR13)
+  were original from [Dragons](DR144).
+* [Lizard Men](../../Dungeon%20Fantasy/Races/Lizard%20Man.gct) from [Page 13](FFRR13)
   were originally from [Dungeon Fantasy 3: The Next Level](DF3:15).
 * [Reptile Men](../../Banestorm/Races/Reptile%20Man.gct) from [Page 14](FFRR14)
   were originally from [Banestorm](BS197).

--- a/Library/Fantasy Folk/The Reptilian Races/README.md
+++ b/Library/Fantasy Folk/The Reptilian Races/README.md
@@ -1,7 +1,6 @@
 # Reptilian Races notes
 
-Not all racial templates in The Reptilian Races are kept in this folder.
-
+Not all racial templates from this book are in this folder, so the full list from the book is:
 * [Dragon-Blooded](../../Dungeon%20Fantasy/Races/Dragon-Blooded.gct) from [Page 13](FFRR13)
   were originally from [Dungeon Fantasy 3: The Next Level](DF3:15).
 * [Draconic Lizardmen](../../Dragons/Draconic%20Lizardman.gct) from [Page 13](FFRR13)
@@ -10,3 +9,4 @@ Not all racial templates in The Reptilian Races are kept in this folder.
   were originally from [Dungeon Fantasy 3: The Next Level](DF3:15).
 * [Reptile Men](../../Banestorm/Races/Reptile%20Man.gct) from [Page 14](FFRR14)
   were originally from [Banestorm](BS197).
+* [Serpent-Lords](Serpent-Lord.gct) from [Page 15](FFRR15) are completely new but include a variant for Monster Hunters.

--- a/Library/Fantasy Folk/The Reptilian Races/README.md
+++ b/Library/Fantasy Folk/The Reptilian Races/README.md
@@ -1,0 +1,10 @@
+# Reptilian Races notes
+
+Not all racial templates in The Reptilian Races are kept in this folder.
+
+* [Dragon-Blooded](../../Dungeon%20Fantasy/Races/Dragon-Blooded.gct) from [Page 13](FFRR13)
+  were originally from [Dungeon Fantasy 3: The Next Level](DF3:15).
+* [Lizard Man](../../Dungeon%20Fantasy/Races/Lizard%20Man.gct) from [Page 13](FFRR13)
+  were originally from [Dungeon Fantasy 3: The Next Level](DF3:15).
+* [Reptile Men](../../Banestorm/Races/Reptile%20Man.gct) from [Page 14](FFRR14)
+  were originally from [Banestorm](BS197).

--- a/Library/Fantasy Folk/The Reptilian Races/Serpent-Lord.gct
+++ b/Library/Fantasy Folk/The Reptilian Races/Serpent-Lord.gct
@@ -1,0 +1,4341 @@
+{
+	"version": 5,
+	"id": "BP6Jcw5inm2m3mBHI",
+	"traits": [
+		{
+			"id": "TGi44IoqTlDzlDPsN",
+			"name": "Serpent-Lord",
+			"reference": "FFRR15",
+			"ancestry": "Human",
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "tE7yYJMXGG7zJbXk6",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tqha9GlDBU9P-Wg-6"
+					},
+					"name": "Increased Strength",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "st",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 10,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "tfcfteT1J0_-2B7Z3",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVt3SvdGWNchJ8z4o"
+					},
+					"name": "Increased Health",
+					"reference": "B14",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Physical"
+					],
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "ht",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 20,
+						"current_level": 2
+					}
+				},
+				{
+					"id": "tKg90YHNIYchnGxkT",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tAZ31tXG_HzDmVCRp"
+					},
+					"name": "Acute Taste & Smell",
+					"reference": "B35",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 2,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "taste_smell",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 2,
+					"calc": {
+						"points": 4,
+						"current_level": 2
+					}
+				},
+				{
+					"id": "tqZApygkVisNBDeBd",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tqyRvrXKWtUMlIEQe"
+					},
+					"name": "Alternate Form (@Form@)",
+					"reference": "B83",
+					"local_notes": "<script>entity.exists ? \"\" : \"Set levels equal to how much more the form costs than your base form, if it's your most expensive form\"</script>",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"Form": "Enhanced Human"
+					},
+					"modifiers": [
+						{
+							"id": "mX9F8bN3FYwv55L7Y",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Powers/Powers Modifiers.adm",
+								"id": "mTvkmxweTpZMphMq8"
+							},
+							"name": "Magical",
+							"reference": "P27",
+							"local_notes": "Requires ambient Mana, and vulnerable to anti-powers.",
+							"cost_adj": "-10%"
+						},
+						{
+							"id": "mrKVdnOkB-SLC7-bJ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm",
+								"id": "mEPw3arucLNUneQGC"
+							},
+							"name": "Reliable",
+							"reference": "PU4:16",
+							"cost_adj": "5%",
+							"levels": 2
+						}
+					],
+					"base_points": 15,
+					"points_per_level": 1,
+					"can_level": true,
+					"calc": {
+						"points": 15,
+						"resolved_notes": "Set levels equal to how much more the form costs than your base form, if it's your most expensive form",
+						"current_level": 0
+					}
+				},
+				{
+					"id": "tJe7rgqGNflzmYmhG",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tBmSJ3pNE53c4IRUU"
+					},
+					"name": "Damage Resistance",
+					"reference": "B46,B47,P45,MA43,PSI14",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Physical"
+					],
+					"modifiers": [
+						{
+							"id": "MmK6Z-9epvuFgPTHb",
+							"name": "Special Limitations",
+							"children": [
+								{
+									"id": "mVX15znArI3kNUlX_",
+									"name": "Tough Skin",
+									"reference": "B47",
+									"local_notes": "Effects that just require skin contact or a scratch ignore this DR",
+									"cost_adj": "-40%"
+								}
+							]
+						}
+					],
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"all"
+							],
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "dr_bonus",
+							"locations": [
+								"eye"
+							],
+							"amount": -1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 3,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "ty7KT5dCM1eoBk8gE",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tk0ZKpvgqpE35AZcM"
+					},
+					"name": "Night Vision",
+					"reference": "B71,P87",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"points_per_level": 1,
+					"can_level": true,
+					"levels": 6,
+					"calc": {
+						"points": 6,
+						"current_level": 6
+					}
+				},
+				{
+					"id": "tTmA_Yl4YcScE7Xd1",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tc74I5tb8McOGp5nr"
+					},
+					"name": "Peripheral Vision",
+					"reference": "B74,P87",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"base_points": 15,
+					"calc": {
+						"points": 15
+					}
+				},
+				{
+					"id": "tpyTMrWqUyEoMb7cs",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "touwUIFalnae02BUl"
+					},
+					"name": "Temperature Tolerance",
+					"reference": "B93",
+					"local_notes": "<script>\nif (entity.exists) {\n  var degreesHotter = 0;\n  var degreesColder = 0;\n  const hotMod = self.findActiveModifier(\"Hot\");\n  const coldMod = self.findActiveModifier(\"Cold\");\n  const degreesHotterMod = self.findActiveModifier(\"Degrees Hotter\");\n  const degreesColderMod = self.findActiveModifier(\"Degrees Colder\");\n  if (hotMod) {\n    degreesHotter = $ht * self.level;\n  }\n  if (coldMod) {\n    degreesColder = $ht *self.level;\n  } \n  if (degreesHotterMod) {\n    degreesHotter = degreesHotterMod.level;\n  }\n  if (degreesColderMod) {\n    degreesColder = degreesColderMod.level;\n  }\n  if (degreesHotter == 0 && degreesColder == 0) {\n    degreesHotter = $ht *self.level / 2;\n    degreesColder = $ht *self.level / 2;\n  }\n  var strings = [];\n  if (degreesHotter != 0) {\n    strings.push(degreesHotter + \"° hotter\");\n  }\n  if (degreesColder != 0) {\n    strings.push(degreesColder +\"° colder\");;\n  }\n  strings.join(\" and \")\n} else {\n  \"Will calculate how much the comfort zone is expanded when added to a character sheet\"\n}\n</script>",
+					"tags": [
+						"Advantage",
+						"Physical"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "script_prereq",
+								"script": "var msgs = [];\nvar modifierCount = 0;\nconst hotMod = self.findActiveModifier(\"Hot\");\nconst coldMod = self.findActiveModifier(\"Cold\");\nconst degreesHotterMod = self.findActiveModifier(\"Degrees Hotter\");\nconst degreesColderMod = self.findActiveModifier(\"Degrees Colder\");\nif (hotMod) {\n  modifierCount++;\n}\nif (coldMod) {\n  modifierCount++;\n}\nif (degreesHotterMod || degreesColderMod) {\n  modifierCount++;\n}\nif (modifierCount > 1) {\n  msgs.push(\"Hot, Cold, and Degrees Hotter/Colder must not be mixed\")\n}\nif (entity.exists) {\n  const expectedLevels = $ht * self.level;\n  var foundLevels = 0;\n  if (degreesHotterMod) {\n    foundLevels += degreesHotterMod.level;\n  }\n  if (degreesColderMod) {\n    foundLevels += degreesColderMod.level;\n  }\n  if (foundLevels != 0 && expectedLevels != foundLevels) {\n    msgs.push(`Total levels of Degrees Hotter and Degrees Colder should be ${expectedLevels} not ${foundLevels}`)\n  }\n}\nmsgs.join(\"\\n* \")"
+							}
+						]
+					},
+					"points_per_level": 1,
+					"can_level": true,
+					"levels": 5,
+					"calc": {
+						"points": 5,
+						"resolved_notes": "Will calculate how much the comfort zone is expanded when added to a character sheet",
+						"current_level": 5
+					}
+				},
+				{
+					"id": "tvv_f8Zlqb0CYcVay",
+					"name": "Feature: Armor is not interchangeable with human armor",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tmccYOeo54yE3aWoC",
+					"name": "Feature: Green scales",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "TzCPSNfmaAtt1DD_f",
+					"name": "Variations",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "TIy151ikEmo3pl_PM",
+							"name": "Serpent-Lord",
+							"children": [
+								{
+									"id": "tQFrvFc9bm-vlZbs-",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t1w1RFcFceKR2T9_e"
+									},
+									"name": "Increased Intelligence",
+									"reference": "B15",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental"
+									],
+									"points_per_level": 20,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "iq",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 3,
+									"calc": {
+										"points": 60,
+										"current_level": 3
+									}
+								},
+								{
+									"id": "tesSyM5GOyaL6X7Yl",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tmpxhXmSORakqvrbn"
+									},
+									"name": "Increased Perception",
+									"reference": "B16",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental",
+										"Physical"
+									],
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "per",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 3,
+									"calc": {
+										"points": 15,
+										"current_level": 3
+									}
+								},
+								{
+									"id": "t4NExHof42aRjh9uV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tj66NHKyO_GObgGsj"
+									},
+									"name": "Sharp Claws",
+									"reference": "B42",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"base_points": 5,
+									"weapons": [
+										{
+											"id": "wqJH8X-37gGZO4cHC",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr",
+												"base": "-1"
+											},
+											"usage": "Slash",
+											"reach": "C",
+											"parry": "0",
+											"defaults": [
+												{
+													"type": "dx"
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Boxing"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Karate"
+													}
+												}
+											],
+											"calc": {
+												"damage": "thr-1 cut"
+											}
+										},
+										{
+											"id": "w_68_5Nv5-raZsk1S",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr"
+											},
+											"usage": "Kick",
+											"reach": "C,1",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -2
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Karate"
+													},
+													"modifier": -2
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													},
+													"modifier": -2
+												}
+											],
+											"calc": {
+												"damage": "thr cut"
+											}
+										}
+									],
+									"calc": {
+										"points": 5
+									}
+								},
+								{
+									"id": "tb2T0y_NHFhAiNt1d",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGjjVtxav9KsrG7Wx"
+									},
+									"name": "Combat Reflexes",
+									"reference": "B43",
+									"local_notes": "Never freeze",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Enhanced Time Sense"
+												}
+											}
+										]
+									},
+									"base_points": 15,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "starts_with",
+												"qualifier": "fast-draw"
+											},
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "dodge",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "parry",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "block",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "fright_check",
+											"amount": 2
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+											"amount": 6
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to initiative rolls for your side (+2 if you are the leader)",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": 15
+									}
+								},
+								{
+									"id": "tkMharL4Cms6xLWA2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tG2tK0QWXPQqFk-rd"
+									},
+									"name": "Enhanced Move (@type@)",
+									"reference": "B52,P49",
+									"local_notes": "Double your normal @type@ Move for each level",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"replacements": {
+										"type": "Ground"
+									},
+									"points_per_level": 20,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 20,
+										"resolved_notes": "Double your normal Ground Move for each level",
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tki80jmo8YVzBnNgl",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUJz4wvVveMiGDX0R"
+									},
+									"name": "Extended Lifespan",
+									"reference": "B53",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": 2,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 2,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "t8jYBoXBLJXqCyMfk",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tpnv8EEpAS6Er2pwK"
+									},
+									"name": "Magery",
+									"reference": "B66",
+									"tags": [
+										"Advantage",
+										"Mental",
+										"Supernatural"
+									],
+									"base_points": 5,
+									"points_per_level": 10,
+									"features": [
+										{
+											"type": "spell_bonus",
+											"match": "all_colleges",
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "thaumatology"
+											},
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 15,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tABi4R7yc8F4PP2_v",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tK9Ov0WtlrhnJFy5n"
+									},
+									"name": "Sharp Teeth",
+									"reference": "B91",
+									"tags": [
+										"Exotic",
+										"Perk",
+										"Physical"
+									],
+									"base_points": 1,
+									"weapons": [
+										{
+											"id": "wDZDHurAc1ghshrIq",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr",
+												"base": "-1"
+											},
+											"usage": "Bite",
+											"reach": "C",
+											"defaults": [
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													}
+												},
+												{
+													"type": "dx"
+												}
+											],
+											"calc": {
+												"damage": "thr-1 cut"
+											}
+										}
+									],
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "tvO4a7xDl03-WSQad",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tyVBpBR5-Ca0VD1Kd"
+									},
+									"name": "Colorblindness",
+									"reference": "B127",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"base_points": -10,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "artist"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "chemistry"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "driving"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "merchant"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "piloting"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "tracking"
+											},
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "ta5L9U6_5j-YC7pmB",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "ttHkLI9zwzfeOIEZc"
+									},
+									"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+									"reference": "B140",
+									"tags": [
+										"Disadvantage",
+										"Mental"
+									],
+									"replacements": {
+										"Class, Ethnicity, Nationality, Religion, Sex, or Species": "General"
+									},
+									"modifiers": [
+										{
+											"id": "m5kPNwVWdhMn-vGb7",
+											"name": "Scope: Anyone unlike you",
+											"reference": "B140",
+											"cost_adj": "-10"
+										}
+									],
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tT3OmJjDzXYTJ8Njw",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t49qcxpm53kg-OdPj"
+									},
+									"name": "Odious Personal Habit",
+									"reference": "B22",
+									"local_notes": "@Habit@",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"replacements": {
+										"Habit": "Eats other sapients"
+									},
+									"modifiers": [
+										{
+											"id": "mpgl28MsKAiwcG5Cd",
+											"name": "-3 Reaction",
+											"reference": "B22",
+											"cost_adj": "-15"
+										}
+									],
+									"calc": {
+										"points": -15,
+										"resolved_notes": "Eats other sapients"
+									}
+								},
+								{
+									"id": "tU8Y-vngRxwQ2omVe",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tj478Y8UdHYlqGNf2"
+									},
+									"name": "Bad Reputation",
+									"reference": "B26,MA54",
+									"tags": [
+										"Disadvantage",
+										"Social"
+									],
+									"replacements": {
+										"Large class of people": "Humans who know of your kind"
+									},
+									"modifiers": [
+										{
+											"id": "mum4aqfiRSBeW8mkn",
+											"name": "People Affected",
+											"reference": "B27",
+											"local_notes": "@Large class of people@",
+											"cost_adj": "x0.5",
+											"calc": {
+												"resolved_notes": "Humans who know of your kind"
+											}
+										}
+									],
+									"points_per_level": -5,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others aware of your reputation",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 2,
+									"calc": {
+										"points": -5,
+										"current_level": 2
+									}
+								},
+								{
+									"id": "tUd1jdZbIeqI4zzFh",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUDjEi-C-T_MPu_5E"
+									},
+									"name": "Sleepy",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mt30l6J1f77zIq-KO",
+											"name": "1/2 time",
+											"reference": "B154",
+											"cost_adj": "-8"
+										}
+									],
+									"calc": {
+										"points": -8
+									}
+								},
+								{
+									"id": "tUbMi3yyJ7H5xOvNI",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t5Qs23yaRu3D4T_hM"
+									},
+									"name": "Attentive",
+									"reference": "B163",
+									"tags": [
+										"Mental",
+										"Quirk"
+									],
+									"base_points": -1,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to skill rolls when working on lengthy tasks, but -3 to notice any important interruption",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "t4pqKvOq8njnRBldJ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+										"id": "t0VPbjg7THRHjm113"
+									},
+									"name": "Early Maturation",
+									"reference": "TT2:12",
+									"tags": [
+										"Exotic",
+										"Feature",
+										"Physical",
+										"Supernatural"
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 0,
+										"current_level": 1
+									}
+								}
+							],
+							"calc": {
+								"points": 84
+							}
+						},
+						{
+							"id": "TMY3Z_tUW8wPSTiwl",
+							"name": "Lamia",
+							"reference": "FFRR16",
+							"reference_highlight": "Lamiae",
+							"children": [
+								{
+									"id": "tqI-X3mO3ZU1CfmYO",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t1w1RFcFceKR2T9_e"
+									},
+									"name": "Increased Intelligence",
+									"reference": "B15",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental"
+									],
+									"points_per_level": 20,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "iq",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 20,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tj1hY-IPDBVBTroCa",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tmpxhXmSORakqvrbn"
+									},
+									"name": "Increased Perception",
+									"reference": "B16",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental",
+										"Physical"
+									],
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "per",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 3,
+									"calc": {
+										"points": 15,
+										"current_level": 3
+									}
+								},
+								{
+									"id": "tvSEXPYH5-b69flU3",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUJz4wvVveMiGDX0R"
+									},
+									"name": "Extended Lifespan",
+									"reference": "B53",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": 2,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 2,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tB7KPhMKrd7luymp7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tpnv8EEpAS6Er2pwK"
+									},
+									"name": "Magery",
+									"reference": "B66",
+									"tags": [
+										"Advantage",
+										"Mental",
+										"Supernatural"
+									],
+									"base_points": 5,
+									"points_per_level": 10,
+									"features": [
+										{
+											"type": "spell_bonus",
+											"match": "all_colleges",
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "thaumatology"
+											},
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 15,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tyZ3EEm-9f8uAfpp2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tj66NHKyO_GObgGsj"
+									},
+									"name": "Sharp Claws",
+									"reference": "B42",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"base_points": 5,
+									"weapons": [
+										{
+											"id": "wJEfHFy2xKyXV5kjf",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr",
+												"base": "-1"
+											},
+											"usage": "Slash",
+											"reach": "C",
+											"parry": "0",
+											"defaults": [
+												{
+													"type": "dx"
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Boxing"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Karate"
+													}
+												}
+											],
+											"calc": {
+												"damage": "thr-1 cut"
+											}
+										},
+										{
+											"id": "w47BMXWMHLP_B1km5",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr"
+											},
+											"usage": "Kick",
+											"reach": "C,1",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -2
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Karate"
+													},
+													"modifier": -2
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													},
+													"modifier": -2
+												}
+											],
+											"hide": true,
+											"calc": {
+												"damage": "thr cut"
+											}
+										}
+									],
+									"calc": {
+										"points": 5
+									}
+								},
+								{
+									"id": "tiWkAPYpIEbhRAB9Z",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tK9Ov0WtlrhnJFy5n"
+									},
+									"name": "Sharp Teeth",
+									"reference": "B91",
+									"tags": [
+										"Exotic",
+										"Perk",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mEaUzKg2v32lWtGd3",
+											"name": "Provided by Vampiric Bite",
+											"reference": "B96",
+											"cost_adj": "-1"
+										}
+									],
+									"base_points": 1,
+									"weapons": [
+										{
+											"id": "wvODBLddqLrDS1yKX",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr",
+												"base": "-1"
+											},
+											"usage": "Bite",
+											"reach": "C",
+											"defaults": [
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													}
+												},
+												{
+													"type": "dx"
+												}
+											],
+											"calc": {
+												"damage": "thr-1 cut"
+											}
+										}
+									],
+									"calc": {
+										"points": 0
+									}
+								},
+								{
+									"id": "tHIAL9a7Pj9mdQBIn",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tFHSoGWBDirlMO6Dd"
+									},
+									"name": "Vampiric Bite",
+									"reference": "B96",
+									"local_notes": "Drains 1 HP + 1/level per second. For every 3 HP stolen, you heal 1 HP or 1 FP (your choice). Also lets you bite in combat without feeding. Add Teeth (Sharp Teeth) or Teeth (Sharp Beak) – your choice for free.",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"base_points": 30,
+									"points_per_level": 5,
+									"can_level": true,
+									"calc": {
+										"points": 30,
+										"current_level": 0
+									}
+								},
+								{
+									"id": "t8S1y2k7hbH6cffFS",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tyVBpBR5-Ca0VD1Kd"
+									},
+									"name": "Colorblindness",
+									"reference": "B127",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"base_points": -10,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "artist"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "chemistry"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "driving"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "merchant"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "piloting"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "tracking"
+											},
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tlRwkmI3JyTMQx8GR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "ttHkLI9zwzfeOIEZc"
+									},
+									"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+									"reference": "B140",
+									"tags": [
+										"Disadvantage",
+										"Mental"
+									],
+									"replacements": {
+										"Class, Ethnicity, Nationality, Religion, Sex, or Species": "General"
+									},
+									"modifiers": [
+										{
+											"id": "mwDpeRypRin04OpmX",
+											"name": "Scope: Anyone unlike you",
+											"reference": "B140",
+											"cost_adj": "-10"
+										}
+									],
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tdu8z_c_B3Wo9nNeR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tMmenR4uGwxyOIH6t"
+									},
+									"name": "No Legs (Slithers)",
+									"reference": "B145",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"calc": {
+										"points": 0
+									}
+								},
+								{
+									"id": "tNRwCy2TBs3YRucB5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t49qcxpm53kg-OdPj"
+									},
+									"name": "Odious Personal Habit",
+									"reference": "B22",
+									"local_notes": "@Habit@",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"replacements": {
+										"Habit": "Eats other sapients"
+									},
+									"modifiers": [
+										{
+											"id": "md_tt-AT-mS39MzdE",
+											"name": "-3 Reaction",
+											"reference": "B22",
+											"cost_adj": "-15"
+										}
+									],
+									"calc": {
+										"points": -15,
+										"resolved_notes": "Eats other sapients"
+									}
+								},
+								{
+									"id": "tQNXQiXS1hUF5r2U_",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tj478Y8UdHYlqGNf2"
+									},
+									"name": "Bad Reputation",
+									"reference": "B26,MA54",
+									"tags": [
+										"Disadvantage",
+										"Social"
+									],
+									"replacements": {
+										"Large class of people": "Humans who know of your kind"
+									},
+									"modifiers": [
+										{
+											"id": "muDTbjtjfurqwxlT9",
+											"name": "People Affected",
+											"reference": "B27",
+											"local_notes": "@Large class of people@",
+											"cost_adj": "x0.5",
+											"calc": {
+												"resolved_notes": "Humans who know of your kind"
+											}
+										}
+									],
+									"points_per_level": -5,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others aware of your reputation",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 2,
+									"calc": {
+										"points": -5,
+										"current_level": 2
+									}
+								},
+								{
+									"id": "ttvBBaX7_mDsjoBYR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUDjEi-C-T_MPu_5E"
+									},
+									"name": "Sleepy",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mnftXg2kTwBOqAXS9",
+											"name": "1/2 time",
+											"reference": "B154",
+											"cost_adj": "-8"
+										}
+									],
+									"calc": {
+										"points": -8
+									}
+								},
+								{
+									"id": "tcFHoRKFz3eWZIpUz",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tHv97hIejdmH2l3xH"
+									},
+									"name": "@Physical Quirk@",
+									"reference": "B165, PU6:22",
+									"reference_highlight": "Physical Quirks",
+									"tags": [
+										"Physical",
+										"Quirk"
+									],
+									"replacements": {
+										"Physical Quirk": "Cannot Jump"
+									},
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "t0WTc0YXJZhEtV8XV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+										"id": "t0VPbjg7THRHjm113"
+									},
+									"name": "Early Maturation",
+									"reference": "TT2:12",
+									"tags": [
+										"Exotic",
+										"Feature",
+										"Physical",
+										"Supernatural"
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 0,
+										"current_level": 1
+									}
+								}
+							],
+							"calc": {
+								"points": 38
+							}
+						},
+						{
+							"id": "TP0VT08wbGzFxZ_Kd",
+							"name": "Lesser Naga",
+							"reference": "FFRR16",
+							"reference_highlight": "Lesser Nagas",
+							"children": [
+								{
+									"id": "t_WpGAGlP885p3Tpv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t1w1RFcFceKR2T9_e"
+									},
+									"name": "Increased Intelligence",
+									"reference": "B15",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental"
+									],
+									"points_per_level": 20,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "iq",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 3,
+									"calc": {
+										"points": 60,
+										"current_level": 3
+									}
+								},
+								{
+									"id": "tAMyjiXIADHRxRSt1",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGjjVtxav9KsrG7Wx"
+									},
+									"name": "Combat Reflexes",
+									"reference": "B43",
+									"local_notes": "Never freeze",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Enhanced Time Sense"
+												}
+											}
+										]
+									},
+									"base_points": 15,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "starts_with",
+												"qualifier": "fast-draw"
+											},
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "dodge",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "parry",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "block",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "fright_check",
+											"amount": 2
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+											"amount": 6
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to initiative rolls for your side (+2 if you are the leader)",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": 15
+									}
+								},
+								{
+									"id": "tTukUcUPMPJT_RyHU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tIixiOHEen0Uqu4Xo"
+									},
+									"name": "Constriction Attack",
+									"reference": "B43,P45",
+									"local_notes": "If you succeed on a grapple against an opponent no larger than your own SM, on your next turn, and each successive turn, roll a Quick Contest of your ST vs. your victim’s ST or HT, whichever is higher. If you win, your victim takes damage equal to your margin of victory; otherwise, no damage is inflicted",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"base_points": 15,
+									"calc": {
+										"points": 15
+									}
+								},
+								{
+									"id": "toEhgx0Mhzk9sC7hL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUX_zxoB4sWyeNpHi"
+									},
+									"name": "Doesn't Breathe",
+									"reference": "B49",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mN5j-r6d91TcjksXE",
+											"name": "Gills",
+											"reference": "B49",
+											"cost_adj": "-50%"
+										}
+									],
+									"base_points": 20,
+									"calc": {
+										"points": 10
+									}
+								},
+								{
+									"id": "tHUy8nPtGSJN0yfPQ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUJz4wvVveMiGDX0R"
+									},
+									"name": "Extended Lifespan",
+									"reference": "B53",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": 2,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 2,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tcFoPROVqkfI3tdcj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "thzHBFCK6BNeYvZxO"
+									},
+									"name": "Jumper (@World/Time/Spirit@)",
+									"reference": "B64,P57,PSI15,DF9:5",
+									"tags": [
+										"Advantage",
+										"Mental",
+										"Supernatural"
+									],
+									"replacements": {
+										"Portal": "Deep Caves and Underground Bodies of Water",
+										"World/Time/Spirit": "Spirit"
+									},
+									"modifiers": [
+										{
+											"id": "m24SYZjbNh3RAAfui",
+											"name": "Special Portal",
+											"reference": "P58",
+											"local_notes": "@Portal@",
+											"cost_adj": "-40",
+											"calc": {
+												"resolved_notes": "Deep Caves and Underground Bodies of Water"
+											}
+										}
+									],
+									"base_points": 100,
+									"calc": {
+										"points": 60
+									}
+								},
+								{
+									"id": "tgl5UP1K0kI1gZHQP",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tpnv8EEpAS6Er2pwK"
+									},
+									"name": "Magery",
+									"reference": "B66",
+									"tags": [
+										"Advantage",
+										"Mental",
+										"Supernatural"
+									],
+									"base_points": 5,
+									"points_per_level": 10,
+									"features": [
+										{
+											"type": "spell_bonus",
+											"match": "all_colleges",
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "thaumatology"
+											},
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 15,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tkCgkktDWuZ6lHQTK",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tK9Ov0WtlrhnJFy5n"
+									},
+									"name": "Sharp Teeth",
+									"reference": "B91",
+									"tags": [
+										"Exotic",
+										"Perk",
+										"Physical"
+									],
+									"base_points": 1,
+									"weapons": [
+										{
+											"id": "wpMxMwK7phnsj0PHH",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr",
+												"base": "-1"
+											},
+											"usage": "Bite",
+											"reach": "C",
+											"defaults": [
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													}
+												},
+												{
+													"type": "dx"
+												}
+											],
+											"calc": {
+												"damage": "thr-1 cut"
+											}
+										}
+									],
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "tLI4V0gC-QHkmhZxH",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "ti8Mwn5KC8w-uyGTH"
+									},
+									"name": "Social Regard",
+									"reference": "B87",
+									"local_notes": "@Type: Feared, Respected or Venerated@: @Reason@",
+									"tags": [
+										"Advantage",
+										"Social"
+									],
+									"replacements": {
+										"Reason": "Naga",
+										"Type: Feared, Respected or Venerated": "Respected"
+									},
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from those who hold you in high regard for being a @Reason@, in a @Type: Feared, Respected or Venerated@ way.",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 2,
+									"calc": {
+										"points": 10,
+										"resolved_notes": "Respected: Naga",
+										"current_level": 2
+									}
+								},
+								{
+									"id": "t3PQHcX_8iL25xELM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tMmenR4uGwxyOIH6t"
+									},
+									"name": "No Legs (Slithers)",
+									"reference": "B145",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"calc": {
+										"points": 0
+									}
+								},
+								{
+									"id": "tNZtTdBUEorQefvTQ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t5bwP6TnS4cX-zM8L"
+									},
+									"name": "Enemy (@Who@)",
+									"reference": "B135",
+									"tags": [
+										"Disadvantage",
+										"Social"
+									],
+									"replacements": {
+										"Who": "Emissaries of the Divine Bird Garuda"
+									},
+									"modifiers": [
+										{
+											"id": "M8D__2z9trKhPM-PZ",
+											"name": "Power",
+											"children": [
+												{
+													"id": "mShavFOhROORlIz29",
+													"name": "Utterly Formidable Group",
+													"reference": "B135",
+													"cost_adj": "-40"
+												}
+											]
+										},
+										{
+											"id": "M-0e7aeo_dGkTis7A",
+											"name": "Intent",
+											"children": [
+												{
+													"id": "m87NGiXzfGA8irQ5w",
+													"name": "Watcher",
+													"reference": "B135",
+													"cost_adj": "x0.25"
+												}
+											]
+										},
+										{
+											"id": "McPIVN9caxwOVcSpk",
+											"name": "Frequency of Appearance",
+											"children": [
+												{
+													"id": "mnu5bJ2skAPO9uXJ4",
+													"name": "Appears quite rarely",
+													"reference": "B36",
+													"local_notes": "6-",
+													"cost_adj": "x0.5"
+												}
+											]
+										}
+									],
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "t4dssHORQJpf0yC5-",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "trPM4mpwMJnj-tqdg"
+									},
+									"name": "@Mental Quirk@",
+									"reference": "B162, PU6:17",
+									"reference_highlight": "Mental Quirks",
+									"tags": [
+										"Mental",
+										"Quirk"
+									],
+									"replacements": {
+										"Mental Quirk": "Fascinated by gold and jewels"
+									},
+									"base_points": -1,
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "tabBLq1JSIiP7ZC2n",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+										"id": "t0VPbjg7THRHjm113"
+									},
+									"name": "Early Maturation",
+									"reference": "TT2:12",
+									"tags": [
+										"Exotic",
+										"Feature",
+										"Physical",
+										"Supernatural"
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 0,
+										"current_level": 1
+									}
+								}
+							],
+							"calc": {
+								"points": 182
+							}
+						},
+						{
+							"id": "TaSv7j-2_VgqEVnvX",
+							"name": "Monster Hunters Serpent Lord",
+							"reference": "FFRR16",
+							"children": [
+								{
+									"id": "tFu7jM4LzBX67AtGz",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t1w1RFcFceKR2T9_e"
+									},
+									"name": "Increased Intelligence",
+									"reference": "B15",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental"
+									],
+									"points_per_level": 20,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "iq",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 3,
+									"calc": {
+										"points": 60,
+										"current_level": 3
+									}
+								},
+								{
+									"id": "tNc5hDSOVM9FL82gY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tmpxhXmSORakqvrbn"
+									},
+									"name": "Increased Perception",
+									"reference": "B16",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental",
+										"Physical"
+									],
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "per",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 3,
+									"calc": {
+										"points": 15,
+										"current_level": 3
+									}
+								},
+								{
+									"id": "t1SUot_qXgZXq3oIf",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tj66NHKyO_GObgGsj"
+									},
+									"name": "Sharp Claws",
+									"reference": "B42",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"base_points": 5,
+									"weapons": [
+										{
+											"id": "wpJJVPIoXJGpCocyE",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr",
+												"base": "-1"
+											},
+											"usage": "Slash",
+											"reach": "C",
+											"parry": "0",
+											"defaults": [
+												{
+													"type": "dx"
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Boxing"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Karate"
+													}
+												}
+											],
+											"calc": {
+												"damage": "thr-1 cut"
+											}
+										},
+										{
+											"id": "wf1inslKdeBLz7_WM",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr"
+											},
+											"usage": "Kick",
+											"reach": "C,1",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -2
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Karate"
+													},
+													"modifier": -2
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													},
+													"modifier": -2
+												}
+											],
+											"calc": {
+												"damage": "thr cut"
+											}
+										}
+									],
+									"calc": {
+										"points": 5
+									}
+								},
+								{
+									"id": "tB6tjBUVm6yWx7sbW",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGjjVtxav9KsrG7Wx"
+									},
+									"name": "Combat Reflexes",
+									"reference": "B43",
+									"local_notes": "Never freeze",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Enhanced Time Sense"
+												}
+											}
+										]
+									},
+									"base_points": 15,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "starts_with",
+												"qualifier": "fast-draw"
+											},
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "dodge",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "parry",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "block",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "fright_check",
+											"amount": 2
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+											"amount": 6
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to initiative rolls for your side (+2 if you are the leader)",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": 15
+									}
+								},
+								{
+									"id": "tN9KtY9yzhYwN_dlX",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tG2tK0QWXPQqFk-rd"
+									},
+									"name": "Enhanced Move (@type@)",
+									"reference": "B52,P49",
+									"local_notes": "Double your normal @type@ Move for each level",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"replacements": {
+										"type": "Ground"
+									},
+									"points_per_level": 20,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 20,
+										"resolved_notes": "Double your normal Ground Move for each level",
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tATgswF1CUsAREdRv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Thaumatology/Thaumatology - RPM Traits.adq",
+										"id": "tbN9n6aAMMZoBiWQL"
+									},
+									"name": "Magery (Ritual Path)",
+									"reference": "TRPM5",
+									"tags": [
+										"Advantage",
+										"Mental",
+										"Supernatural"
+									],
+									"base_points": 5,
+									"points_per_level": 10,
+									"can_level": true,
+									"levels": 4,
+									"calc": {
+										"points": 45,
+										"current_level": 4
+									}
+								},
+								{
+									"id": "tbrx5diptXd8r2T8-",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tK9Ov0WtlrhnJFy5n"
+									},
+									"name": "Sharp Teeth",
+									"reference": "B91",
+									"tags": [
+										"Exotic",
+										"Perk",
+										"Physical"
+									],
+									"base_points": 1,
+									"weapons": [
+										{
+											"id": "wiaIYrf9tB7H_Kq_s",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr",
+												"base": "-1"
+											},
+											"usage": "Bite",
+											"reach": "C",
+											"defaults": [
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													}
+												},
+												{
+													"type": "dx"
+												}
+											],
+											"calc": {
+												"damage": "thr-1 cut"
+											}
+										}
+									],
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "tJgNeqblSxEGynUN7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tyVBpBR5-Ca0VD1Kd"
+									},
+									"name": "Colorblindness",
+									"reference": "B127",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"base_points": -10,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "artist"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "chemistry"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "driving"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "merchant"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "piloting"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "tracking"
+											},
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "t960EipoRamw-NLAq",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "ttHkLI9zwzfeOIEZc"
+									},
+									"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+									"reference": "B140",
+									"tags": [
+										"Disadvantage",
+										"Mental"
+									],
+									"replacements": {
+										"Class, Ethnicity, Nationality, Religion, Sex, or Species": "General"
+									},
+									"modifiers": [
+										{
+											"id": "mizlmvy6TDvhQ7toY",
+											"name": "Scope: Anyone unlike you",
+											"reference": "B140",
+											"cost_adj": "-10"
+										}
+									],
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "thv3sWi8KE6U7wwN4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t49qcxpm53kg-OdPj"
+									},
+									"name": "Odious Personal Habit",
+									"reference": "B22",
+									"local_notes": "@Habit@",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"replacements": {
+										"Habit": "Eats other sapients"
+									},
+									"modifiers": [
+										{
+											"id": "mXxAD9dHegz_dSoJk",
+											"name": "-3 Reaction",
+											"reference": "B22",
+											"cost_adj": "-15"
+										}
+									],
+									"calc": {
+										"points": -15,
+										"resolved_notes": "Eats other sapients"
+									}
+								},
+								{
+									"id": "tL6mXQ-10waYZrYBV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tj478Y8UdHYlqGNf2"
+									},
+									"name": "Bad Reputation",
+									"reference": "B26,MA54",
+									"tags": [
+										"Disadvantage",
+										"Social"
+									],
+									"replacements": {
+										"Large class of people": "Humans who know of your kind"
+									},
+									"modifiers": [
+										{
+											"id": "mIS0yur4jCItiB1UO",
+											"name": "People Affected",
+											"reference": "B27",
+											"local_notes": "@Large class of people@",
+											"cost_adj": "x0.5",
+											"calc": {
+												"resolved_notes": "Humans who know of your kind"
+											}
+										}
+									],
+									"points_per_level": -5,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others aware of your reputation",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 2,
+									"calc": {
+										"points": -5,
+										"current_level": 2
+									}
+								},
+								{
+									"id": "tCUpnqCI_zlMkWMj8",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUDjEi-C-T_MPu_5E"
+									},
+									"name": "Sleepy",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "m7_jtkLhWDg9gaUjj",
+											"name": "1/2 time",
+											"reference": "B154",
+											"cost_adj": "-8"
+										}
+									],
+									"calc": {
+										"points": -8
+									}
+								},
+								{
+									"id": "tV7nRj6By-OuQBSI2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t5Qs23yaRu3D4T_hM"
+									},
+									"name": "Attentive",
+									"reference": "B163",
+									"tags": [
+										"Mental",
+										"Quirk"
+									],
+									"base_points": -1,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to skill rolls when working on lengthy tasks, but -3 to notice any important interruption",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								}
+							],
+							"calc": {
+								"points": 112
+							}
+						},
+						{
+							"id": "TyRNd6PdAzF6J69Es",
+							"name": "Psionic Serpent-Lord",
+							"reference": "FFRR17",
+							"children": [
+								{
+									"id": "t49BtnilAw5rg0-H7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t1w1RFcFceKR2T9_e"
+									},
+									"name": "Increased Intelligence",
+									"reference": "B15",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental"
+									],
+									"points_per_level": 20,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "iq",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 3,
+									"calc": {
+										"points": 60,
+										"current_level": 3
+									}
+								},
+								{
+									"id": "tw4VL2gVjbKKNq_3a",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tmpxhXmSORakqvrbn"
+									},
+									"name": "Increased Perception",
+									"reference": "B16",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental",
+										"Physical"
+									],
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "per",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 3,
+									"calc": {
+										"points": 15,
+										"current_level": 3
+									}
+								},
+								{
+									"id": "tyb_APSFstuvs7yRf",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tj66NHKyO_GObgGsj"
+									},
+									"name": "Sharp Claws",
+									"reference": "B42",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"base_points": 5,
+									"weapons": [
+										{
+											"id": "w3UGMLYzm_1Me9uhr",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr",
+												"base": "-1"
+											},
+											"usage": "Slash",
+											"reach": "C",
+											"parry": "0",
+											"defaults": [
+												{
+													"type": "dx"
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Boxing"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Karate"
+													}
+												}
+											],
+											"calc": {
+												"damage": "thr-1 cut"
+											}
+										},
+										{
+											"id": "wNh7E0bdN1gnLCJS1",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr"
+											},
+											"usage": "Kick",
+											"reach": "C,1",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -2
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Karate"
+													},
+													"modifier": -2
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													},
+													"modifier": -2
+												}
+											],
+											"calc": {
+												"damage": "thr cut"
+											}
+										}
+									],
+									"calc": {
+										"points": 5
+									}
+								},
+								{
+									"id": "tlbkqzxESpJiCYFeM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGjjVtxav9KsrG7Wx"
+									},
+									"name": "Combat Reflexes",
+									"reference": "B43",
+									"local_notes": "Never freeze",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Enhanced Time Sense"
+												}
+											}
+										]
+									},
+									"base_points": 15,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "starts_with",
+												"qualifier": "fast-draw"
+											},
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "dodge",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "parry",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "block",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "fright_check",
+											"amount": 2
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+											"amount": 6
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to initiative rolls for your side (+2 if you are the leader)",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": 15
+									}
+								},
+								{
+									"id": "twKl0DMYbBpgYatB2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tG2tK0QWXPQqFk-rd"
+									},
+									"name": "Enhanced Move (@type@)",
+									"reference": "B52,P49",
+									"local_notes": "Double your normal @type@ Move for each level",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"replacements": {
+										"type": "Ground"
+									},
+									"points_per_level": 20,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 20,
+										"resolved_notes": "Double your normal Ground Move for each level",
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tK5BmBALeuVhX4QOe",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUJz4wvVveMiGDX0R"
+									},
+									"name": "Extended Lifespan",
+									"reference": "B53",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"points_per_level": 2,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 2,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tAvRuqtUG45uMHGXM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tK9Ov0WtlrhnJFy5n"
+									},
+									"name": "Sharp Teeth",
+									"reference": "B91",
+									"tags": [
+										"Exotic",
+										"Perk",
+										"Physical"
+									],
+									"base_points": 1,
+									"weapons": [
+										{
+											"id": "wSvu5ehC4oMMiymoD",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr",
+												"base": "-1"
+											},
+											"usage": "Bite",
+											"reach": "C",
+											"defaults": [
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													}
+												},
+												{
+													"type": "dx"
+												}
+											],
+											"calc": {
+												"damage": "thr-1 cut"
+											}
+										}
+									],
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "tU5hdX1e-wyEVu2Te",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Psionics/Psionics Traits.adq",
+										"id": "tBAEUyE1yVLSN9wnz"
+									},
+									"name": "Telepathy Talent",
+									"reference": "PSI19",
+									"tags": [
+										"Communication",
+										"Control",
+										"Mental",
+										"Offense",
+										"Power",
+										"Sense and Defense",
+										"Telepathy"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Offense Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Control Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Sense and Defense Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Communication Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
+									},
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"tags": {
+												"compare": "is",
+												"qualifier": "PsionicSkill:Telepathy"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Crippling Blow"
+											},
+											"specialization": {
+												"compare": "contains",
+												"qualifier": "Telepathy"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Deafening Display"
+											},
+											"specialization": {
+												"compare": "contains",
+												"qualifier": "Telepathy"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Drugged Weapon"
+											},
+											"specialization": {
+												"compare": "contains",
+												"qualifier": "Telepathy"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Fatiguing Strike"
+											},
+											"specialization": {
+												"compare": "contains",
+												"qualifier": "Telepathy"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Project Blow"
+											},
+											"specialization": {
+												"compare": "contains",
+												"qualifier": "Telepathy"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Restorative Armor"
+											},
+											"specialization": {
+												"compare": "contains",
+												"qualifier": "Telepathy"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Stealthy Attack"
+											},
+											"specialization": {
+												"compare": "contains",
+												"qualifier": "Telepathy"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Stupefying Blow"
+											},
+											"specialization": {
+												"compare": "contains",
+												"qualifier": "Telepathy"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Subtle Defense"
+											},
+											"specialization": {
+												"compare": "contains",
+												"qualifier": "Telepathy"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Sudden Death"
+											},
+											"specialization": {
+												"compare": "contains",
+												"qualifier": "Telepathy"
+											},
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "Thunderous Defense"
+											},
+											"specialization": {
+												"compare": "contains",
+												"qualifier": "Telepathy"
+											},
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 3,
+									"calc": {
+										"points": 15,
+										"current_level": 3
+									}
+								},
+								{
+									"id": "tHmi32BbPXT_f3jgr",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tyVBpBR5-Ca0VD1Kd"
+									},
+									"name": "Colorblindness",
+									"reference": "B127",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"base_points": -10,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "artist"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "chemistry"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "driving"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "merchant"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "piloting"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "tracking"
+											},
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tEeKbap_1Qd2P0dl8",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "ttHkLI9zwzfeOIEZc"
+									},
+									"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+									"reference": "B140",
+									"tags": [
+										"Disadvantage",
+										"Mental"
+									],
+									"replacements": {
+										"Class, Ethnicity, Nationality, Religion, Sex, or Species": "General"
+									},
+									"modifiers": [
+										{
+											"id": "mVtTwihBGlhJ_gGWg",
+											"name": "Scope: Anyone unlike you",
+											"reference": "B140",
+											"cost_adj": "-10"
+										}
+									],
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tgF1LsoF-BkRgTZn0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t49qcxpm53kg-OdPj"
+									},
+									"name": "Odious Personal Habit",
+									"reference": "B22",
+									"local_notes": "@Habit@",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"replacements": {
+										"Habit": "Eats other sapients"
+									},
+									"modifiers": [
+										{
+											"id": "m9uhQ33q4k01wxUoZ",
+											"name": "-3 Reaction",
+											"reference": "B22",
+											"cost_adj": "-15"
+										}
+									],
+									"calc": {
+										"points": -15,
+										"resolved_notes": "Eats other sapients"
+									}
+								},
+								{
+									"id": "tckQlryEhFqxNVVaz",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tj478Y8UdHYlqGNf2"
+									},
+									"name": "Bad Reputation",
+									"reference": "B26,MA54",
+									"tags": [
+										"Disadvantage",
+										"Social"
+									],
+									"replacements": {
+										"Large class of people": "Humans who know of your kind"
+									},
+									"modifiers": [
+										{
+											"id": "mRJ7cK8XJxvI_BHIi",
+											"name": "People Affected",
+											"reference": "B27",
+											"local_notes": "@Large class of people@",
+											"cost_adj": "x0.5",
+											"calc": {
+												"resolved_notes": "Humans who know of your kind"
+											}
+										}
+									],
+									"points_per_level": -5,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others aware of your reputation",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 2,
+									"calc": {
+										"points": -5,
+										"current_level": 2
+									}
+								},
+								{
+									"id": "tfP8WghNrMXZQSWzw",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUDjEi-C-T_MPu_5E"
+									},
+									"name": "Sleepy",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mGR8MwNrwqubkvRxX",
+											"name": "1/2 time",
+											"reference": "B154",
+											"cost_adj": "-8"
+										}
+									],
+									"calc": {
+										"points": -8
+									}
+								},
+								{
+									"id": "tbo3V-gVOWqOmxXgK",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t5Qs23yaRu3D4T_hM"
+									},
+									"name": "Attentive",
+									"reference": "B163",
+									"tags": [
+										"Mental",
+										"Quirk"
+									],
+									"base_points": -1,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to skill rolls when working on lengthy tasks, but -3 to notice any important interruption",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								},
+								{
+									"id": "tLD6Om5Z5HeWJkIEk",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Template Toolkit/Template Toolkit 2 - Races/Template Toolkit 2 - Races Traits.adq",
+										"id": "t0VPbjg7THRHjm113"
+									},
+									"name": "Early Maturation",
+									"reference": "TT2:12",
+									"tags": [
+										"Exotic",
+										"Feature",
+										"Physical",
+										"Supernatural"
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 0,
+										"current_level": 1
+									}
+								}
+							],
+							"calc": {
+								"points": 84
+							}
+						},
+						{
+							"id": "TdQidP3IORNcg33Z3",
+							"name": "Timeless Terror",
+							"reference": "FFRR17",
+							"children": [
+								{
+									"id": "t6Wn1IR3zZZTMgtRM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t1w1RFcFceKR2T9_e"
+									},
+									"name": "Increased Intelligence",
+									"reference": "B15",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental"
+									],
+									"points_per_level": 20,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "iq",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 3,
+									"calc": {
+										"points": 60,
+										"current_level": 3
+									}
+								},
+								{
+									"id": "tjwQXKXXrGbpr7Qnj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tmpxhXmSORakqvrbn"
+									},
+									"name": "Increased Perception",
+									"reference": "B16",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental",
+										"Physical"
+									],
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "per",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 3,
+									"calc": {
+										"points": 15,
+										"current_level": 3
+									}
+								},
+								{
+									"id": "tAEz4GhOJY2dvLOEL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tj66NHKyO_GObgGsj"
+									},
+									"name": "Sharp Claws",
+									"reference": "B42",
+									"tags": [
+										"Advantage",
+										"Physical"
+									],
+									"base_points": 5,
+									"weapons": [
+										{
+											"id": "wDghHsbxDP6P6iq0h",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr",
+												"base": "-1"
+											},
+											"usage": "Slash",
+											"reach": "C",
+											"parry": "0",
+											"defaults": [
+												{
+													"type": "dx"
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Boxing"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Karate"
+													}
+												}
+											],
+											"calc": {
+												"damage": "thr-1 cut"
+											}
+										},
+										{
+											"id": "w17TnVzy3m-slSVUp",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr"
+											},
+											"usage": "Kick",
+											"reach": "C,1",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -2
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Karate"
+													},
+													"modifier": -2
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													},
+													"modifier": -2
+												}
+											],
+											"calc": {
+												"damage": "thr cut"
+											}
+										}
+									],
+									"calc": {
+										"points": 5
+									}
+								},
+								{
+									"id": "tE76iaxmd0Z7bX8CP",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGjjVtxav9KsrG7Wx"
+									},
+									"name": "Combat Reflexes",
+									"reference": "B43",
+									"local_notes": "Never freeze",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Enhanced Time Sense"
+												}
+											}
+										]
+									},
+									"base_points": 15,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "starts_with",
+												"qualifier": "fast-draw"
+											},
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "dodge",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "parry",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "block",
+											"amount": 1
+										},
+										{
+											"type": "attribute_bonus",
+											"attribute": "fright_check",
+											"amount": 2
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+											"amount": 6
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to initiative rolls for your side (+2 if you are the leader)",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": 15
+									}
+								},
+								{
+									"id": "tqpDW7XJ1dhqgaYff",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tG2tK0QWXPQqFk-rd"
+									},
+									"name": "Enhanced Move (@type@)",
+									"reference": "B52,P49",
+									"local_notes": "Double your normal @type@ Move for each level",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"replacements": {
+										"type": "Ground"
+									},
+									"points_per_level": 20,
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 20,
+										"resolved_notes": "Double your normal Ground Move for each level",
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tATItGsl2gScIQdQN",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tpnv8EEpAS6Er2pwK"
+									},
+									"name": "Magery",
+									"reference": "B66",
+									"tags": [
+										"Advantage",
+										"Mental",
+										"Supernatural"
+									],
+									"base_points": 5,
+									"points_per_level": 10,
+									"features": [
+										{
+											"type": "spell_bonus",
+											"match": "all_colleges",
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "thaumatology"
+											},
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 15,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tPtKIcUzkmqS7oWLi",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tK9Ov0WtlrhnJFy5n"
+									},
+									"name": "Sharp Teeth",
+									"reference": "B91",
+									"tags": [
+										"Exotic",
+										"Perk",
+										"Physical"
+									],
+									"base_points": 1,
+									"weapons": [
+										{
+											"id": "w1Mc-8a8ah_LCMMAb",
+											"sv": 1,
+											"damage": {
+												"type": "cut",
+												"st": "thr",
+												"base": "-1"
+											},
+											"usage": "Bite",
+											"reach": "C",
+											"defaults": [
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													}
+												},
+												{
+													"type": "dx"
+												}
+											],
+											"calc": {
+												"damage": "thr-1 cut"
+											}
+										}
+									],
+									"calc": {
+										"points": 1
+									}
+								},
+								{
+									"id": "tV73euTMrkMRzIBcS",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tYnrwhhEwv7uvdomv"
+									},
+									"name": "Unaging",
+									"reference": "B95,PSI18",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "mJl8IkszeXNL1q-2x",
+											"name": "Age Control",
+											"reference": "B95",
+											"cost_adj": "20%",
+											"disabled": true
+										},
+										{
+											"id": "mg1kQDDIvKQWR7FRo",
+											"name": "IQ Only",
+											"reference": "RSWL24",
+											"cost_adj": "-75%",
+											"disabled": true
+										},
+										{
+											"id": "mwPZERQGx0IXfd-hw",
+											"name": "Halt Aging, Weekly",
+											"reference": "PSI18",
+											"cost_adj": "80%",
+											"disabled": true
+										},
+										{
+											"id": "m05jYxxCWRV_mZIyf",
+											"name": "Halt Aging, Monthly",
+											"reference": "PSI18",
+											"cost_adj": "100%",
+											"disabled": true
+										},
+										{
+											"id": "mJZGKpvY1u7_ekaIL",
+											"name": "Halt Aging, Yearly",
+											"reference": "PSI18",
+											"cost_adj": "130%",
+											"disabled": true
+										},
+										{
+											"id": "mGckp9YtQae7EFeJh",
+											"name": "Life Extension",
+											"reference": "PSI18",
+											"cost_adj": "-30%",
+											"disabled": true
+										}
+									],
+									"base_points": 15,
+									"calc": {
+										"points": 15
+									}
+								},
+								{
+									"id": "tGvlPF3eNcE3HBxQd",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tyVBpBR5-Ca0VD1Kd"
+									},
+									"name": "Colorblindness",
+									"reference": "B127",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"base_points": -10,
+									"features": [
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "artist"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "chemistry"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "driving"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "is",
+												"qualifier": "merchant"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "piloting"
+											},
+											"amount": -1
+										},
+										{
+											"type": "skill_bonus",
+											"selection_type": "skills_with_name",
+											"name": {
+												"compare": "contains",
+												"qualifier": "tracking"
+											},
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tx4Fl5ohdKbv46wXD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "ttHkLI9zwzfeOIEZc"
+									},
+									"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+									"reference": "B140",
+									"tags": [
+										"Disadvantage",
+										"Mental"
+									],
+									"replacements": {
+										"Class, Ethnicity, Nationality, Religion, Sex, or Species": "General"
+									},
+									"modifiers": [
+										{
+											"id": "mwmhXEpQTxvoLs_af",
+											"name": "Scope: Anyone unlike you",
+											"reference": "B140",
+											"cost_adj": "-10"
+										}
+									],
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+											"amount": -1
+										}
+									],
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tMQwU7CszS2Qcslqv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t49qcxpm53kg-OdPj"
+									},
+									"name": "Odious Personal Habit",
+									"reference": "B22",
+									"local_notes": "@Habit@",
+									"tags": [
+										"Disadvantage",
+										"Physical"
+									],
+									"replacements": {
+										"Habit": "Eats other sapients"
+									},
+									"modifiers": [
+										{
+											"id": "mNAf27iJEgL6r0AjT",
+											"name": "-3 Reaction",
+											"reference": "B22",
+											"cost_adj": "-15"
+										}
+									],
+									"calc": {
+										"points": -15,
+										"resolved_notes": "Eats other sapients"
+									}
+								},
+								{
+									"id": "tkh7F_6xiL9DLijMI",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tj478Y8UdHYlqGNf2"
+									},
+									"name": "Bad Reputation",
+									"reference": "B26,MA54",
+									"tags": [
+										"Disadvantage",
+										"Social"
+									],
+									"replacements": {
+										"Large class of people": "Humans who know of your kind"
+									},
+									"modifiers": [
+										{
+											"id": "moIggm5cGbE5qXegq",
+											"name": "People Affected",
+											"reference": "B27",
+											"local_notes": "@Large class of people@",
+											"cost_adj": "x0.5",
+											"calc": {
+												"resolved_notes": "Humans who know of your kind"
+											}
+										}
+									],
+									"points_per_level": -5,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others aware of your reputation",
+											"amount": -1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 2,
+									"calc": {
+										"points": -5,
+										"current_level": 2
+									}
+								},
+								{
+									"id": "tAPygugVNSC8V5vJY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tUDjEi-C-T_MPu_5E"
+									},
+									"name": "Sleepy",
+									"reference": "B154",
+									"tags": [
+										"Disadvantage",
+										"Exotic",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "m1Ut8oQAcr9EtZDwk",
+											"name": "1/2 time",
+											"reference": "B154",
+											"cost_adj": "-8"
+										}
+									],
+									"calc": {
+										"points": -8
+									}
+								},
+								{
+									"id": "t_qb6gVYTm8yubdbW",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t5Qs23yaRu3D4T_hM"
+									},
+									"name": "Attentive",
+									"reference": "B163",
+									"tags": [
+										"Mental",
+										"Quirk"
+									],
+									"base_points": -1,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to skill rolls when working on lengthy tasks, but -3 to notice any important interruption",
+											"amount": 1
+										}
+									],
+									"calc": {
+										"points": -1
+									}
+								}
+							],
+							"calc": {
+								"points": 97
+							}
+						}
+					],
+					"calc": {
+						"points": 597
+					}
+				}
+			],
+			"calc": {
+				"points": 675
+			}
+		},
+		{
+			"id": "TeCqRFjKHfkc-QRk3",
+			"name": "Enhanced Human",
+			"reference": "FFRR15",
+			"reference_highlight": "a normal human but",
+			"disabled": true,
+			"ancestry": "Human",
+			"container_type": "ancestry",
+			"children": [
+				{
+					"id": "ti1-tdOEerWmzVHUy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t1w1RFcFceKR2T9_e"
+					},
+					"name": "Increased Intelligence",
+					"reference": "B15",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Mental"
+					],
+					"points_per_level": 20,
+					"features": [
+						{
+							"type": "attribute_bonus",
+							"attribute": "iq",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 3,
+					"calc": {
+						"points": 0,
+						"current_level": 0
+					}
+				},
+				{
+					"id": "tUL3CnJn_WdCU8MVb",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tGjjVtxav9KsrG7Wx"
+					},
+					"name": "Combat Reflexes",
+					"reference": "B43",
+					"local_notes": "Never freeze",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Enhanced Time Sense"
+								}
+							}
+						]
+					},
+					"base_points": 15,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "starts_with",
+								"qualifier": "fast-draw"
+							},
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "dodge",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "parry",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "block",
+							"amount": 1
+						},
+						{
+							"type": "attribute_bonus",
+							"attribute": "fright_check",
+							"amount": 2
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+							"amount": 6
+						},
+						{
+							"type": "conditional_modifier",
+							"situation": "to initiative rolls for your side (+2 if you are the leader)",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tcU7ZQTXOi4NM71Go",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tpnv8EEpAS6Er2pwK"
+					},
+					"name": "Magery",
+					"reference": "B66",
+					"tags": [
+						"Advantage",
+						"Mental",
+						"Supernatural"
+					],
+					"base_points": 5,
+					"points_per_level": 10,
+					"features": [
+						{
+							"type": "spell_bonus",
+							"match": "all_colleges",
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "thaumatology"
+							},
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 0,
+						"current_level": 0
+					}
+				},
+				{
+					"id": "ta48vd91kGQS7l02E",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "ttHkLI9zwzfeOIEZc"
+					},
+					"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+					"reference": "B140",
+					"tags": [
+						"Disadvantage",
+						"Mental"
+					],
+					"replacements": {
+						"Class, Ethnicity, Nationality, Religion, Sex, or Species": "General"
+					},
+					"modifiers": [
+						{
+							"id": "mU6EnrODuNRNy2RND",
+							"name": "Scope: Anyone unlike you",
+							"reference": "B140",
+							"cost_adj": "-10"
+						}
+					],
+					"features": [
+						{
+							"type": "reaction_bonus",
+							"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+							"amount": -1
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "t7b5kVnfTkrVyEzVQ",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t5Qs23yaRu3D4T_hM"
+					},
+					"name": "Attentive",
+					"reference": "B163",
+					"tags": [
+						"Mental",
+						"Quirk"
+					],
+					"base_points": -1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to skill rolls when working on lengthy tasks, but -3 to notice any important interruption",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				}
+			],
+			"calc": {
+				"points": 0
+			}
+		}
+	],
+	"skills": [
+		{
+			"id": "STqdWhf4gYoNN4Wxj",
+			"name": "Serpent-Lord",
+			"children": [
+				{
+					"id": "sUU243dmiw11SCoEu",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Skills.skl",
+						"id": "sm-zCRgqY_1QXowLd"
+					},
+					"name": "Hypnotism",
+					"reference": "B201",
+					"tags": [
+						"Medical"
+					],
+					"difficulty": "iq/h",
+					"points": 8
+				},
+				{
+					"id": "SQbj2_DR6IASuvLyd",
+					"name": "If a Monster Hunters Serpent Lord",
+					"reference": "FFRR16",
+					"reference_highlight": "Monster Hunters Serpent-Lords",
+					"template_picker": {
+						"type": "count"
+					},
+					"children": [
+						{
+							"id": "sHlwpVM6HR3dobTnw",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "svEm7OyeCu_9wJ8Kk"
+							},
+							"name": "Stealth",
+							"reference": "B222",
+							"tags": [
+								"Criminal",
+								"Police",
+								"Spy",
+								"Street"
+							],
+							"difficulty": "dx/a",
+							"encumbrance_penalty_multiplier": 1,
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -5
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 2
+						}
+					]
+				}
+			]
+		}
+	],
+	"notes": []
+}

--- a/Library/Fantasy Folk/The Reptilian Races/Serpent-Lord.gct
+++ b/Library/Fantasy Folk/The Reptilian Races/Serpent-Lord.gct
@@ -4055,188 +4055,230 @@
 			}
 		},
 		{
-			"id": "TeCqRFjKHfkc-QRk3",
-			"name": "Enhanced Human",
-			"reference": "FFRR15",
-			"reference_highlight": "a normal human but",
-			"disabled": true,
-			"ancestry": "Human",
-			"container_type": "ancestry",
+			"id": "T_oYdi7y700rBpVeV",
+			"name": "Pick the corresponding Enhanced Human form",
+			"local_notes": "Timeless Terror uses the same as the basic Serpent-Lord",
+			"template_picker": {
+				"type": "count",
+				"qualifier": {
+					"compare": "is",
+					"qualifier": 1
+				}
+			},
 			"children": [
 				{
-					"id": "ti1-tdOEerWmzVHUy",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Basic Set/Basic Set Traits.adq",
-						"id": "t1w1RFcFceKR2T9_e"
-					},
-					"name": "Increased Intelligence",
-					"reference": "B15",
-					"tags": [
-						"Advantage",
-						"Attribute",
-						"Mental"
-					],
-					"points_per_level": 20,
-					"features": [
+					"id": "TeCqRFjKHfkc-QRk3",
+					"name": "Serpent-Lord Enhanced Human form",
+					"reference": "FFRR15",
+					"reference_highlight": "a normal human but",
+					"disabled": true,
+					"ancestry": "Human",
+					"container_type": "ancestry",
+					"children": [
 						{
-							"type": "attribute_bonus",
-							"attribute": "iq",
-							"amount": 1,
-							"per_level": true
-						}
-					],
-					"can_level": true,
-					"levels": 3,
-					"calc": {
-						"points": 0,
-						"current_level": 0
-					}
-				},
-				{
-					"id": "tUL3CnJn_WdCU8MVb",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Basic Set/Basic Set Traits.adq",
-						"id": "tGjjVtxav9KsrG7Wx"
-					},
-					"name": "Combat Reflexes",
-					"reference": "B43",
-					"local_notes": "Never freeze",
-					"tags": [
-						"Advantage",
-						"Mental"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Enhanced Time Sense"
+							"id": "ti1-tdOEerWmzVHUy",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
+							"name": "Increased Intelligence",
+							"reference": "B15",
+							"tags": [
+								"Advantage",
+								"Attribute",
+								"Mental"
+							],
+							"points_per_level": 20,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "iq",
+									"amount": 1,
+									"per_level": true
 								}
+							],
+							"can_level": true,
+							"levels": 3,
+							"calc": {
+								"points": 0,
+								"current_level": 0
 							}
-						]
-					},
-					"base_points": 15,
-					"features": [
+						},
 						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "starts_with",
-								"qualifier": "fast-draw"
+							"id": "tUL3CnJn_WdCU8MVb",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGjjVtxav9KsrG7Wx"
 							},
-							"amount": 1
-						},
-						{
-							"type": "attribute_bonus",
-							"attribute": "dodge",
-							"amount": 1
-						},
-						{
-							"type": "attribute_bonus",
-							"attribute": "parry",
-							"amount": 1
-						},
-						{
-							"type": "attribute_bonus",
-							"attribute": "block",
-							"amount": 1
-						},
-						{
-							"type": "attribute_bonus",
-							"attribute": "fright_check",
-							"amount": 2
-						},
-						{
-							"type": "conditional_modifier",
-							"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
-							"amount": 6
-						},
-						{
-							"type": "conditional_modifier",
-							"situation": "to initiative rolls for your side (+2 if you are the leader)",
-							"amount": 1
-						}
-					],
-					"calc": {
-						"points": 0
-					}
-				},
-				{
-					"id": "tcU7ZQTXOi4NM71Go",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Basic Set/Basic Set Traits.adq",
-						"id": "tpnv8EEpAS6Er2pwK"
-					},
-					"name": "Magery",
-					"reference": "B66",
-					"tags": [
-						"Advantage",
-						"Mental",
-						"Supernatural"
-					],
-					"base_points": 5,
-					"points_per_level": 10,
-					"features": [
-						{
-							"type": "spell_bonus",
-							"match": "all_colleges",
-							"amount": 1,
-							"per_level": true
-						},
-						{
-							"type": "skill_bonus",
-							"selection_type": "skills_with_name",
-							"name": {
-								"compare": "is",
-								"qualifier": "thaumatology"
+							"name": "Combat Reflexes",
+							"reference": "B43",
+							"local_notes": "Never freeze",
+							"tags": [
+								"Advantage",
+								"Mental"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Enhanced Time Sense"
+										}
+									}
+								]
 							},
-							"amount": 1,
-							"per_level": true
-						}
-					],
-					"can_level": true,
-					"levels": 1,
-					"calc": {
-						"points": 0,
-						"current_level": 0
-					}
-				},
-				{
-					"id": "ta48vd91kGQS7l02E",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Basic Set/Basic Set Traits.adq",
-						"id": "ttHkLI9zwzfeOIEZc"
-					},
-					"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
-					"reference": "B140",
-					"tags": [
-						"Disadvantage",
-						"Mental"
-					],
-					"replacements": {
-						"Class, Ethnicity, Nationality, Religion, Sex, or Species": "General"
-					},
-					"modifiers": [
+							"base_points": 15,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "starts_with",
+										"qualifier": "fast-draw"
+									},
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "dodge",
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "parry",
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "block",
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "fright_check",
+									"amount": 2
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+									"amount": 6
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "to initiative rolls for your side (+2 if you are the leader)",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
 						{
-							"id": "mU6EnrODuNRNy2RND",
-							"name": "Scope: Anyone unlike you",
+							"id": "tcU7ZQTXOi4NM71Go",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tpnv8EEpAS6Er2pwK"
+							},
+							"name": "Magery",
+							"reference": "B66",
+							"tags": [
+								"Advantage",
+								"Mental",
+								"Supernatural"
+							],
+							"base_points": 5,
+							"points_per_level": 10,
+							"features": [
+								{
+									"type": "spell_bonus",
+									"match": "all_colleges",
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "thaumatology"
+									},
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 0,
+								"current_level": 0
+							}
+						},
+						{
+							"id": "ta48vd91kGQS7l02E",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "ttHkLI9zwzfeOIEZc"
+							},
+							"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
 							"reference": "B140",
-							"cost_adj": "-10"
-						}
-					],
-					"features": [
+							"tags": [
+								"Disadvantage",
+								"Mental"
+							],
+							"replacements": {
+								"Class, Ethnicity, Nationality, Religion, Sex, or Species": "General"
+							},
+							"modifiers": [
+								{
+									"id": "mU6EnrODuNRNy2RND",
+									"name": "Scope: Anyone unlike you",
+									"reference": "B140",
+									"cost_adj": "-10"
+								}
+							],
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+									"amount": -1
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
 						{
-							"type": "reaction_bonus",
-							"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
-							"amount": -1
+							"id": "t7b5kVnfTkrVyEzVQ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t5Qs23yaRu3D4T_hM"
+							},
+							"name": "Attentive",
+							"reference": "B163",
+							"tags": [
+								"Mental",
+								"Quirk"
+							],
+							"base_points": -1,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to skill rolls when working on lengthy tasks, but -3 to notice any important interruption",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 0
+							}
 						}
 					],
 					"calc": {
@@ -4244,24 +4286,984 @@
 					}
 				},
 				{
-					"id": "t7b5kVnfTkrVyEzVQ",
-					"source": {
-						"library": "richardwilkes/gcs_master_library",
-						"path": "Basic Set/Basic Set Traits.adq",
-						"id": "t5Qs23yaRu3D4T_hM"
-					},
-					"name": "Attentive",
-					"reference": "B163",
-					"tags": [
-						"Mental",
-						"Quirk"
-					],
-					"base_points": -1,
-					"features": [
+					"id": "TFcXuaNHBIuDFqAWR",
+					"name": "Lamia Enhanced Human form",
+					"reference": "FFRR15",
+					"reference_highlight": "a normal human but",
+					"disabled": true,
+					"ancestry": "Human",
+					"container_type": "ancestry",
+					"children": [
 						{
-							"type": "conditional_modifier",
-							"situation": "to skill rolls when working on lengthy tasks, but -3 to notice any important interruption",
-							"amount": 1
+							"id": "tiq_L4O6KpmUg_J0_",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
+							"name": "Increased Intelligence",
+							"reference": "B15",
+							"tags": [
+								"Advantage",
+								"Attribute",
+								"Mental"
+							],
+							"points_per_level": 20,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "iq",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 0,
+								"current_level": 0
+							}
+						},
+						{
+							"id": "thpea6nJoyUvNfsIz",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tpnv8EEpAS6Er2pwK"
+							},
+							"name": "Magery",
+							"reference": "B66",
+							"tags": [
+								"Advantage",
+								"Mental",
+								"Supernatural"
+							],
+							"base_points": 5,
+							"points_per_level": 10,
+							"features": [
+								{
+									"type": "spell_bonus",
+									"match": "all_colleges",
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "thaumatology"
+									},
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 0,
+								"current_level": 0
+							}
+						},
+						{
+							"id": "tYzQn_2vyPdPwgtev",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "ttHkLI9zwzfeOIEZc"
+							},
+							"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+							"reference": "B140",
+							"tags": [
+								"Disadvantage",
+								"Mental"
+							],
+							"replacements": {
+								"Class, Ethnicity, Nationality, Religion, Sex, or Species": "General"
+							},
+							"modifiers": [
+								{
+									"id": "mdNH-C-7BYUTmA84N",
+									"name": "Scope: Anyone unlike you",
+									"reference": "B140",
+									"cost_adj": "-10"
+								}
+							],
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+									"amount": -1
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "T-B-X6fdiExwlBazN",
+					"name": "Lesser Naga Enhanced Human form",
+					"reference": "FFRR15",
+					"reference_highlight": "a normal human but",
+					"disabled": true,
+					"ancestry": "Human",
+					"container_type": "ancestry",
+					"children": [
+						{
+							"id": "tqPUPb-pNfy9kgwmE",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
+							"name": "Increased Intelligence",
+							"reference": "B15",
+							"tags": [
+								"Advantage",
+								"Attribute",
+								"Mental"
+							],
+							"points_per_level": 20,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "iq",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 0,
+								"current_level": 0
+							}
+						},
+						{
+							"id": "tYWiIXIeP7nKLzwc8",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGjjVtxav9KsrG7Wx"
+							},
+							"name": "Combat Reflexes",
+							"reference": "B43",
+							"local_notes": "Never freeze",
+							"tags": [
+								"Advantage",
+								"Mental"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Enhanced Time Sense"
+										}
+									}
+								]
+							},
+							"base_points": 15,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "starts_with",
+										"qualifier": "fast-draw"
+									},
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "dodge",
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "parry",
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "block",
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "fright_check",
+									"amount": 2
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+									"amount": 6
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "to initiative rolls for your side (+2 if you are the leader)",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "t3ajgx5JaGL88rdaR",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tpnv8EEpAS6Er2pwK"
+							},
+							"name": "Magery",
+							"reference": "B66",
+							"tags": [
+								"Advantage",
+								"Mental",
+								"Supernatural"
+							],
+							"base_points": 5,
+							"points_per_level": 10,
+							"features": [
+								{
+									"type": "spell_bonus",
+									"match": "all_colleges",
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "thaumatology"
+									},
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 0,
+								"current_level": 0
+							}
+						},
+						{
+							"id": "tA9VcX_7OJNGmOzBP",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t5bwP6TnS4cX-zM8L"
+							},
+							"name": "Enemy (@Who@)",
+							"reference": "B135",
+							"tags": [
+								"Disadvantage",
+								"Social"
+							],
+							"replacements": {
+								"Who": "Emissaries of the Divine Bird Garuda"
+							},
+							"modifiers": [
+								{
+									"id": "MyrCiLyALzRDAwvAC",
+									"name": "Power",
+									"children": [
+										{
+											"id": "mIws2pFZcxU_xhZ0F",
+											"name": "Utterly Formidable Group",
+											"reference": "B135",
+											"cost_adj": "-40"
+										}
+									]
+								},
+								{
+									"id": "MPQ777SMTPUYVqKr1",
+									"name": "Intent",
+									"children": [
+										{
+											"id": "mwsElITV_M3Wt7Pr0",
+											"name": "Watcher",
+											"reference": "B135",
+											"cost_adj": "x0.25"
+										}
+									]
+								},
+								{
+									"id": "ML-mycBXUTpaqhhQV",
+									"name": "Frequency of Appearance",
+									"children": [
+										{
+											"id": "mO7_yHBgt2b7_VnKg",
+											"name": "Appears quite rarely",
+											"reference": "B36",
+											"local_notes": "6-",
+											"cost_adj": "x0.5"
+										}
+									]
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "tasSz2QKxNniktTfp",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "trPM4mpwMJnj-tqdg"
+							},
+							"name": "@Mental Quirk@",
+							"reference": "B162, PU6:17",
+							"reference_highlight": "Mental Quirks",
+							"tags": [
+								"Mental",
+								"Quirk"
+							],
+							"replacements": {
+								"Mental Quirk": "Fascinated by gold and jewels"
+							},
+							"base_points": -1,
+							"calc": {
+								"points": 0
+							}
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "TjLVy7VqQl7yQsOF_",
+					"name": "Serpent-Lord Enhanced Human form",
+					"reference": "FFRR15",
+					"reference_highlight": "a normal human but",
+					"disabled": true,
+					"ancestry": "Human",
+					"container_type": "ancestry",
+					"children": [
+						{
+							"id": "tWSD_8T63x6uLpQ5C",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
+							"name": "Increased Intelligence",
+							"reference": "B15",
+							"tags": [
+								"Advantage",
+								"Attribute",
+								"Mental"
+							],
+							"points_per_level": 20,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "iq",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 3,
+							"calc": {
+								"points": 0,
+								"current_level": 0
+							}
+						},
+						{
+							"id": "t2anK3dDZRONHU2Tf",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGjjVtxav9KsrG7Wx"
+							},
+							"name": "Combat Reflexes",
+							"reference": "B43",
+							"local_notes": "Never freeze",
+							"tags": [
+								"Advantage",
+								"Mental"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Enhanced Time Sense"
+										}
+									}
+								]
+							},
+							"base_points": 15,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "starts_with",
+										"qualifier": "fast-draw"
+									},
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "dodge",
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "parry",
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "block",
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "fright_check",
+									"amount": 2
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+									"amount": 6
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "to initiative rolls for your side (+2 if you are the leader)",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "t1XumEVpnS5PmTJHm",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Thaumatology/Thaumatology - RPM Traits.adq",
+								"id": "tbN9n6aAMMZoBiWQL"
+							},
+							"name": "Magery (Ritual Path)",
+							"reference": "TRPM5",
+							"tags": [
+								"Advantage",
+								"Mental",
+								"Supernatural"
+							],
+							"base_points": 5,
+							"points_per_level": 10,
+							"can_level": true,
+							"levels": 4,
+							"calc": {
+								"points": 0,
+								"current_level": 0
+							}
+						},
+						{
+							"id": "toLStKg8z4Pj4-_-i",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "ttHkLI9zwzfeOIEZc"
+							},
+							"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+							"reference": "B140",
+							"tags": [
+								"Disadvantage",
+								"Mental"
+							],
+							"replacements": {
+								"Class, Ethnicity, Nationality, Religion, Sex, or Species": "General"
+							},
+							"modifiers": [
+								{
+									"id": "mrSQnK-guiHOhwTsn",
+									"name": "Scope: Anyone unlike you",
+									"reference": "B140",
+									"cost_adj": "-10"
+								}
+							],
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+									"amount": -1
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "tpEXolesg_qewk6lt",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t5Qs23yaRu3D4T_hM"
+							},
+							"name": "Attentive",
+							"reference": "B163",
+							"tags": [
+								"Mental",
+								"Quirk"
+							],
+							"base_points": -1,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to skill rolls when working on lengthy tasks, but -3 to notice any important interruption",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						}
+					],
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "TPPRNRSiwFeENGZyK",
+					"name": "Psionic Serpent-Lord Enhanced Human form",
+					"reference": "FFRR15",
+					"reference_highlight": "a normal human but",
+					"disabled": true,
+					"ancestry": "Human",
+					"container_type": "ancestry",
+					"children": [
+						{
+							"id": "t6-WI4YBQliwVQIeo",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
+							"name": "Increased Intelligence",
+							"reference": "B15",
+							"tags": [
+								"Advantage",
+								"Attribute",
+								"Mental"
+							],
+							"points_per_level": 20,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "iq",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 3,
+							"calc": {
+								"points": 0,
+								"current_level": 0
+							}
+						},
+						{
+							"id": "tHkosJDQb5-GFdWSj",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGjjVtxav9KsrG7Wx"
+							},
+							"name": "Combat Reflexes",
+							"reference": "B43",
+							"local_notes": "Never freeze",
+							"tags": [
+								"Advantage",
+								"Mental"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Enhanced Time Sense"
+										}
+									}
+								]
+							},
+							"base_points": 15,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "starts_with",
+										"qualifier": "fast-draw"
+									},
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "dodge",
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "parry",
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "block",
+									"amount": 1
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "fright_check",
+									"amount": 2
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "on all IQ rolls to wake up or to recover from surprise or mental stun",
+									"amount": 6
+								},
+								{
+									"type": "conditional_modifier",
+									"situation": "to initiative rolls for your side (+2 if you are the leader)",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "tKBvKo9Had-hLlxRT",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Psionics/Psionics Traits.adq",
+								"id": "tBAEUyE1yVLSN9wnz"
+							},
+							"name": "Telepathy Talent",
+							"reference": "PSI19",
+							"tags": [
+								"Communication",
+								"Control",
+								"Mental",
+								"Offense",
+								"Power",
+								"Sense and Defense",
+								"Telepathy"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Offense Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Control Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Sense and Defense Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Communication Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
+							},
+							"points_per_level": 5,
+							"features": [
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"tags": {
+										"compare": "is",
+										"qualifier": "PsionicSkill:Telepathy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Crippling Blow"
+									},
+									"specialization": {
+										"compare": "contains",
+										"qualifier": "Telepathy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Deafening Display"
+									},
+									"specialization": {
+										"compare": "contains",
+										"qualifier": "Telepathy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Drugged Weapon"
+									},
+									"specialization": {
+										"compare": "contains",
+										"qualifier": "Telepathy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Fatiguing Strike"
+									},
+									"specialization": {
+										"compare": "contains",
+										"qualifier": "Telepathy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Project Blow"
+									},
+									"specialization": {
+										"compare": "contains",
+										"qualifier": "Telepathy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Restorative Armor"
+									},
+									"specialization": {
+										"compare": "contains",
+										"qualifier": "Telepathy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Stealthy Attack"
+									},
+									"specialization": {
+										"compare": "contains",
+										"qualifier": "Telepathy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Stupefying Blow"
+									},
+									"specialization": {
+										"compare": "contains",
+										"qualifier": "Telepathy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Subtle Defense"
+									},
+									"specialization": {
+										"compare": "contains",
+										"qualifier": "Telepathy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Sudden Death"
+									},
+									"specialization": {
+										"compare": "contains",
+										"qualifier": "Telepathy"
+									},
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "skill_bonus",
+									"selection_type": "skills_with_name",
+									"name": {
+										"compare": "is",
+										"qualifier": "Thunderous Defense"
+									},
+									"specialization": {
+										"compare": "contains",
+										"qualifier": "Telepathy"
+									},
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 3,
+							"calc": {
+								"points": 0,
+								"current_level": 0
+							}
+						},
+						{
+							"id": "t4WkFmrgTiVw_Eam-",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "ttHkLI9zwzfeOIEZc"
+							},
+							"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
+							"reference": "B140",
+							"tags": [
+								"Disadvantage",
+								"Mental"
+							],
+							"replacements": {
+								"Class, Ethnicity, Nationality, Religion, Sex, or Species": "General"
+							},
+							"modifiers": [
+								{
+									"id": "mze9s4zvGhyrmWZU9",
+									"name": "Scope: Anyone unlike you",
+									"reference": "B140",
+									"cost_adj": "-10"
+								}
+							],
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "from victims of your intolerance (may be as much as -5, at GM's discretion)",
+									"amount": -1
+								}
+							],
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "tqn5bQTbJ2e1EbaDd",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t5Qs23yaRu3D4T_hM"
+							},
+							"name": "Attentive",
+							"reference": "B163",
+							"tags": [
+								"Mental",
+								"Quirk"
+							],
+							"base_points": -1,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to skill rolls when working on lengthy tasks, but -3 to notice any important interruption",
+									"amount": 1
+								}
+							],
+							"calc": {
+								"points": 0
+							}
 						}
 					],
 					"calc": {


### PR DESCRIPTION
This adds the racial templates from Fantasy Folk: The Reptilian Races.

Because this includes extensions to racial templates that were previously described in Banestorm, Dragons, or Dungeon Fantasy, I have created/updated the templates in their original place, and included a README.md for the Reptilian Races folder that includes markdown links to those templates.