### PR TITLE
Fix the trailing space in Low Status' name

### DIFF
--- a/Library/1shotadventures/Characters/Black Mine of Teihiihan/Johnny-Buck.gcs
+++ b/Library/1shotadventures/Characters/Black Mine of Teihiihan/Johnny-Buck.gcs
@@ -657,18 +657,27 @@
 		},
 		{
 			"id": "tWz5g6m8QdIeq-3Ak",
-			"name": "Low Status ",
-			"reference": "B28",
-			"local_notes": "Poor Farmhand",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "tn-kBo-qGnIc4wYlI"
+			},
+			"name": "Low Status",
+			"reference": "B28, L8, DW37",
+			"local_notes": "@Description@",
 			"tags": [
 				"Disadvantage",
 				"Social"
 			],
+			"replacements": {
+				"Description": "Poor Farmhand"
+			},
 			"points_per_level": -5,
 			"can_level": true,
 			"levels": 1,
 			"calc": {
 				"points": -5,
+				"resolved_notes": "Poor Farmhand",
 				"current_level": 1
 			}
 		},
@@ -1705,7 +1714,7 @@
 		}
 	],
 	"created_date": "2024-06-10T23:01:17-07:00",
-	"modified_date": "2024-06-11T12:32:45-07:00",
+	"modified_date": "2026-06-29T21:08:48+01:00",
 	"calc": {
 		"swing": "1d",
 		"thrust": "1d-2",

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -16096,7 +16096,7 @@
 		},
 		{
 			"id": "tn-kBo-qGnIc4wYlI",
-			"name": "Low Status ",
+			"name": "Low Status",
 			"reference": "B28, L8, DW37",
 			"local_notes": "@Description@",
 			"tags": [

--- a/Library/Discworld Roleplaying Game/Discworld Roleplaying Game Traits.adq
+++ b/Library/Discworld Roleplaying Game/Discworld Roleplaying Game Traits.adq
@@ -3058,7 +3058,7 @@
 										"path": "Basic Set/Basic Set Traits.adq",
 										"id": "tn-kBo-qGnIc4wYlI"
 									},
-									"name": "Low Status ",
+									"name": "Low Status",
 									"reference": "B28, L8, DW37",
 									"local_notes": "@Description@",
 									"tags": [

--- a/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Bandit.gct
+++ b/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Bandit.gct
@@ -455,9 +455,18 @@
 			"children": [
 				{
 					"id": "texdayLrC_oFJ54yG",
-					"name": "Low Status ",
-					"reference": "DW37",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tn-kBo-qGnIc4wYlI"
+					},
+					"name": "Low Status",
+					"reference": "B28, L8, DW37",
 					"local_notes": "@Description@",
+					"tags": [
+						"Disadvantage",
+						"Social"
+					],
 					"points_per_level": -5,
 					"can_level": true,
 					"levels": 1,

--- a/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Entertainer.gct
+++ b/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Entertainer.gct
@@ -779,9 +779,18 @@
 			"children": [
 				{
 					"id": "tBD9AsI7HPHOKW2u3",
-					"name": "Low Status ",
-					"reference": "DW37",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tn-kBo-qGnIc4wYlI"
+					},
+					"name": "Low Status",
+					"reference": "B28, L8, DW37",
 					"local_notes": "@Description@",
+					"tags": [
+						"Disadvantage",
+						"Social"
+					],
 					"points_per_level": -5,
 					"can_level": true,
 					"levels": 1,

--- a/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Fool - Clown.gct
+++ b/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Fool - Clown.gct
@@ -753,9 +753,18 @@
 						},
 						{
 							"id": "tbz_840R0RB4eaeeX",
-							"name": "Low Status ",
-							"reference": "DW37",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tn-kBo-qGnIc4wYlI"
+							},
+							"name": "Low Status",
+							"reference": "B28, L8, DW37",
 							"local_notes": "@Description@",
+							"tags": [
+								"Disadvantage",
+								"Social"
+							],
 							"points_per_level": -5,
 							"can_level": true,
 							"levels": 1,

--- a/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Fourecksian Backpacker.gct
+++ b/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Fourecksian Backpacker.gct
@@ -649,9 +649,18 @@
 			"children": [
 				{
 					"id": "tcAho9qd9_rwML9rq",
-					"name": "Low Status ",
-					"reference": "DW37",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tn-kBo-qGnIc4wYlI"
+					},
+					"name": "Low Status",
+					"reference": "B28, L8, DW37",
 					"local_notes": "@Description@",
+					"tags": [
+						"Disadvantage",
+						"Social"
+					],
 					"points_per_level": -5,
 					"can_level": true,
 					"levels": 1,

--- a/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Peasant.gct
+++ b/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Peasant.gct
@@ -1516,9 +1516,18 @@
 						},
 						{
 							"id": "txZ6IXOSUmZdu4uvy",
-							"name": "Low Status ",
-							"reference": "DW37",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tn-kBo-qGnIc4wYlI"
+							},
+							"name": "Low Status",
+							"reference": "B28, L8, DW37",
 							"local_notes": "@Description@",
+							"tags": [
+								"Disadvantage",
+								"Social"
+							],
 							"points_per_level": -5,
 							"can_level": true,
 							"levels": 1,

--- a/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Ruffian.gct
+++ b/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Ruffian.gct
@@ -480,9 +480,18 @@
 			"children": [
 				{
 					"id": "tLyrGqtJ5QW2nqvc5",
-					"name": "Low Status ",
-					"reference": "DW37",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tn-kBo-qGnIc4wYlI"
+					},
+					"name": "Low Status",
+					"reference": "B28, L8, DW37",
 					"local_notes": "@Description@",
+					"tags": [
+						"Disadvantage",
+						"Social"
+					],
 					"points_per_level": -5,
 					"can_level": true,
 					"levels": 1,

--- a/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Tribesman.gct
+++ b/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Tribesman.gct
@@ -539,9 +539,18 @@
 				},
 				{
 					"id": "tazuf7pFJP6jHr-tT",
-					"name": "Low Status ",
-					"reference": "DW37",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tn-kBo-qGnIc4wYlI"
+					},
+					"name": "Low Status",
+					"reference": "B28, L8, DW37",
 					"local_notes": "@Description@",
+					"tags": [
+						"Disadvantage",
+						"Social"
+					],
 					"points_per_level": -5,
 					"can_level": true,
 					"levels": 1,

--- a/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Émigré Gnome.gct
+++ b/Library/Discworld Roleplaying Game/Occupational Templates/Low-Powered Characters/Émigré Gnome.gct
@@ -1876,9 +1876,18 @@
 						},
 						{
 							"id": "tUwX3fChNKR8CYjVC",
-							"name": "Low Status ",
-							"reference": "DW37",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tn-kBo-qGnIc4wYlI"
+							},
+							"name": "Low Status",
+							"reference": "B28, L8, DW37",
 							"local_notes": "@Description@",
+							"tags": [
+								"Disadvantage",
+								"Social"
+							],
 							"points_per_level": -5,
 							"can_level": true,
 							"levels": 1,

--- a/Library/Discworld Roleplaying Game/Occupational Templates/Medium-Powered Characters/Barbarian Hero Wannabe.gct
+++ b/Library/Discworld Roleplaying Game/Occupational Templates/Medium-Powered Characters/Barbarian Hero Wannabe.gct
@@ -2322,9 +2322,18 @@
 						},
 						{
 							"id": "tiJkS2-DqncY7d37o",
-							"name": "Low Status ",
-							"reference": "DW37",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tn-kBo-qGnIc4wYlI"
+							},
+							"name": "Low Status",
+							"reference": "B28, L8, DW37",
 							"local_notes": "@Description@",
+							"tags": [
+								"Disadvantage",
+								"Social"
+							],
 							"points_per_level": -5,
 							"can_level": true,
 							"levels": 1,

--- a/Library/Fantasy Folk/3rd Edition Races/Insect Man.gct
+++ b/Library/Fantasy Folk/3rd Edition Races/Insect Man.gct
@@ -223,8 +223,14 @@
 								},
 								{
 									"id": "t5pdqw75Cpi6rTa4C",
-									"name": "Low Status ",
-									"reference": "B28",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tn-kBo-qGnIc4wYlI"
+									},
+									"name": "Low Status",
+									"reference": "B28, L8, DW37",
+									"local_notes": "@Description@",
 									"tags": [
 										"Disadvantage",
 										"Social"

--- a/Library/Fantasy Folk/Goblins and Hobgoblins/Profession Templates/Hobgoblin Witch Doctor.gct
+++ b/Library/Fantasy Folk/Goblins and Hobgoblins/Profession Templates/Hobgoblin Witch Doctor.gct
@@ -2949,8 +2949,14 @@
 				},
 				{
 					"id": "tPoZbXzqknEmXpXIE",
-					"name": "Low Status ",
-					"reference": "B28",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tn-kBo-qGnIc4wYlI"
+					},
+					"name": "Low Status",
+					"reference": "B28, L8, DW37",
+					"local_notes": "@Description@",
 					"tags": [
 						"Disadvantage",
 						"Social"

--- a/Library/Fantasy Folk/Kobolds/Profession Templates/Sycophant.gct
+++ b/Library/Fantasy Folk/Kobolds/Profession Templates/Sycophant.gct
@@ -1136,9 +1136,14 @@
 				},
 				{
 					"id": "tATvp3z72-vuM_i6Q",
-					"name": "Low Status ",
-					"reference": "B28",
-					"local_notes": "Sycophant",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tn-kBo-qGnIc4wYlI"
+					},
+					"name": "Low Status",
+					"reference": "B28, L8, DW37",
+					"local_notes": "@Description@",
 					"tags": [
 						"Disadvantage",
 						"Social"

--- a/Library/Fantasy Folk/Kobolds/Profession Templates/Trap-Master.gct
+++ b/Library/Fantasy Folk/Kobolds/Profession Templates/Trap-Master.gct
@@ -2367,8 +2367,14 @@
 						},
 						{
 							"id": "tnO76LH5dp5KePsiN",
-							"name": "Low Status ",
-							"reference": "B28",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tn-kBo-qGnIc4wYlI"
+							},
+							"name": "Low Status",
+							"reference": "B28, L8, DW37",
+							"local_notes": "@Description@",
 							"tags": [
 								"Disadvantage",
 								"Social"

--- a/Library/Lite/Lite Traits.adq
+++ b/Library/Lite/Lite Traits.adq
@@ -1725,7 +1725,7 @@
 				"path": "Basic Set/Basic Set Traits.adq",
 				"id": "tn-kBo-qGnIc4wYlI"
 			},
