### PR TITLE
Fix uncongenial

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -28323,7 +28323,7 @@
 		{
 			"id": "tVKcKQGhh9NHMQOvi",
 			"name": "Uncongenial",
-			"reference": "B164",
+			"reference": "B165",
 			"tags": [
 				"Mental",
 				"Quirk"

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -28323,10 +28323,11 @@
 		{
 			"id": "tVKcKQGhh9NHMQOvi",
 			"name": "Uncongenial",
-			"reference": "B165",
+			"reference": "B165, PU6:20",
 			"tags": [
 				"Mental",
-				"Quirk"
+				"Quirk",
+				"Social"
 			],
 			"base_points": -1,
 			"calc": {

--- a/Library/Basic Set/Characters/Sora.gcs
+++ b/Library/Basic Set/Characters/Sora.gcs
@@ -1604,12 +1604,18 @@
 			}
 		},
 		{
-			"id": "thUSvD7IpE2j9Iiza",
-			"name": "Quirk: Uncongenial",
-			"reference": "B164",
+			"id": "tpXJ-bZ3E1XfbIvwS",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "tVKcKQGhh9NHMQOvi"
+			},
+			"name": "Uncongenial",
+			"reference": "B165, PU6:20",
 			"tags": [
 				"Mental",
-				"Quirk"
+				"Quirk",
+				"Social"
 			],
 			"base_points": -1,
 			"calc": {
@@ -3081,7 +3087,7 @@
 		}
 	],
 	"created_date": "2023-01-15T21:53:59Z",
-	"modified_date": "2025-06-02T16:07:43-07:00",
+	"modified_date": "2026-06-25T18:00:32+01:00",
 	"calc": {
 		"swing": "1d+2",
 		"thrust": "1d-1",

--- a/Library/Fantasy/Races/Trolls.gct
+++ b/Library/Fantasy/Races/Trolls.gct
@@ -1013,10 +1013,18 @@
 							}
 						},
 						{
-							"id": "twKGWZ5JSNPpdCEyL",
+							"id": "twzfM4R1Uh3HzSyNC",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVKcKQGhh9NHMQOvi"
+							},
 							"name": "Uncongenial",
+							"reference": "B165, PU6:20",
 							"tags": [
-								"Physical"
+								"Mental",
+								"Quirk",
+								"Social"
 							],
 							"base_points": -1,
 							"calc": {
@@ -2065,10 +2073,18 @@
 							}
 						},
 						{
-							"id": "tMv0gvvO5bTQsoBqQ",
+							"id": "tZ1xJb2HxTevXv-W2",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVKcKQGhh9NHMQOvi"
+							},
 							"name": "Uncongenial",
+							"reference": "B165, PU6:20",
 							"tags": [
-								"Physical"
+								"Mental",
+								"Quirk",
+								"Social"
 							],
 							"base_points": -1,
 							"calc": {

--- a/Library/Historical Folks/Alchemist.gct
+++ b/Library/Historical Folks/Alchemist.gct
@@ -1352,12 +1352,18 @@
 									}
 								},
 								{
-									"id": "tPV7iF0OUH1_xWgvI",
+									"id": "tFuqZ2WhSV5yax-Kv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tVKcKQGhh9NHMQOvi"
+									},
 									"name": "Uncongenial",
-									"reference": "B164",
+									"reference": "B165, PU6:20",
 									"tags": [
 										"Mental",
-										"Quirk"
+										"Quirk",
+										"Social"
 									],
 									"base_points": -1,
 									"calc": {

--- a/Library/Historical Folks/Animal Handler.gct
+++ b/Library/Historical Folks/Animal Handler.gct
@@ -1581,12 +1581,18 @@
 									}
 								},
 								{
-									"id": "t-284MxbwWUF0G9Na",
+									"id": "tgl1A98v-taINBYN5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tVKcKQGhh9NHMQOvi"
+									},
 									"name": "Uncongenial",
