### PR TITLE
Make Wealth and Status consistent in all the different trait lists

### DIFF
--- a/Library/Action/Action Traits.adq
+++ b/Library/Action/Action Traits.adq
@@ -5901,80 +5901,411 @@
 					}
 				},
 				{
-					"id": "tpKVMwb0FieOnxG4D",
+					"id": "TX7EJFWsWt9upI1y6",
 					"name": "Wealth",
-					"reference": "B25",
-					"tags": [
-						"Advantage",
-						"Disadvantage",
-						"Social"
-					],
-					"modifiers": [
+					"children": [
 						{
-							"id": "mAYHZEqhuM3xIlAhL",
-							"name": "Dead Broke",
-							"reference": "B25",
-							"local_notes": "Starting wealth is $0",
-							"cost_adj": "-25",
-							"disabled": true
+							"id": "tzxYEpVobXKa3akGN",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tNs3r-xh05OnHz3pI"
+							},
+							"name": "Average Wealth",
+							"reference": "B25, L8, DFA54, DW33",
+							"reference_highlight": "Average",
+							"local_notes": "Starting wealth is normal",
+							"tags": [
+								"Advantage",
+								"Social",
+								"Wealth"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Comfortable Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Dead Broke"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Poor"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Struggling"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Very Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Filthy Rich"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Multimillionaire"
+										}
+									}
+								]
+							},
+							"calc": {
+								"points": 0
+							}
 						},
 						{
-							"id": "mb-mrgFZvf21RtXJP",
-							"name": "Poor",
-							"reference": "B25",
-							"local_notes": "Starting wealth is 1/5 average",
-							"cost_adj": "-15",
-							"disabled": true
+							"id": "tGFtsnI1kdv-7I4x0",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tdEOEbc8ltxyQNFJj"
+							},
+							"name": "Comfortable Wealth",
+							"reference": "B25, L8, DFA54, DW33",
+							"reference_highlight": "Comfortable",
+							"local_notes": "Starting wealth is twice normal",
+							"tags": [
+								"Advantage",
+								"Social",
+								"Wealth"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Average Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Dead Broke"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Poor"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Struggling"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Very Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Filthy Rich"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Multimillionaire"
+										}
+									}
+								]
+							},
+							"base_points": 10,
+							"calc": {
+								"points": 10
+							}
 						},
 						{
-							"id": "mL6kKC3ewGgDZqNMg",
-							"name": "Struggling",
-							"reference": "B25",
-							"local_notes": "Starting wealth is 1/2 average",
-							"cost_adj": "-10",
-							"disabled": true
-						},
-						{
-							"id": "mlCNBWDQwIkbu9BZW",
-							"name": "Average",
-							"reference": "B25",
-							"disabled": true
-						},
-						{
-							"id": "mxTdVn8D5QjzKawpM",
-							"name": "Comfortable",
-							"reference": "B25",
-							"local_notes": "Starting wealth is 2x average",
-							"cost_adj": "10",
-							"disabled": true
-						},
-						{
-							"id": "maKKtXhM52EYPyuJ0",
+							"id": "t2_Xp0rlVhFql4xyu",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t55UZnC4Hxsvl7-ri"
+							},
 							"name": "Wealthy",
-							"reference": "B25",
-							"local_notes": "Starting wealth is 5x average",
-							"cost_adj": "20",
-							"disabled": true
+							"reference": "B25, L8, DFA54, DW33",
+							"local_notes": "Starting wealth is 5x normal",
+							"tags": [
+								"Advantage",
+								"Social",
+								"Wealth"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Average Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Dead Broke"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Poor"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Struggling"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Comfortable Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Very Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Filthy Rich"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Multimillionaire"
+										}
+									}
+								]
+							},
+							"modifiers": [
+								{
+									"id": "mckp1-FTfYLnkB9_q",
+									"name": "Wealth grants Status",
+									"reference": "B26",
+									"reference_highlight": "Wealth and Status",
+									"features": [
+										{
+											"type": "trait_bonus",
+											"name": {
+												"compare": "is",
+												"qualifier": "Status"
+											},
+											"amount": 1
+										}
+									],
+									"disabled": true
+								}
+							],
+							"base_points": 20,
+							"calc": {
+								"points": 20
+							}
 						},
 						{
-							"id": "meVcjof4y9RE8UAG2",
+							"id": "t1idacPjiKd6xvIDy",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tgNjs3lrycmChMxRC"
+							},
 							"name": "Very Wealthy",
-							"reference": "B25",
-							"local_notes": "Starting wealth is 20x average",
-							"cost_adj": "30",
-							"disabled": true
-						},
-						{
-							"id": "muPG7qVaCZXwZsiP-",
-							"name": "Filthy Rich",
-							"reference": "B25",
-							"local_notes": "Starting wealth is 100x average",
-							"cost_adj": "50",
-							"disabled": true
+							"reference": "B25, L8, DFA54, DW33",
+							"local_notes": "Starting wealth is 20x normal",
+							"tags": [
+								"Advantage",
+								"Social",
+								"Wealth"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Average Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Dead Broke"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Poor"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Struggling"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Comfortable Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Filthy Rich"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Multimillionaire"
+										}
+									}
+								]
+							},
+							"modifiers": [
+								{
+									"id": "mrQ3S6A7aoB4AOm8v",
+									"name": "Wealth grants Status",
+									"reference": "B26",
+									"reference_highlight": "Wealth and Status",
+									"features": [
+										{
+											"type": "trait_bonus",
+											"name": {
+												"compare": "is",
+												"qualifier": "Status"
+											},
+											"amount": 1
+										}
+									],
+									"disabled": true
+								}
+							],
+							"base_points": 30,
+							"calc": {
+								"points": 30
+							}
 						}
 					],
 					"calc": {
-						"points": 0
+						"points": 60
 					}
 				},
 				{
@@ -6047,7 +6378,7 @@
 				}
 			],
 			"calc": {
-				"points": 662
+				"points": 722
 			}
 		},
 		{

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -8855,6 +8855,25 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "mxxXX0DiOkPBXV89H",
+					"name": "Wealth grants Status",
+					"reference": "B26",
+					"reference_highlight": "Wealth and Status",
+					"features": [
+						{
+							"type": "trait_bonus",
+							"name": {
+								"compare": "is",
+								"qualifier": "Status"
+							},
+							"amount": 1
+						}
+					],
+					"disabled": true
+				}
+			],
 			"base_points": 50,
 			"calc": {
 				"points": 50
@@ -18147,6 +18166,10 @@
 				"all": true,
 				"prereqs": [
 					{
+						"type": "script_prereq",
+						"script": "const statusModifier = self.findActiveModifier(\"Wealth grants Status\");\nif (statusModifier \u0026\u0026 statusModifier.level == 2 \u0026\u0026 self.level != 1) {\n  \"Wealth grants Status 2 must be used with Multimillionaire 1\"\n} else if (statusModifier \u0026\u0026 statusModifier.level == 3 \u0026\u0026 self.level == 1) {\n  \"Wealth grants Status 3 must be used with Multimillionaire 2+\"\n} else if (self.level == 0) {\n  \"Multimillionaire should not be level 0\"\n} else { \n  \"\"\n}"
+					},
+					{
 						"type": "trait_prereq",
 						"has": false,
 						"name": {
@@ -18212,6 +18235,56 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "MDbXjHSLTEvlrARdu",
+					"name": "Multimillionaire 1 only",
+					"children": [
+						{
+							"id": "mdJkLsMNq2c-yG7ls",
+							"name": "Wealth grants Status",
+							"reference": "B26",
+							"reference_highlight": "Wealth and Status",
+							"features": [
+								{
+									"type": "trait_bonus",
+									"name": {
+										"compare": "is",
+										"qualifier": "Status"
+									},
+									"amount": 2
+								}
+							],
+							"levels": 2,
+							"disabled": true
+						}
+					]
+				},
+				{
+					"id": "MSOGTpGSxmAFTvtm2",
+					"name": "Multimillionaire 2+",
+					"children": [
+						{
+							"id": "mnL5Zw8FlrpWv1wdY",
+							"name": "Wealth grants Status",
+							"reference": "B26",
+							"reference_highlight": "Wealth and Status",
+							"features": [
+								{
+									"type": "trait_bonus",
+									"name": {
+										"compare": "is",
+										"qualifier": "Status"
+									},
+									"amount": 3
+								}
+							],
+							"levels": 3,
+							"disabled": true
+						}
+					]
+				}
+			],
 			"base_points": 50,
 			"points_per_level": 25,
 			"can_level": true,
@@ -29079,6 +29152,25 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "m3GIvK8sm3D6wM63W",
+					"name": "Wealth grants Status",
+					"reference": "B26",
+					"reference_highlight": "Wealth and Status",
+					"features": [
+						{
+							"type": "trait_bonus",
+							"name": {
+								"compare": "is",
+								"qualifier": "Status"
+							},
+							"amount": 1
+						}
+					],
+					"disabled": true
+				}
+			],
 			"base_points": 30,
 			"calc": {
 				"points": 30
@@ -29979,6 +30071,25 @@
 					}
 				]
 			},