-			"name": "Low Status ",
+			"name": "Low Status",
 			"reference": "B28, L8, DW37",
 			"local_notes": "@Description@",
 			"tags": [

--- a/Library/Thaumatology/Wang Laowu.gcs
+++ b/Library/Thaumatology/Wang Laowu.gcs
@@ -2234,18 +2234,27 @@
 				},
 				{
 					"id": "tRXaAVrrhObG75q6T",
-					"name": "Low Status ",
-					"reference": "B28",
-					"local_notes": "Poor boatman",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tn-kBo-qGnIc4wYlI"
+					},
+					"name": "Low Status",
+					"reference": "B28, L8, DW37",
+					"local_notes": "@Description@",
 					"tags": [
 						"Disadvantage",
 						"Social"
 					],
+					"replacements": {
+						"Description": "Poor boatman"
+					},
 					"points_per_level": -5,
 					"can_level": true,
 					"levels": 2,
 					"calc": {
 						"points": -10,
+						"resolved_notes": "Poor boatman",
 						"current_level": 2
 					}
 				},
@@ -3294,7 +3303,7 @@
 		}
 	],
 	"created_date": "2023-02-11T20:43:59Z",
-	"modified_date": "2026-06-25T18:00:48+01:00",
+	"modified_date": "2026-06-29T21:09:10+01:00",
 	"calc": {
 		"swing": "1d-1",
 		"thrust": "1d-2",


### PR DESCRIPTION
This fixes the Low Status trait in the Basic Set Traits, Low Tech Traits and Discworld Roleplaying Game trait lists.

It also updates all sheets and templates that use Low Status to use the fixed version.