-									"reference": "B164",
+									"reference": "B165, PU6:20",
 									"tags": [
 										"Mental",
-										"Quirk"
+										"Quirk",
+										"Social"
 									],
 									"base_points": -1,
 									"calc": {

--- a/Library/Historical Folks/Woodcutter.gct
+++ b/Library/Historical Folks/Woodcutter.gct
@@ -1274,12 +1274,18 @@
 									}
 								},
 								{
-									"id": "tYwmltDqMu7-7BhSW",
+									"id": "tIMn8kdXlzUT69N2g",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tVKcKQGhh9NHMQOvi"
+									},
 									"name": "Uncongenial",
-									"reference": "B164",
+									"reference": "B165, PU6:20",
 									"tags": [
 										"Mental",
-										"Quirk"
+										"Quirk",
+										"Social"
 									],
 									"base_points": -1,
 									"calc": {

--- a/Library/Power Ups/Power Ups Traits.adq
+++ b/Library/Power Ups/Power Ups Traits.adq
@@ -203,8 +203,13 @@
 		},
 		{
 			"id": "t4DZmBMUA719o06FH",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "tVKcKQGhh9NHMQOvi"
+			},
 			"name": "Uncongenial",
-			"reference": "PU6:20",
+			"reference": "B165, PU6:20",
 			"tags": [
 				"Mental",
 				"Quirk",

--- a/Library/Supers/Templates/Phantom.gct
+++ b/Library/Supers/Templates/Phantom.gct
@@ -2011,12 +2011,18 @@
 					}
 				},
 				{
-					"id": "tUNGue92vXMdHAhyg",
+					"id": "tkZlL9TvmlyDcos2D",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVKcKQGhh9NHMQOvi"
+					},
 					"name": "Uncongenial",
-					"reference": "B164",
+					"reference": "B165, PU6:20",
 					"tags": [
 						"Mental",
-						"Quirk"
+						"Quirk",
+						"Social"
 					],
 					"base_points": -1,
 					"calc": {

--- a/Library/Thaumatology/Wang Laowu.gcs
+++ b/Library/Thaumatology/Wang Laowu.gcs
@@ -2343,12 +2343,18 @@
 					}
 				},
 				{
-					"id": "tJhMjEj1qW-bbRVb-",
+					"id": "tpERgrvAVFqT4SloK",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tVKcKQGhh9NHMQOvi"
+					},
 					"name": "Uncongenial",
-					"reference": "B164",
+					"reference": "B165, PU6:20",
 					"tags": [
 						"Mental",
-						"Quirk"
+						"Quirk",
+						"Social"
 					],
 					"base_points": -1,
 					"calc": {
@@ -3288,7 +3294,7 @@
 		}
 	],
 	"created_date": "2023-02-11T20:43:59Z",
-	"modified_date": "2023-02-12T08:08:49Z",
+	"modified_date": "2026-06-25T18:00:48+01:00",
 	"calc": {
 		"swing": "1d-1",
 		"thrust": "1d-2",

--- a/Library/Traveller/Races/Ael Yael.gct
+++ b/Library/Traveller/Races/Ael Yael.gct
@@ -583,12 +583,18 @@
 							}
 						},
 						{
-							"id": "tpwAYdamXdtsZcHgA",
+							"id": "tfvN3d9PqURsrb0bP",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVKcKQGhh9NHMQOvi"
+							},
 							"name": "Uncongenial",
-							"reference": "B164",
+							"reference": "B165, PU6:20",
 							"tags": [
 								"Mental",
-								"Quirk"
+								"Quirk",
+								"Social"
 							],
 							"base_points": -1,
 							"calc": {


### PR DESCRIPTION
As mentioned in the gcs discord by El Dourado, Uncongenial's page reference is incorrect.

This does three things:
* Change the page reference for Basic Set Traits' Uncongenial trait to the correct one.
* Merge Basic Set Traits and Power Ups Traits' Uncongenial together by adding all the tags and page references from Power Ups' trait to Basic Set's, and then add a source library reference from Power Ups Traits' trait to Basic Set's trait.
  This means that only the Basic Set trait needs to be changed in future for changes to be picked up by source library sync.
* Go through all the sheets and templates in the master library and make sure they use the fixed Uncongenial trait.