+			"modifiers": [
+				{
+					"id": "m83yyP9vajaeUHLAH",
+					"name": "Wealth grants Status",
+					"reference": "B26",
+					"reference_highlight": "Wealth and Status",
+					"features": [
+						{
+							"type": "trait_bonus",
+							"name": {
+								"compare": "is",
+								"qualifier": "Status"
+							},
+							"amount": 1
+						}
+					],
+					"disabled": true
+				}
+			],
 			"base_points": 20,
 			"calc": {
 				"points": 20

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -18155,7 +18155,7 @@
 			"id": "tc2Bw-0JpkS5K2zxY",
 			"name": "Multimillionaire",
 			"reference": "B25",
-			"local_notes": "Starting wealth is \u003cscript\u003eformatNum(100 * Math.pow(10, self.level), true, false)\u003c/script\u003ex normal",
+			"local_notes": "Starting wealth is \u003cscript\u003e\n// Partial Multimillionaire Levels (SS2:26) allows Multimillionaire level to be any multiple of 0.2.\nlet whole = Math.trunc(self.level), partial = Math.round((self.level - whole)* 10) || 1;\nformatNum(10 ** ( whole + 2) * partial, true, false)\n\u003c/script\u003ex normal",
 			"tags": [
 				"Advantage",
 				"Social",
@@ -18167,7 +18167,7 @@
 				"prereqs": [
 					{
 						"type": "script_prereq",
-						"script": "const statusModifier = self.findActiveModifier(\"Wealth grants Status\");\nif (statusModifier \u0026\u0026 statusModifier.level == 2 \u0026\u0026 self.level != 1) {\n  \"Wealth grants Status 2 must be used with Multimillionaire 1\"\n} else if (statusModifier \u0026\u0026 statusModifier.level == 3 \u0026\u0026 self.level == 1) {\n  \"Wealth grants Status 3 must be used with Multimillionaire 2+\"\n} else if (self.level == 0) {\n  \"Multimillionaire should not be level 0\"\n} else { \n  \"\"\n}"
+						"script": "const statusModifier = self.findActiveModifier(\"Wealth grants Status\");\nif (statusModifier \u0026\u0026 statusModifier.level == 2 \u0026\u0026 (self.level \u003c 1 || self.level \u003e= 2)) {\n  \"Multimillionaire level must be at least 1 and less than 2 for Wealth grants Status 2\"\n} else if (statusModifier \u0026\u0026 statusModifier.level == 3 \u0026\u0026 self.level \u003c 2) {\n  \"Multimillionaire level must be at least 2 for Wealth grants Status 3\"\n} else { \n  \"\"\n}"
 					},
 					{
 						"type": "trait_prereq",

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -2198,7 +2198,7 @@
 		{
 			"id": "tNs3r-xh05OnHz3pI",
 			"name": "Average Wealth",
-			"reference": "B25",
+			"reference": "B25, L8, DFA54, DW33",
 			"reference_highlight": "Average",
 			"local_notes": "Starting wealth is normal",
 			"tags": [
@@ -3971,7 +3971,7 @@
 		{
 			"id": "tdEOEbc8ltxyQNFJj",
 			"name": "Comfortable Wealth",
-			"reference": "B25",
+			"reference": "B25, L8, DFA54, DW33",
 			"reference_highlight": "Comfortable",
 			"local_notes": "Starting wealth is twice normal",
 			"tags": [
@@ -5437,7 +5437,7 @@
 		{
 			"id": "tw71iZfV_lekRjlBO",
 			"name": "Dead Broke",
-			"reference": "B25",
+			"reference": "B25, L8, DFA67, DW33",
 			"local_notes": "Starting wealth is 0",
 			"tags": [
 				"Disadvantage",
@@ -8778,7 +8778,7 @@
 		{
 			"id": "tqzd8zGIvcYp0FgjE",
 			"name": "Filthy Rich",
-			"reference": "B25",
+			"reference": "B25, L8, DFRC2:49, DW33",
 			"local_notes": "Starting wealth is 100x normal",
 			"tags": [
 				"Advantage",
@@ -10449,7 +10449,7 @@
 		{
 			"id": "tA7Kmr7kSEEXGBSQO",
 			"name": "Status",
-			"reference": "B28",
+			"reference": "B28, L8, DW37",
 			"local_notes": "@Description@",
 			"tags": [
 				"Advantage",
@@ -16097,7 +16097,7 @@
 		{
 			"id": "tn-kBo-qGnIc4wYlI",
 			"name": "Low Status ",
-			"reference": "B28",
+			"reference": "B28, L8, DW37",
 			"local_notes": "@Description@",
 			"tags": [
 				"Disadvantage",
@@ -18153,7 +18153,7 @@
 		{
 			"id": "tc2Bw-0JpkS5K2zxY",
 			"name": "Multimillionaire",
-			"reference": "B25",
+			"reference": "B25, DFRC2:49, DW33",
 			"local_notes": "Starting wealth is \u003cscript\u003e\n// Partial Multimillionaire Levels (SS2:26) allows Multimillionaire level to be any multiple of 0.2.\nlet whole = Math.trunc(self.level), partial = Math.round((self.level - whole)* 10) || 1;\nformatNum(10 ** ( whole + 2) * partial, true, false)\n\u003c/script\u003ex normal",
 			"tags": [
 				"Advantage",
@@ -20720,7 +20720,7 @@
 		{
 			"id": "t-X2ObErkLG1c_UzW",
 			"name": "Poor",
-			"reference": "B25",
+			"reference": "B25, L8, DFA67, DW33",
 			"local_notes": "Starting wealth is 1/5 normal",
 			"tags": [
 				"Disadvantage",
@@ -25071,7 +25071,7 @@
 		{
 			"id": "trgleL6LZZ7FUDMEB",
 			"name": "Struggling",
-			"reference": "B25",
+			"reference": "B25, L8, DFA67, DW33",
 			"local_notes": "Starting wealth is ½ normal",
 			"tags": [
 				"Disadvantage",
@@ -29074,7 +29074,7 @@
 		{
 			"id": "tgNjs3lrycmChMxRC",
 			"name": "Very Wealthy",
-			"reference": "B25",
+			"reference": "B25, L8, DFA54, DW33",
 			"local_notes": "Starting wealth is 20x normal",
 			"tags": [
 				"Advantage",
@@ -29993,7 +29993,7 @@
 		{
 			"id": "t55UZnC4Hxsvl7-ri",
 			"name": "Wealthy",
-			"reference": "B25",
+			"reference": "B25, L8, DFA54, DW33",
 			"local_notes": "Starting wealth is 5x normal",
 			"tags": [
 				"Advantage",

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -2199,6 +2199,7 @@
 			"id": "tNs3r-xh05OnHz3pI",
 			"name": "Average Wealth",
 			"reference": "B25",
+			"reference_highlight": "Average",
 			"local_notes": "Starting wealth is normal",
 			"tags": [
 				"Advantage",
@@ -3971,6 +3972,7 @@
 			"id": "tdEOEbc8ltxyQNFJj",
 			"name": "Comfortable Wealth",
 			"reference": "B25",
+			"reference_highlight": "Comfortable",
 			"local_notes": "Starting wealth is twice normal",
 			"tags": [
 				"Advantage",
@@ -3986,7 +3988,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "dead broke"
+							"qualifier": "Average Wealth"
 						}
 					},
 					{
@@ -3994,7 +3996,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "poor"
+							"qualifier": "Dead Broke"
 						}
 					},
 					{
@@ -4002,7 +4004,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "struggling"
+							"qualifier": "Poor"
 						}
 					},
 					{
@@ -4010,7 +4012,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "wealthy"
+							"qualifier": "Struggling"
 						}
 					},
 					{
@@ -4018,7 +4020,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "very wealthy"
+							"qualifier": "Wealthy"
 						}
 					},
 					{
@@ -4026,7 +4028,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "filthy rich"
+							"qualifier": "Very Wealthy"
 						}
 					},
 					{
@@ -4034,7 +4036,15 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "multimillionaire"
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
 						}
 					}
 				]
@@ -5443,7 +5453,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "poor"
+							"qualifier": "Average Wealth"
 						}
 					},
 					{
@@ -5451,7 +5461,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "struggling"
+							"qualifier": "Poor"
 						}
 					},
 					{
@@ -5459,7 +5469,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "comfortable wealth"
+							"qualifier": "Struggling"
 						}
 					},
 					{
@@ -5467,7 +5477,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "wealthy"
+							"qualifier": "Comfortable Wealth"
 						}
 					},
 					{
@@ -5475,7 +5485,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "very wealthy"
+							"qualifier": "Wealthy"
 						}
 					},
 					{
@@ -5483,7 +5493,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "filthy rich"
+							"qualifier": "Very Wealthy"
 						}
 					},
 					{
@@ -5491,7 +5501,15 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "multimillionaire"
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
 						}
 					}
 				]
@@ -8776,7 +8794,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "dead broke"
+							"qualifier": "Average Wealth"
 						}
 					},
 					{
@@ -8784,7 +8802,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "poor"
+							"qualifier": "Dead Broke"
 						}
 					},
 					{
@@ -8792,7 +8810,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "struggling"
+							"qualifier": "Poor"
 						}
 					},
 					{
@@ -8800,7 +8818,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "comfortable wealth"
+							"qualifier": "Struggling"
 						}
 					},
 					{
@@ -8808,7 +8826,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "wealthy"
+							"qualifier": "Comfortable Wealth"
 						}
 					},
 					{
@@ -8816,7 +8834,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "very wealthy"
+							"qualifier": "Wealthy"
 						}
 					},
 					{
@@ -8824,7 +8842,15 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "multimillionaire"
+							"qualifier": "Very Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
 						}
 					}
 				]
@@ -18125,7 +18151,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "dead broke"
+							"qualifier": "Average Wealth"
 						}
 					},
 					{
@@ -18133,7 +18159,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "poor"
+							"qualifier": "Dead Broke"
 						}
 					},
 					{
@@ -18141,7 +18167,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "struggling"
+							"qualifier": "Poor"
 						}
 					},
 					{
@@ -18149,7 +18175,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "comfortable wealth"
+							"qualifier": "Struggling"
 						}
 					},
 					{
@@ -18157,7 +18183,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "wealthy"
+							"qualifier": "Comfortable Wealth"
 						}
 					},
 					{
@@ -18165,7 +18191,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "very wealthy"
+							"qualifier": "Wealthy"
 						}
 					},
 					{
@@ -18173,7 +18199,15 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "filthy rich"
+							"qualifier": "Very Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
 						}
 					}
 				]
