### PR TITLE
Basic Set Skills: Allow Mental Strength's prerequisites to be satisfied with more things

### DIFF
--- a/Library/Basic Set/Basic Set Skills.skl
+++ b/Library/Basic Set/Basic Set Skills.skl
@@ -13638,6 +13638,34 @@
 					{
 						"type": "trait_prereq",
 						"has": true,
+						"notes": {
+							"compare": "contains",
+							"qualifier": "Permits Mental Strength"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Unusual Background (Psionic)"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "Magery"
+						},
+						"level": {
+							"compare": "at_least",
+							"qualifier": 1
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": true,
 						"name": {
 							"compare": "starts_with",
 							"qualifier": "weapon master"

--- a/Library/Horror/Classes/Mystic Practitioner.gct
+++ b/Library/Horror/Classes/Mystic Practitioner.gct
@@ -6,6 +6,7 @@
 			"id": "TNHzzoymZE8k1pKNI",
 			"name": "Mystic (Practitioner)",
 			"reference": "H39",
+			"local_notes": "Permits Mental Strength",
 			"children": [
 				{
 					"id": "T3NFaLP6nBQ_mYVjD",
@@ -4107,7 +4108,12 @@
 									"points": 1
 								},
 								{
-									"id": "sMJz-MujoRSZ21gY-",
+									"id": "sEoXrHcxIUnQ-S46-",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sxDgiqntG5jIWBGld"
+									},
 									"name": "Mental Strength",
 									"reference": "B209",
 									"tags": [
@@ -4118,6 +4124,34 @@
 										"type": "prereq_list",
 										"all": false,
 										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"notes": {
+													"compare": "contains",
+													"qualifier": "Permits Mental Strength"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
 											{
 												"type": "trait_prereq",
 												"has": true,

--- a/Library/Horror/Classes/Priest.gct
+++ b/Library/Horror/Classes/Priest.gct
@@ -6,6 +6,7 @@
 			"id": "TsA7cCKwjx_5X8Iv_",
 			"name": "Priest",
 			"reference": "H41",
+			"local_notes": "Permits Mental Strength",
 			"children": [
 				{
 					"id": "TSl-m6k37QtE9i5Dd",
@@ -2262,7 +2263,12 @@
 									"points": 2
 								},
 								{
-									"id": "sWTTSDFQnGxI2527E",
+									"id": "sVJmPRjqKS429F7Jl",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sxDgiqntG5jIWBGld"
+									},
 									"name": "Mental Strength",
 									"reference": "B209",
 									"tags": [
@@ -2273,6 +2279,34 @@
 										"type": "prereq_list",
 										"all": false,
 										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"notes": {
+													"compare": "contains",
+													"qualifier": "Permits Mental Strength"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
 											{
 												"type": "trait_prereq",
 												"has": true,


### PR DESCRIPTION
This includes Magery 1 and Unusual Background (Psionic) as Mental Strength mentions that GMs may permit mages or psi to learn this.

It also includes any trait that says "Permits Mental Strength" in its description, intended to allow flexibility for permitting it on a case-by-case basis. e.g. a template adds this may have the trait container for that template mention "Permits Mental Strength" as sufficient justification for taking that skill.

This Pull Request also includes a commit to fix the templates from GURPS Horror to permit Mental Strength, as access to that skill is provided even when they lack magery or psionic abilities.