### PR TITLE
Baset Set Trait Modifiers: hide/shorten their notes where possible

### DIFF
--- a/Library/Basic Set/Basic Set Enhancement Modifiers.adm
+++ b/Library/Basic Set/Basic Set Enhancement Modifiers.adm
@@ -298,8 +298,21 @@
 			"id": "mVP0kyIRXqPj6Gt7X",
 			"name": "Accurate",
 			"reference": "B102,P99",
-			"local_notes": "+1/level to Accuracy",
 			"cost_adj": "5%",
+			"features": [
+				{
+					"type": "weapon_acc_bonus",
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 1,
+					"leveled": true
+				}
+			],
 			"levels": 1
 		},
 		{

--- a/Library/Basic Set/Basic Set Enhancement Modifiers.adm
+++ b/Library/Basic Set/Basic Set Enhancement Modifiers.adm
@@ -768,9 +768,12 @@
 			"id": "msnycFZUVspQ77fd7",
 			"name": "Side Effect (@Side Effect Affliction@)",
 			"reference": "B109,P106",
-			"local_notes": "Set level to 50, plus 1 per percentage point of Affliction enhancements included (Stunning is the default, at +0%)",
+			"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"Set level to 50, plus 1 per percentage point of Affliction enhancements included (Stunning is the default, at +0%)\"\u003c/script\u003e",
 			"cost_adj": "1%",
-			"levels": 50
+			"levels": 50,
+			"calc": {
+				"resolved_notes": "Set level to 50, plus 1 per percentage point of Affliction enhancements included (Stunning is the default, at +0%)"
+			}
 		},
 		{
 			"id": "mzUmNTI_isgbeOkEY",

--- a/Library/Basic Set/Basic Set Enhancement Modifiers.adm
+++ b/Library/Basic Set/Basic Set Enhancement Modifiers.adm
@@ -494,9 +494,12 @@
 			"id": "mcXN1MCeZnZB4Jz2e",
 			"name": "Follow-Up (@Carrier Attack@)",
 			"reference": "B105,P102",
-			"local_notes": "1 point per level",
+			"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"1 point per level\"\u003c/script\u003e",
 			"cost_adj": "1%",
-			"levels": 1
+			"levels": 1,
+			"calc": {
+				"resolved_notes": "1 point per level"
+			}
 		},
 		{
 			"id": "m1nJdcOiKLxg7pXwe",

--- a/Library/Basic Set/Basic Set Enhancement Modifiers.adm
+++ b/Library/Basic Set/Basic Set Enhancement Modifiers.adm
@@ -785,8 +785,11 @@
 			"id": "md0iavn_lCSnS1Xkf",
 			"name": "Symptoms (@HP Threshold and Effect@)",
 			"reference": "B109",
-			"local_notes": "1 point per level",
-			"cost_adj": "1%"
+			"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"1 point per level\"\u003c/script\u003e",
+			"cost_adj": "1%",
+			"calc": {
+				"resolved_notes": "1 point per level"
+			}
 		},
 		{
 			"id": "mdFYMCDPzqbAuFeAd",

--- a/Library/Basic Set/Basic Set Enhancement Modifiers.adm
+++ b/Library/Basic Set/Basic Set Enhancement Modifiers.adm
@@ -331,9 +331,12 @@
 			"id": "mbO8GjGu_NuPTLz6e",
 			"name": "Area Effect",
 			"reference": "B102,P100",
-			"local_notes": "2^level radius",
+			"local_notes": "\u003cscript\u003eself.attachedTo ? `${2**self.level} yd` : \"2^level\"\u003c/script\u003e radius",
 			"cost_adj": "50%",
-			"levels": 1
+			"levels": 1,
+			"calc": {
+				"resolved_notes": "2^level radius"
+			}
 		},
 		{
 			"id": "mA3P30XALk8RFhXPu",

--- a/Library/Basic Set/Basic Set Limitation Modifiers.adm
+++ b/Library/Basic Set/Basic Set Limitation Modifiers.adm
@@ -5,8 +5,11 @@
 			"id": "m2IwCpU9KwYmjiSSA",
 			"name": "Accessibility (@Condition@)",
 			"reference": "B110,P99",
-			"local_notes": "1 point per level",
-			"cost_adj": "-1%"
+			"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"1 point per level\"\u003c/script\u003e",
+			"cost_adj": "-1%",
+			"calc": {
+				"resolved_notes": "1 point per level"
+			}
 		},
 		{
 			"id": "mjuUqIZoOHqvugUN1",

--- a/Library/Basic Set/Basic Set Limitation Modifiers.adm
+++ b/Library/Basic Set/Basic Set Limitation Modifiers.adm
@@ -176,9 +176,12 @@
 			"id": "mHGpYfPpTxJ8KT7J_",
 			"name": "Follow-Up (@Carrier Attack@)",
 			"reference": "B105,P102",
-			"local_notes": "-1 point per level",
+			"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"-1 point per level\"\u003c/script\u003e",
 			"cost_adj": "-1%",
-			"levels": 1
+			"levels": 1,
+			"calc": {
+				"resolved_notes": "-1 point per level"
+			}
 		},
 		{
 			"id": "mi0GLwUMSp46WDrSF",

--- a/Library/Basic Set/Basic Set Limitation Modifiers.adm
+++ b/Library/Basic Set/Basic Set Limitation Modifiers.adm
@@ -740,9 +740,12 @@
 			"id": "m-F3ACfcl680ioFta",
 			"name": "Resistible",
 			"reference": "B115,P105",
-			"local_notes": "HT + (level - 6) to resist",
+			"local_notes": "HT\u003cscript\u003eself.attachedTo ? signedValue(self.level-6) : \" + (level - 6)\"\u003c/script\u003e to resist",
 			"cost_adj": "-5%",
-			"levels": 1
+			"levels": 1,
+			"calc": {
+				"resolved_notes": "HT + (level - 6) to resist"
+			}
 		},
 		{
 			"id": "mwOn3HOcXabGaSQBP",

--- a/Library/Basic Set/Basic Set Limitation Modifiers.adm
+++ b/Library/Basic Set/Basic Set Limitation Modifiers.adm
@@ -786,8 +786,11 @@
 			"id": "mdoMyuuoZBbQiTi3L",
 			"name": "Temporary Disadvantage (@Temporary Disadvantage@)",
 			"reference": "B115,P106",
-			"local_notes": "1 point per level",
-			"cost_adj": "-1%"
+			"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"1 point per level\"\u003c/script\u003e",
+			"cost_adj": "-1%",
+			"calc": {
+				"resolved_notes": "1 point per level"
+			}
 		},
 		{
 			"id": "mQjsgnm-42rgt94Au",

--- a/Library/Basic Set/Basic Set Limitation Modifiers.adm
+++ b/Library/Basic Set/Basic Set Limitation Modifiers.adm
@@ -360,8 +360,21 @@
 			"id": "mCQQumJbdkZnaPoNN",
 			"name": "Inaccurate",
 			"reference": "B112",
-			"local_notes": "-1/level to Accuracy",
 			"cost_adj": "-5%",
+			"features": [
+				{
+					"type": "weapon_acc_bonus",
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": -1,
+					"leveled": true
+				}
+			],
 			"levels": 1
 		},
 		{

--- a/Library/Basic Set/Basic Set Limitation Modifiers.adm
+++ b/Library/Basic Set/Basic Set Limitation Modifiers.adm
@@ -155,8 +155,21 @@
 			"id": "mQZe8ac78QJj3FsEo",
 			"name": "Extra Recoil",
 			"reference": "B112,P102",
-			"local_notes": "+1/level to Recoil",
 			"cost_adj": "-10%",
+			"features": [
+				{
+					"type": "weapon_recoil_bonus",
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 1,
+					"leveled": true
+				}
+			],
 			"levels": 1
 		},
 		{


### PR DESCRIPTION
A problem I have observed with using trait modifiers is that the space in a trait's notes is relatively precious - complex traits have a lot of modifiers to list in the trait's notes, and adding trait modifier notes too all adds up.

e.g. you could end up with a trait like "Enhanced Move 1" with the description "Accessibility (native gravity only) (1 point per level) 20; Temporary Disadvantage (Electrical) (1 point per level) 20".

The "1 point per level" note is there in the trait library to explain what to use its level for, but is completely redundant once it's added to the trait.

One solution is to modify the trait modifier and clear source library data from it, but I think it would be preferrable to keep its source library data.

This Pull Request goes through Basic Set Enhancement Modifiers and Basic Set Limitation Modifiers, looking for modifiers which have notes that could be easily made shorter by either:
* Replacing the notes with the equivalent feature.
* Replacing a formula with calculating the value of the formula when the modifier is added to a trait.
* Hide explanatory notes when the modifier is added to a trait.