@@ -20630,7 +20664,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "dead broke"
+							"qualifier": "Average Wealth"
 						}
 					},
 					{
@@ -20638,7 +20672,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "struggling"
+							"qualifier": "Dead Broke"
 						}
 					},
 					{
@@ -20646,7 +20680,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "comfortable wealth"
+							"qualifier": "Struggling"
 						}
 					},
 					{
@@ -20654,7 +20688,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "wealthy"
+							"qualifier": "Comfortable Wealth"
 						}
 					},
 					{
@@ -20662,7 +20696,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "very wealthy"
+							"qualifier": "Wealthy"
 						}
 					},
 					{
@@ -20670,7 +20704,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "filthy rich"
+							"qualifier": "Very Wealthy"
 						}
 					},
 					{
@@ -20678,7 +20712,15 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "multimillionaire"
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
 						}
 					}
 				]
@@ -24973,7 +25015,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "dead broke"
+							"qualifier": "Average Wealth"
 						}
 					},
 					{
@@ -24981,7 +25023,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "poor"
+							"qualifier": "Dead Broke"
 						}
 					},
 					{
@@ -24989,7 +25031,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "comfortable wealth"
+							"qualifier": "Poor"
 						}
 					},
 					{
@@ -24997,7 +25039,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "wealthy"
+							"qualifier": "Comfortable Wealth"
 						}
 					},
 					{
@@ -25005,7 +25047,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "very wealthy"
+							"qualifier": "Wealthy"
 						}
 					},
 					{
@@ -25013,7 +25055,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "filthy rich"
+							"qualifier": "Very Wealthy"
 						}
 					},
 					{
@@ -25021,7 +25063,15 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "multimillionaire"
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
 						}
 					}
 				]
@@ -28968,7 +29018,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "dead broke"
+							"qualifier": "Average Wealth"
 						}
 					},
 					{
@@ -28976,7 +29026,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "poor"
+							"qualifier": "Dead Broke"
 						}
 					},
 					{
@@ -28984,7 +29034,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "struggling"
+							"qualifier": "Poor"
 						}
 					},
 					{
@@ -28992,7 +29042,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "comfortable wealth"
+							"qualifier": "Struggling"
 						}
 					},
 					{
@@ -29000,7 +29050,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "wealthy"
+							"qualifier": "Comfortable Wealth"
 						}
 					},
 					{
@@ -29008,7 +29058,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "filthy rich"
+							"qualifier": "Wealthy"
 						}
 					},
 					{
@@ -29016,7 +29066,15 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "multimillionaire"
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
 						}
 					}
 				]
@@ -29860,7 +29918,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "dead broke"
+							"qualifier": "Average Wealth"
 						}
 					},
 					{
@@ -29868,7 +29926,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "poor"
+							"qualifier": "Dead Broke"
 						}
 					},
 					{
@@ -29876,7 +29934,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "struggling"
+							"qualifier": "Poor"
 						}
 					},
 					{
@@ -29884,7 +29942,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "comfortable wealth"
+							"qualifier": "Struggling"
 						}
 					},
 					{
@@ -29892,7 +29950,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "very wealthy"
+							"qualifier": "Comfortable Wealth"
 						}
 					},
 					{
@@ -29900,7 +29958,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "filthy rich"
+							"qualifier": "Very Wealthy"
 						}
 					},
 					{
@@ -29908,7 +29966,15 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "multimillionaire"
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
 						}
 					}
 				]

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -10448,7 +10448,7 @@
 		},
 		{
 			"id": "tA7Kmr7kSEEXGBSQO",
-			"name": "High Status",
+			"name": "Status",
 			"reference": "B28",
 			"local_notes": "@Description@",
 			"tags": [
@@ -10457,10 +10457,9 @@
 			],
 			"points_per_level": 5,
 			"can_level": true,
-			"levels": 1,
 			"calc": {
-				"points": 5,
-				"current_level": 1
+				"points": 0,
+				"current_level": 0
 			}
 		},
 		{

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -2196,6 +2196,90 @@
 			}
 		},
 		{
+			"id": "tNs3r-xh05OnHz3pI",
+			"name": "Average Wealth",
+			"reference": "B25",
+			"local_notes": "Starting wealth is normal",
+			"tags": [
+				"Advantage",
+				"Social",
+				"Wealth"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Comfortable Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dead Broke"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Poor"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Struggling"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
+						}
+					}
+				]
+			},
+			"calc": {
+				"points": 0
+			}
+		},
+		{
 			"id": "tOIbA7bxjknhRjYSU",
 			"name": "Bad Back",
 			"reference": "B123",

--- a/Library/Discworld Roleplaying Game/Discworld Roleplaying Game Traits.adq
+++ b/Library/Discworld Roleplaying Game/Discworld Roleplaying Game Traits.adq
@@ -1676,49 +1676,19 @@
 					"children": [
 						{
 							"id": "tHvSl1_SAR6dmcUrz",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t55UZnC4Hxsvl7-ri"
+							},
 							"name": "Wealthy",
-							"reference": "DW33",
+							"reference": "B25, L8, DFA54, DW33",
 							"local_notes": "Starting wealth is 5x normal",
-							"base_points": 20,
-							"calc": {
-								"points": 20
-							}
-						},
-						{
-							"id": "tP3joLjkqg9R0BXnq",
-							"name": "Very Wealthy",
-							"reference": "DW33",
-							"local_notes": "Starting wealth is 20x normal",
-							"base_points": 30,
-							"calc": {
-								"points": 30
-							}
-						},
-						{
-							"id": "tW300qMS8abGlbpKs",
-							"name": "Struggling",
-							"reference": "DW33",
-							"local_notes": "Starting wealth is ½ normal",
-							"base_points": -10,
-							"calc": {
-								"points": -10
-							}
-						},
-						{
-							"id": "ttn9qtwdVyGoKEJ1A",
-							"name": "Poor",
-							"reference": "DW33",
-							"local_notes": "Starting wealth is 1/5 normal",
-							"base_points": -15,
-							"calc": {
-								"points": -15
-							}
-						},
-						{
-							"id": "t3fVrBmGnrIQZiI00",
-							"name": "Multimillionaire",
-							"reference": "DW33",
-							"local_notes": "Starting wealth is 100x10^level normal",
+							"tags": [
+								"Advantage",
+								"Social",
+								"Wealth"
+							],
 							"prereqs": {
 								"type": "prereq_list",
 								"all": true,
@@ -1728,25 +1698,633 @@
 										"has": false,
 										"name": {
 											"compare": "is",
-											"qualifier": "filthy rich"
+											"qualifier": "Average Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Dead Broke"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Poor"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Struggling"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Comfortable Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Very Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Filthy Rich"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Multimillionaire"
 										}
 									}
 								]
 							},
+							"modifiers": [
+								{
+									"id": "mVRC5NREZ2_-0Eyzr",
+									"name": "Wealth grants Status",
+									"reference": "B26",
+									"reference_highlight": "Wealth and Status",
+									"features": [
+										{
+											"type": "trait_bonus",
+											"name": {
+												"compare": "is",
+												"qualifier": "Status"
+											},
+											"amount": 1
+										}
+									],
+									"disabled": true
+								}
+							],
+							"base_points": 20,
+							"calc": {
+								"points": 20
+							}
+						},
+						{
+							"id": "tP3joLjkqg9R0BXnq",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tgNjs3lrycmChMxRC"
+							},
+							"name": "Very Wealthy",
+							"reference": "B25, L8, DFA54, DW33",
+							"local_notes": "Starting wealth is 20x normal",
+							"tags": [
+								"Advantage",
+								"Social",
+								"Wealth"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Average Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Dead Broke"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Poor"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Struggling"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Comfortable Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Filthy Rich"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Multimillionaire"
+										}
+									}
+								]
+							},
+							"modifiers": [
+								{
+									"id": "mUT2qztFUo5foQVAJ",
+									"name": "Wealth grants Status",
+									"reference": "B26",
+									"reference_highlight": "Wealth and Status",
+									"features": [
+										{
+											"type": "trait_bonus",
+											"name": {
+												"compare": "is",
+												"qualifier": "Status"
+											},
+											"amount": 1
+										}
+									],
+									"disabled": true
+								}
+							],
+							"base_points": 30,
+							"calc": {
+								"points": 30
+							}
+						},
+						{
+							"id": "tW300qMS8abGlbpKs",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "trgleL6LZZ7FUDMEB"
+							},
+							"name": "Struggling",
+							"reference": "B25, L8, DFA67, DW33",
+							"local_notes": "Starting wealth is ½ normal",
+							"tags": [
+								"Disadvantage",
+								"Social",
+								"Wealth"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Average Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Dead Broke"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Poor"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Comfortable Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Very Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Filthy Rich"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Multimillionaire"
+										}
+									}
+								]
+							},
+							"base_points": -10,
+							"calc": {
+								"points": -10
+							}
+						},
+						{
+							"id": "ttn9qtwdVyGoKEJ1A",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t-X2ObErkLG1c_UzW"
+							},
+							"name": "Poor",
+							"reference": "B25, L8, DFA67, DW33",
+							"local_notes": "Starting wealth is 1/5 normal",
+							"tags": [
+								"Disadvantage",
+								"Social",
+								"Wealth"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Average Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Dead Broke"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Struggling"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Comfortable Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Very Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Filthy Rich"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Multimillionaire"
+										}
+									}
+								]
+							},
+							"base_points": -15,
+							"calc": {
+								"points": -15
+							}
+						},
+						{
+							"id": "tAIMMOyPpH5ltccGG",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tc2Bw-0JpkS5K2zxY"
+							},
+							"name": "Multimillionaire",
+							"reference": "B25, DFRC2:49, DW33",
+							"local_notes": "Starting wealth is \u003cscript\u003e\n// Partial Multimillionaire Levels (SS2:26) allows Multimillionaire level to be any multiple of 0.2.\nlet whole = Math.trunc(self.level), partial = Math.round((self.level - whole)* 10) || 1;\nformatNum(10 ** ( whole + 2) * partial, true, false)\n\u003c/script\u003ex normal",
+							"tags": [
+								"Advantage",
+								"Social",
+								"Wealth"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "script_prereq",
+										"script": "const statusModifier = self.findActiveModifier(\"Wealth grants Status\");\nif (statusModifier \u0026\u0026 statusModifier.level == 2 \u0026\u0026 (self.level \u003c 1 || self.level \u003e= 2)) {\n  \"Multimillionaire level must be at least 1 and less than 2 for Wealth grants Status 2\"\n} else if (statusModifier \u0026\u0026 statusModifier.level == 3 \u0026\u0026 self.level \u003c 2) {\n  \"Multimillionaire level must be at least 2 for Wealth grants Status 3\"\n} else { \n  \"\"\n}"
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Average Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Dead Broke"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Poor"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Struggling"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Comfortable Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Very Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Filthy Rich"
+										}
+									}
+								]
+							},
+							"modifiers": [
+								{
+									"id": "MpVb4d49OHzTgisAb",
+									"name": "Multimillionaire 1 only",
+									"children": [
+										{
+											"id": "mncdfkKuKiojYfod7",
+											"name": "Wealth grants Status",
+											"reference": "B26",
+											"reference_highlight": "Wealth and Status",
+											"features": [
+												{
+													"type": "trait_bonus",
+													"name": {
+														"compare": "is",
+														"qualifier": "Status"
+													},
+													"amount": 2
+												}
+											],
+											"levels": 2,
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "Mpqb8oBZ2JF8BxTel",
+									"name": "Multimillionaire 2+",
+									"children": [
+										{
+											"id": "mPsiXmjzIPdmj3NLx",
+											"name": "Wealth grants Status",
+											"reference": "B26",
+											"reference_highlight": "Wealth and Status",
+											"features": [
+												{
+													"type": "trait_bonus",
+													"name": {
+														"compare": "is",
+														"qualifier": "Status"
+													},
+													"amount": 3
+												}
+											],
+											"levels": 3,
+											"disabled": true
+										}
+									]
+								}
+							],
 							"base_points": 50,
 							"points_per_level": 25,
 							"can_level": true,
 							"levels": 1,
 							"calc": {
 								"points": 75,
+								"resolved_notes": "Starting wealth is 1,000x normal",
 								"current_level": 1
 							}
 						},
 						{
 							"id": "tysG7eRvX9ICZ2FT8",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tqzd8zGIvcYp0FgjE"
+							},
 							"name": "Filthy Rich",
-							"reference": "DW33",
+							"reference": "B25, L8, DFRC2:49, DW33",
 							"local_notes": "Starting wealth is 100x normal",
+							"tags": [
+								"Advantage",
+								"Social",
+								"Wealth"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Average Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Dead Broke"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Poor"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Struggling"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Comfortable Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Very Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Multimillionaire"
+										}
+									}
+								]
+							},
+							"modifiers": [
+								{
+									"id": "mg_jIX6sKQHAkUgOu",
+									"name": "Wealth grants Status",
+									"reference": "B26",
+									"reference_highlight": "Wealth and Status",
+									"features": [
+										{
+											"type": "trait_bonus",
+											"name": {
+												"compare": "is",
+												"qualifier": "Status"
+											},
+											"amount": 1
+										}
+									],
+									"disabled": true
+								}
+							],
 							"base_points": 50,
 							"calc": {
 								"points": 50
@@ -1754,9 +2332,89 @@
 						},
 						{
 							"id": "tGAHpLyrsJ7S8wMH9",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tw71iZfV_lekRjlBO"
+							},
 							"name": "Dead Broke",
-							"reference": "DW33",
+							"reference": "B25, L8, DFA67, DW33",
 							"local_notes": "Starting wealth is 0",
+							"tags": [
+								"Disadvantage",
+								"Social",
+								"Wealth"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Average Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Poor"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Struggling"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Comfortable Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Very Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Filthy Rich"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Multimillionaire"
+										}
+									}
+								]
+							},
 							"base_points": -25,
 							"calc": {
 								"points": -25
@@ -1764,9 +2422,90 @@
 						},
 						{
 							"id": "tDDEQqudaSXwK7aJx",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tdEOEbc8ltxyQNFJj"
+							},
 							"name": "Comfortable Wealth",
-							"reference": "DW33",
+							"reference": "B25, L8, DFA54, DW33",
+							"reference_highlight": "Comfortable",
 							"local_notes": "Starting wealth is twice normal",
+							"tags": [
+								"Advantage",
+								"Social",
+								"Wealth"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Average Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Dead Broke"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Poor"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Struggling"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Very Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Filthy Rich"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Multimillionaire"
+										}
+									}
+								]
+							},
 							"base_points": 10,
 							"calc": {
 								"points": 10
@@ -1774,9 +2513,90 @@
 						},
 						{
 							"id": "taHfkfv79ARAxnVF_",
-							"name": "Average",
-							"reference": "DW33",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tNs3r-xh05OnHz3pI"
+							},
+							"name": "Average Wealth",
+							"reference": "B25, L8, DFA54, DW33",
+							"reference_highlight": "Average",
 							"local_notes": "Starting wealth is normal",
+							"tags": [
+								"Advantage",
+								"Social",
+								"Wealth"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Comfortable Wealth"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Dead Broke"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Poor"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Struggling"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Very Wealthy"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Filthy Rich"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": false,
+										"name": {
+											"compare": "is",
+											"qualifier": "Multimillionaire"
+										}
+									}
+								]
+							},
 							"calc": {
 								"points": 0
 							}

--- a/Library/Discworld Roleplaying Game/Discworld Roleplaying Game Traits.adq
+++ b/Library/Discworld Roleplaying Game/Discworld Roleplaying Game Traits.adq
@@ -3053,9 +3053,18 @@
 							"children": [
 								{
 									"id": "tR3BK3eF4j1adSBJh",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tn-kBo-qGnIc4wYlI"
+									},
 									"name": "Low Status ",
-									"reference": "DW37",
+									"reference": "B28, L8, DW37",
 									"local_notes": "@Description@",
+									"tags": [
+										"Disadvantage",
+										"Social"
+									],
 									"points_per_level": -5,
 									"can_level": true,
 									"levels": 1,
@@ -3066,79 +3075,33 @@
 								},
 								{
 									"id": "tctPD4IgwJNZFsFPA",
-									"name": "High Status",
-									"reference": "DW37",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tA7Kmr7kSEEXGBSQO"
+									},
+									"name": "Status",
+									"reference": "B28, L8, DW37",
 									"local_notes": "@Description@",
-									"modifiers": [
-										{
-											"id": "M0_Lwk3PGcnM03VL4",
-											"name": "Wealth",
-											"children": [
-												{
-													"id": "m7Rr_noVz_aS0FG55",
-													"name": "Wealthy - Fithly Rich",
-													"reference": "DW38",
-													"cost_adj": "-5",
-													"affects": "base_only",
-													"disabled": true
-												},
-												{
-													"id": "ma9Qo8iv7j1zSTeGS",
-													"name": "Multimilionaire 1",
-													"reference": "DW38",
-													"cost_adj": "-10",
-													"affects": "base_only",
-													"disabled": true
-												},
-												{
-													"id": "mRurdksfqptghDD81",
-													"name": "Multimilionaire 2",
-													"reference": "DW38",
-													"cost_adj": "-15",
-													"affects": "base_only",
-													"disabled": true
-												}
-											]
-										},
-										{
-											"id": "M9epAk3GROchmO7n8",
-											"name": "Rank",
-											"children": [
-												{
-													"id": "m1LTrk7TevytVkALp",
-													"name": "Rank 3-5",
-													"reference": "DW38",
-													"cost_adj": "-5",
-													"affects": "base_only",
-													"disabled": true
-												},
-												{
-													"id": "mt9VYOTTcd8Bsw_jX",
-													"name": "Rank 6+",
-													"reference": "DW38",
-													"cost_adj": "-10",
-													"affects": "base_only",
-													"disabled": true
-												}
-											]
-										}
+									"tags": [
+										"Advantage",
+										"Social"
 									],
 									"points_per_level": 5,
 									"can_level": true,
-									"levels": 1,
 									"calc": {
-										"points": 5,
-										"current_level": 1
+										"points": 0,
+										"current_level": 0
 									}
 								}
 							],
 							"calc": {
-								"points": 0
+								"points": -5
 							}
 						}
 					],
 					"calc": {
-						"points": -60
+						"points": -65
 					}
 				},
 				{
@@ -3627,7 +3590,7 @@
 				}
 			],
 			"calc": {
-				"points": 75
+				"points": 70
 			}
 		},
 		{

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -9688,81 +9688,672 @@
 			}
 		},
 		{
-			"id": "twjsNQ_2IYvFzZPA0",
-			"name": "Wealth",
-			"reference": "DFA54",
-			"local_notes": "Advantage",
+			"id": "tv-hkvdKJkBvQnNst",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "tNs3r-xh05OnHz3pI"
+			},
+			"name": "Average Wealth",
+			"reference": "B25, L8, DFA54, DW33",
+			"reference_highlight": "Average",
+			"local_notes": "Starting wealth is normal",
 			"tags": [
 				"Advantage",
-				"Social"
+				"Social",
+				"Wealth"
 			],
-			"modifiers": [
-				{
-					"id": "muVG3zrbPldaRzHjV",
-					"name": "Comfortable",
-					"reference": "B25",
-					"local_notes": "Starting wealth is 2x average",
-					"cost_adj": "10",
-					"disabled": true
-				},
-				{
-					"id": "mm-g2PZbzlENNqxkL",
-					"name": "Wealthy",
-					"reference": "B25",
-					"local_notes": "Starting wealth is 5x average",
-					"cost_adj": "20",
-					"disabled": true
-				},
-				{
-					"id": "m_oco09uMQnKg_HiD",
-					"name": "Very Wealthy",
-					"reference": "B25",
-					"local_notes": "Starting wealth is 20x average",
-					"cost_adj": "30",
-					"disabled": true
-				}
-			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Comfortable Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dead Broke"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Poor"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Struggling"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
+						}
+					}
+				]
+			},
 			"calc": {
 				"points": 0
 			}
 		},
 		{
-			"id": "tTF_7UCZQvD8OO3cz",
-			"name": "Wealth",
-			"reference": "DFA67",
-			"local_notes": "Disadvantage",
+			"id": "tB2OkJgHurcPtkScL",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "tdEOEbc8ltxyQNFJj"
+			},
+			"name": "Comfortable Wealth",
+			"reference": "B25, L8, DFA54, DW33",
+			"reference_highlight": "Comfortable",
+			"local_notes": "Starting wealth is twice normal",
+			"tags": [
+				"Advantage",
+				"Social",
+				"Wealth"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Average Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dead Broke"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Poor"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Struggling"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
+						}
+					}
+				]
+			},
+			"base_points": 10,
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "tfHmfo2ucusu8hxpm",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "tw71iZfV_lekRjlBO"
+			},
+			"name": "Dead Broke",
+			"reference": "B25, L8, DFA67, DW33",
+			"local_notes": "Starting wealth is 0",
 			"tags": [
 				"Disadvantage",
-				"Social"
+				"Social",
+				"Wealth"
 			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Average Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Poor"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Struggling"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Comfortable Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
+						}
+					}
+				]
+			},
+			"base_points": -25,
+			"calc": {
+				"points": -25
+			}
+		},
+		{
+			"id": "toDaCYi95LgGppaB9",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "t-X2ObErkLG1c_UzW"
+			},
+			"name": "Poor",
+			"reference": "B25, L8, DFA67, DW33",
+			"local_notes": "Starting wealth is 1/5 normal",
+			"tags": [
+				"Disadvantage",
+				"Social",
+				"Wealth"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Average Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dead Broke"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Struggling"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Comfortable Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
+						}
+					}
+				]
+			},
+			"base_points": -15,
+			"calc": {
+				"points": -15
+			}
+		},
+		{
+			"id": "tizD8SFRiMTJgERVx",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "trgleL6LZZ7FUDMEB"
+			},
+			"name": "Struggling",
+			"reference": "B25, L8, DFA67, DW33",
+			"local_notes": "Starting wealth is ½ normal",
+			"tags": [
+				"Disadvantage",
+				"Social",
+				"Wealth"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Average Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dead Broke"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Poor"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Comfortable Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
+						}
+					}
+				]
+			},
+			"base_points": -10,
+			"calc": {
+				"points": -10
+			}
+		},
+		{
+			"id": "tw62wN9PSUOsPvkM-",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "tgNjs3lrycmChMxRC"
+			},
+			"name": "Very Wealthy",
+			"reference": "B25, L8, DFA54, DW33",
+			"local_notes": "Starting wealth is 20x normal",
+			"tags": [
+				"Advantage",
+				"Social",
+				"Wealth"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Average Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dead Broke"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Poor"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Struggling"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Comfortable Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
+						}
+					}
+				]
+			},
 			"modifiers": [
 				{
-					"id": "m_bnqs_rfQMb9PXmN",
-					"name": "Dead Broke",
-					"reference": "B25",
-					"local_notes": "Starting wealth is $0",
-					"cost_adj": "-25",
-					"disabled": true
-				},
-				{
-					"id": "mLq15s4i8a2xt7hc_",
-					"name": "Poor",
-					"reference": "B25",
-					"local_notes": "Starting wealth is 1/5 average",
-					"cost_adj": "-15",
-					"disabled": true
-				},
-				{
-					"id": "mGi-ig7a3Bzx8v7cN",
-					"name": "Struggling",
-					"reference": "B25",
-					"local_notes": "Starting wealth is 1/2 average",
-					"cost_adj": "-10",
+					"id": "m7tfw8ZIgATldO8B1",
+					"name": "Wealth grants Status",
+					"reference": "B26",
+					"reference_highlight": "Wealth and Status",
+					"features": [
+						{
+							"type": "trait_bonus",
+							"name": {
+								"compare": "is",
+								"qualifier": "Status"
+							},
+							"amount": 1
+						}
+					],
 					"disabled": true
 				}
 			],
+			"base_points": 30,
 			"calc": {
-				"points": 0
+				"points": 30
+			}
+		},
+		{
+			"id": "tC2zAZVbmELpUUQJ5",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "t55UZnC4Hxsvl7-ri"
+			},
+			"name": "Wealthy",
+			"reference": "B25, L8, DFA54, DW33",
+			"local_notes": "Starting wealth is 5x normal",
+			"tags": [
+				"Advantage",
+				"Social",
+				"Wealth"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Average Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dead Broke"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Poor"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Struggling"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Comfortable Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Multimillionaire"
+						}
+					}
+				]
+			},
+			"modifiers": [
+				{
+					"id": "m00eup0BAF8gmJkmb",
+					"name": "Wealth grants Status",
+					"reference": "B26",
+					"reference_highlight": "Wealth and Status",
+					"features": [
+						{
+							"type": "trait_bonus",
+							"name": {
+								"compare": "is",
+								"qualifier": "Status"
+							},
+							"amount": 1
+						}
+					],
+					"disabled": true
+				}
+			],
+			"base_points": 20,
+			"calc": {
+				"points": 20
 			}
 		},
 		{

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -9688,196 +9688,10 @@
 			}
 		},
 		{
-			"id": "tv-hkvdKJkBvQnNst",
-			"source": {
-				"library": "richardwilkes/gcs_master_library",
-				"path": "Basic Set/Basic Set Traits.adq",
-				"id": "tNs3r-xh05OnHz3pI"
-			},
-			"name": "Average Wealth",
-			"reference": "B25, L8, DFA54, DW33",
-			"reference_highlight": "Average",
-			"local_notes": "Starting wealth is normal",
-			"tags": [
-				"Advantage",
-				"Social",
-				"Wealth"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Comfortable Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Dead Broke"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Poor"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Struggling"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Very Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Filthy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Multimillionaire"
-						}
-					}
-				]
-			},
-			"calc": {
-				"points": 0
-			}
-		},
-		{
-			"id": "tB2OkJgHurcPtkScL",
-			"source": {
-				"library": "richardwilkes/gcs_master_library",
-				"path": "Basic Set/Basic Set Traits.adq",
-				"id": "tdEOEbc8ltxyQNFJj"
-			},
-			"name": "Comfortable Wealth",
-			"reference": "B25, L8, DFA54, DW33",
-			"reference_highlight": "Comfortable",
-			"local_notes": "Starting wealth is twice normal",
-			"tags": [
-				"Advantage",
-				"Social",
-				"Wealth"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Average Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Dead Broke"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Poor"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Struggling"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Very Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Filthy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Multimillionaire"
-						}
-					}
-				]
-			},
-			"base_points": 10,
-			"calc": {
-				"points": 10
-			}
-		},
-		{
 			"id": "tfHmfo2ucusu8hxpm",
-			"source": {
-				"library": "richardwilkes/gcs_master_library",
-				"path": "Basic Set/Basic Set Traits.adq",
-				"id": "tw71iZfV_lekRjlBO"
-			},
 			"name": "Dead Broke",
-			"reference": "B25, L8, DFA67, DW33",
-			"local_notes": "Starting wealth is 0",
+			"reference": "DFA67",
+			"local_notes": "Starting wealth is $0, you sell at 0%",
 			"tags": [
 				"Disadvantage",
 				"Social",
@@ -9892,6 +9706,38 @@
 						"has": false,
 						"name": {
 							"compare": "is",
+							"qualifier": "Rich Beyond Measure"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Far Too Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Crazy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Stinking Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
 							"qualifier": "Average Wealth"
 						}
 					},
@@ -9941,14 +9787,6 @@
 						"name": {
 							"compare": "is",
 							"qualifier": "Filthy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Multimillionaire"
 						}
 					}
 				]
@@ -9960,14 +9798,9 @@
 		},
 		{
 			"id": "toDaCYi95LgGppaB9",
-			"source": {
-				"library": "richardwilkes/gcs_master_library",
-				"path": "Basic Set/Basic Set Traits.adq",
-				"id": "t-X2ObErkLG1c_UzW"
-			},
 			"name": "Poor",
-			"reference": "B25, L8, DFA67, DW33",
-			"local_notes": "Starting wealth is 1/5 normal",
+			"reference": "DFA67",
+			"local_notes": "Starting wealth is $200, you sell at 10%",
 			"tags": [
 				"Disadvantage",
 				"Social",
@@ -9977,6 +9810,38 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Rich Beyond Measure"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Far Too Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Crazy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Stinking Rich"
+						}
+					},
 					{
 						"type": "trait_prereq",
 						"has": false,
@@ -10031,14 +9896,6 @@
 						"name": {
 							"compare": "is",
 							"qualifier": "Filthy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Multimillionaire"
 						}
 					}
 				]
@@ -10050,14 +9907,9 @@
 		},
 		{
 			"id": "tizD8SFRiMTJgERVx",
-			"source": {
-				"library": "richardwilkes/gcs_master_library",
-				"path": "Basic Set/Basic Set Traits.adq",
-				"id": "trgleL6LZZ7FUDMEB"
-			},
 			"name": "Struggling",
-			"reference": "B25, L8, DFA67, DW33",
-			"local_notes": "Starting wealth is ½ normal",
+			"reference": "DFA67",
+			"local_notes": "Starting wealth is $500, you sell at 20%",
 			"tags": [
 				"Disadvantage",
 				"Social",
@@ -10072,6 +9924,38 @@
 						"has": false,
 						"name": {
 							"compare": "is",
+							"qualifier": "Rich Beyond Measure"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Far Too RIch"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Crazy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Stinking Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
 							"qualifier": "Average Wealth"
 						}
 					},
@@ -10121,14 +10005,6 @@
 						"name": {
 							"compare": "is",
 							"qualifier": "Filthy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Multimillionaire"
 						}
 					}
 				]
@@ -10139,15 +10015,11 @@
 			}
 		},
 		{
-			"id": "tw62wN9PSUOsPvkM-",
-			"source": {
-				"library": "richardwilkes/gcs_master_library",
-				"path": "Basic Set/Basic Set Traits.adq",
-				"id": "tgNjs3lrycmChMxRC"
-			},
-			"name": "Very Wealthy",
-			"reference": "B25, L8, DFA54, DW33",
-			"local_notes": "Starting wealth is 20x normal",
+			"id": "tv-hkvdKJkBvQnNst",
+			"name": "Average Wealth",
+			"reference": "DFA54",
+			"reference_highlight": "Average",
+			"local_notes": "Starting wealth is $1000, you sell at 40%",
 			"tags": [
 				"Advantage",
 				"Social",
@@ -10157,6 +10029,147 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Rich Beyond Measure"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Far Too Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Crazy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Stinking Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Comfortable Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dead Broke"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Poor"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Struggling"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
+						}
+					}
+				]
+			},
+			"calc": {
+				"points": 0
+			}
+		},
+		{
+			"id": "tB2OkJgHurcPtkScL",
+			"name": "Comfortable Wealth",
+			"reference": "DFA54",
+			"reference_highlight": "Comfortable",
+			"local_notes": "Starting wealth is $2000, you sell at 60%",
+			"tags": [
+				"Advantage",
+				"Social",
+				"Wealth"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Rich Beyond Measure"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Far Too Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Crazy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Stinking Rich"
+						}
+					},
 					{
 						"type": "trait_prereq",
 						"has": false,
@@ -10194,7 +10207,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "Comfortable Wealth"
+							"qualifier": "Wealthy"
 						}
 					},
 					{
@@ -10202,7 +10215,7 @@
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "Wealthy"
+							"qualifier": "Very Wealthy"
 						}
 					},
 					{
@@ -10212,51 +10225,19 @@
 							"compare": "is",
 							"qualifier": "Filthy Rich"
 						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Multimillionaire"
-						}
 					}
 				]
 			},
-			"modifiers": [
-				{
-					"id": "m7tfw8ZIgATldO8B1",
-					"name": "Wealth grants Status",
-					"reference": "B26",
-					"reference_highlight": "Wealth and Status",
-					"features": [
-						{
-							"type": "trait_bonus",
-							"name": {
-								"compare": "is",
-								"qualifier": "Status"
-							},
-							"amount": 1
-						}
-					],
-					"disabled": true
-				}
-			],
-			"base_points": 30,
+			"base_points": 10,
 			"calc": {
-				"points": 30
+				"points": 10
 			}
 		},
 		{
 			"id": "tC2zAZVbmELpUUQJ5",
-			"source": {
-				"library": "richardwilkes/gcs_master_library",
-				"path": "Basic Set/Basic Set Traits.adq",
-				"id": "t55UZnC4Hxsvl7-ri"
-			},
 			"name": "Wealthy",
-			"reference": "B25, L8, DFA54, DW33",
-			"local_notes": "Starting wealth is 5x normal",
+			"reference": "DFA54",
+			"local_notes": "Starting wealth is $5000, you sell at 80%",
 			"tags": [
 				"Advantage",
 				"Social",
@@ -10266,6 +10247,38 @@
 				"type": "prereq_list",
 				"all": true,
 				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Rich Beyond Measure"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Far Too Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Crazy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Stinking Rich"
+						}
+					},
 					{
 						"type": "trait_prereq",
 						"has": false,
@@ -10321,39 +10334,701 @@
 							"compare": "is",
 							"qualifier": "Filthy Rich"
 						}
+					}
+				]
+			},
+			"base_points": 20,
+			"calc": {
+				"points": 20
+			}
+		},
+		{
+			"id": "tw62wN9PSUOsPvkM-",
+			"name": "Very Wealthy",
+			"reference": "DFA54",
+			"local_notes": "Starting wealth is $20,000, you sell at 100%",
+			"tags": [
+				"Advantage",
+				"Social",
+				"Wealth"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Rich Beyond Measure"
+						}
 					},
 					{
 						"type": "trait_prereq",
 						"has": false,
 						"name": {
 							"compare": "is",
-							"qualifier": "Multimillionaire"
+							"qualifier": "Far Too Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Crazy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Stinking Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Average Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dead Broke"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Poor"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Struggling"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Comfortable Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
 						}
 					}
 				]
 			},
-			"modifiers": [
-				{
-					"id": "m00eup0BAF8gmJkmb",
-					"name": "Wealth grants Status",
-					"reference": "B26",
-					"reference_highlight": "Wealth and Status",
-					"features": [
-						{
-							"type": "trait_bonus",
-							"name": {
-								"compare": "is",
-								"qualifier": "Status"
-							},
-							"amount": 1
+			"base_points": 30,
+			"calc": {
+				"points": 30
+			}
+		},
+		{
+			"id": "tE-1d7ORxYf-GQmFN",
+			"name": "Filthy Rich",
+			"reference": "DFRC2:49",
+			"local_notes": "Starting wealth is $100,000, you sell at 100%",
+			"tags": [
+				"Advantage",
+				"Social",
+				"Wealth"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Rich Beyond Measure"
 						}
-					],
-					"disabled": true
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Far Too Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Crazy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Stinking Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Average Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dead Broke"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Poor"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Struggling"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Comfortable Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Wealthy"
+						}
+					}
+				]
+			},
+			"base_points": 50,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to any roll within your realm that money and title could influence",
+					"amount": 1
 				}
 			],
-			"base_points": 20,
 			"calc": {
-				"points": 20
+				"points": 50
+			}
+		},
+		{
+			"id": "t4lRx3OCYfWndN0DB",
+			"name": "Stinking Rich",
+			"reference": "DFRC2:49",
+			"local_notes": "Starting wealth is $1,000,000, you sell at 100%",
+			"tags": [
+				"Advantage",
+				"Social",
+				"Wealth"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Rich Beyond Measure"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Far Too Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Crazy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Average Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dead Broke"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Poor"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Struggling"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Comfortable Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Wealthy"
+						}
+					}
+				]
+			},
+			"base_points": 75,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to any roll within your realm that money and title could influence",
+					"amount": 2
+				}
+			],
+			"calc": {
+				"points": 75
+			}
+		},
+		{
+			"id": "tMAhrEI2tvSpv4eFi",
+			"name": "Crazy Rich",
+			"reference": "DFRC2:49",
+			"local_notes": "Starting wealth is $10,000,000, you sell at 100%",
+			"tags": [
+				"Advantage",
+				"Social",
+				"Wealth"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Rich Beyond Measure"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Far Too Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Stinking Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Average Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dead Broke"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Poor"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Struggling"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Comfortable Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Wealthy"
+						}
+					}
+				]
+			},
+			"base_points": 100,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to any roll within your realm that money and title could influence",
+					"amount": 3
+				}
+			],
+			"calc": {
+				"points": 100
+			}
+		},
+		{
+			"id": "tNoRaAgr1cInqHyFa",
+			"name": "Far Too Rich",
+			"reference": "DFRC2:49",
+			"local_notes": "Starting wealth is $100,000,000, you sell at 100%",
+			"tags": [
+				"Advantage",
+				"Social",
+				"Wealth"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Rich Beyond Measure"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Crazy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Stinking Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Average Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dead Broke"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Poor"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Struggling"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Comfortable Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Wealthy"
+						}
+					}
+				]
+			},
+			"base_points": 125,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to any roll within your realm that money and title could influence",
+					"amount": 4
+				}
+			],
+			"calc": {
+				"points": 125
+			}
+		},
+		{
+			"id": "ttD2aYm7pqgj-jeYe",
+			"name": "Rich Beyond Measure",
+			"reference": "DFRC2:49",
+			"local_notes": "Starting wealth is $1,000,000,000, you sell at 100%",
+			"tags": [
+				"Advantage",
+				"Social",
+				"Wealth"
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Far Too Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Crazy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Stinking Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Filthy Rich"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Average Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Dead Broke"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Poor"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Struggling"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Comfortable Wealth"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Wealthy"
+						}
+					},
+					{
+						"type": "trait_prereq",
+						"has": false,
+						"name": {
+							"compare": "is",
+							"qualifier": "Very Wealthy"
+						}
+					}
+				]
+			},
+			"base_points": 150,
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to any roll within your realm that money and title could influence",
+					"amount": 5
+				}
+			],
+			"calc": {
+				"points": 150
 			}
 		},
 		{

--- a/Library/Lite/Lite Traits.adq
+++ b/Library/Lite/Lite Traits.adq
@@ -2262,80 +2262,790 @@
 			}
 		},
 		{
-			"id": "tLFpvk-I4dzDpXC4b",
+			"id": "TUrlAlYvXuglx_OJc",
 			"name": "Wealth",
-			"reference": "L8",
-			"tags": [
-				"Advantage",
-				"Disadvantage",
-				"Social"
-			],
-			"modifiers": [
+			"children": [
 				{
-					"id": "mS6lf-sDRhT5Ynfih",
+					"id": "tgiH8lpi4g0Rb4v4L",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tNs3r-xh05OnHz3pI"
+					},
+					"name": "Average Wealth",
+					"reference": "B25, L8, DFA54, DW33",
+					"reference_highlight": "Average",
+					"local_notes": "Starting wealth is normal",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Multimillionaire"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tpzz7Xb0ro-WuJm_n",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tdEOEbc8ltxyQNFJj"
+					},
+					"name": "Comfortable Wealth",
+					"reference": "B25, L8, DFA54, DW33",
+					"reference_highlight": "Comfortable",
+					"local_notes": "Starting wealth is twice normal",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Multimillionaire"
+								}
+							}
+						]
+					},
+					"base_points": 10,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tgnJjNyx1zTbEDz5U",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tw71iZfV_lekRjlBO"
+					},
 					"name": "Dead Broke",
-					"reference": "B25",
-					"local_notes": "Starting wealth is $0",
-					"cost_adj": "-25",
-					"disabled": true
+					"reference": "B25, L8, DFA67, DW33",
+					"local_notes": "Starting wealth is 0",
+					"tags": [
+						"Disadvantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Multimillionaire"
+								}
+							}
+						]
+					},
+					"base_points": -25,
+					"calc": {
+						"points": -25
+					}
 				},
 				{
-					"id": "mW0m4IGg9R6QvBcRb",
-					"name": "Poor",
-					"reference": "B25",
-					"local_notes": "Starting wealth is 1/5 average",
-					"cost_adj": "-15",
-					"disabled": true
-				},
-				{
-					"id": "mvIv33JFM0LRerv0_",
-					"name": "Struggling",
-					"reference": "B25",
-					"local_notes": "Starting wealth is 1/2 average",
-					"cost_adj": "-10",
-					"disabled": true
-				},
-				{
-					"id": "mphFvcTf74tpt8sy1",
-					"name": "Average",
-					"reference": "B25",
-					"disabled": true
-				},
-				{
-					"id": "muX0Q_4g5F30zG1Pe",
-					"name": "Comfortable",
-					"reference": "B25",
-					"local_notes": "Starting wealth is 2x average",
-					"cost_adj": "10",
-					"disabled": true
-				},
-				{
-					"id": "muH6nbCSfPNucTWfG",
-					"name": "Wealthy",
-					"reference": "B25",
-					"local_notes": "Starting wealth is 5x average",
-					"cost_adj": "20",
-					"disabled": true
-				},
-				{
-					"id": "mDr8jixT4E5-kVM8-",
-					"name": "Very Wealthy",
-					"reference": "B25",
-					"local_notes": "Starting wealth is 20x average",
-					"cost_adj": "30",
-					"disabled": true
-				},
-				{
-					"id": "m5RPqzB8ySP3lMXMH",
+					"id": "tRQAQ5zMbUHd0SGQS",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tqzd8zGIvcYp0FgjE"
+					},
 					"name": "Filthy Rich",
-					"reference": "B25",
-					"local_notes": "Starting wealth is 100x average",
-					"cost_adj": "50",
-					"disabled": true
+					"reference": "B25, L8, DFRC2:49, DW33",
+					"local_notes": "Starting wealth is 100x normal",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Multimillionaire"
+								}
+							}
+						]
+					},
+					"modifiers": [
+						{
+							"id": "mcAnEZasq3U7Tdq4a",
+							"name": "Wealth grants Status",
+							"reference": "B26",
+							"reference_highlight": "Wealth and Status",
+							"features": [
+								{
+									"type": "trait_bonus",
+									"name": {
+										"compare": "is",
+										"qualifier": "Status"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					],
+					"base_points": 50,
+					"calc": {
+						"points": 50
+					}
+				},
+				{
+					"id": "t57qie6hgVv0DRIAO",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t-X2ObErkLG1c_UzW"
+					},
+					"name": "Poor",
+					"reference": "B25, L8, DFA67, DW33",
+					"local_notes": "Starting wealth is 1/5 normal",
+					"tags": [
+						"Disadvantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Multimillionaire"
+								}
+							}
+						]
+					},
+					"base_points": -15,
+					"calc": {
+						"points": -15
+					}
+				},
+				{
+					"id": "tAncdl_5piShW1hk3",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "trgleL6LZZ7FUDMEB"
+					},
+					"name": "Struggling",
+					"reference": "B25, L8, DFA67, DW33",
+					"local_notes": "Starting wealth is ½ normal",
+					"tags": [
+						"Disadvantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Multimillionaire"
+								}
+							}
+						]
+					},
+					"base_points": -10,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "tzQu0ngVWAsN8j7BU",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tgNjs3lrycmChMxRC"
+					},
+					"name": "Very Wealthy",
+					"reference": "B25, L8, DFA54, DW33",
+					"local_notes": "Starting wealth is 20x normal",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Multimillionaire"
+								}
+							}
+						]
+					},
+					"modifiers": [
+						{
+							"id": "mCpudEio8wLZ8-wAe",
+							"name": "Wealth grants Status",
+							"reference": "B26",
+							"reference_highlight": "Wealth and Status",
+							"features": [
+								{
+									"type": "trait_bonus",
+									"name": {
+										"compare": "is",
+										"qualifier": "Status"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					],
+					"base_points": 30,
+					"calc": {
+						"points": 30
+					}
+				},
+				{
+					"id": "tf0kY1782hVkjtHXr",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "t55UZnC4Hxsvl7-ri"
+					},
+					"name": "Wealthy",
+					"reference": "B25, L8, DFA54, DW33",
+					"local_notes": "Starting wealth is 5x normal",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Multimillionaire"
+								}
+							}
+						]
+					},
+					"modifiers": [
+						{
+							"id": "mx2TNYMxenF5ma2I7",
+							"name": "Wealth grants Status",
+							"reference": "B26",
+							"reference_highlight": "Wealth and Status",
+							"features": [
+								{
+									"type": "trait_bonus",
+									"name": {
+										"compare": "is",
+										"qualifier": "Status"
+									},
+									"amount": 1
+								}
+							],
+							"disabled": true
+						}
+					],
+					"base_points": 20,
+					"calc": {
+						"points": 20
+					}
 				}
 			],
 			"calc": {
-				"points": 0
+				"points": 60
 			}
 		}
 	]

--- a/Library/Lite/Lite Traits.adq
+++ b/Library/Lite/Lite Traits.adq
@@ -1699,8 +1699,13 @@
 		},
 		{
 			"id": "tkX5tSbkiDMlUHFRi",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "tA7Kmr7kSEEXGBSQO"
+			},
 			"name": "Status",
-			"reference": "L8",
+			"reference": "B28, L8, DW37",
 			"local_notes": "@Description@",
 			"tags": [
 				"Advantage",
@@ -1708,16 +1713,21 @@
 			],
 			"points_per_level": 5,
 			"can_level": true,
-			"levels": 1,
 			"calc": {
-				"points": 5,
-				"current_level": 1
+				"points": 0,
+				"current_level": 0
 			}
 		},
 		{
 			"id": "t8mWNNR6HPOMUMpmV",
-			"name": "Status (@Description@)",
-			"reference": "L8",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "tn-kBo-qGnIc4wYlI"
+			},
+			"name": "Low Status ",
+			"reference": "B28, L8, DW37",
+			"local_notes": "@Description@",
 			"tags": [
 				"Disadvantage",
 				"Social"


### PR DESCRIPTION
It was mentioned in the gcs discord that there was no Average Wealth trait or Status 0 trait.

I looked through all the places Wealth and Status are mentioned in the master library.

For status, there is a mix of:
1. Status as an advantage and Status as a disadvantage (slightly confusing, inconvenient when giving status due to wealth as a feature).
2. Status as two traits, High Status and Low Status (slightly confusing to have a trait named "High Status 0" to describe having Status 0).
To have a consistent treatment of Status that allows Status 0 to be described, I decided to have two traits, "Status" (default level is 0) and "Low Status".

For Wealth, there is a mix of:
1. A trait called Wealth with modifiers for the different wealth levels.
2. Multiple traits for each different level of Wealth.

Because traits with trait modifiers can be inconvenient for syncing (fields in the trait get synced but the modifiers stay unchanged), I decided to choose multiple traits.

Note that GURPS Lite doesn't have Multimillionaire, and DFRPG (without Dungeon Fantasy Companion 2) doesn't have Multimillionaire or Filthy Rich, so they are sometimes omitted from the list.

As a general plan to make it easier to keep things updated in the master library, I've merged these traits together in various trait lists - Basic Set Traits includes page references for Lite, Discworld Roleplaying Game and DFRPG, and their counterparts in Lite, Discworld Roleplaying Game and (but not DFRPG due to later changes) use the traits from Basic Set Traits, with source library information pointing back - With this merged, if Wealth or Status need to be changed again, they only *have* to be changed in Basic Set Traits. When those traits from other libraries get added to a character sheet, gcs will note that it differs from Basic Set Traits and can be synchronized.

Other, related changes are:
* Implemented the optional Wealth and Status rule, so you can enable a trait modifier to get a Status bonus at high levels of Wealth.
  * This includes a scripted prerequisite for Multimillionaire to make sure you select the right trait modifier
* Implemented Partial Multimillionaire Levels from Spaceships 2
  * This includes calculating how much a multiplier to starting wealth you get from your level of Multimillionaire, which can be a decimal.
  * It also includes altering the code for the Wealth and Status prerequisite to continue to behave correctly when the trait's level can be a decimal instead of an integer.
* It adds the higher wealth levels from Dungeon Fantasy Companion 2 to the Dungeon Fantasy RPG Traits list.
  * Because this is incompatible with keeping source library syncing with Basic Set Traits, I deleted the source library information and made them DFRPG-specific.