### PR TITLE
Fix Strongbow in its multiple places

### DIFF
--- a/Library/Delvers to Grow/DTG Fast Delver Build Template.gct
+++ b/Library/Delvers to Grow/DTG Fast Delver Build Template.gct
@@ -4463,13 +4463,47 @@
 								},
 								{
 									"id": "tVNEf3mJJfPtQF96B",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Martial Arts/Martial Arts Traits.adq",
+										"id": "tHAfA2lKnn4OT6QIN"
+									},
 									"name": "Strongbow",
-									"reference": "DFA35",
+									"reference": "MA51, PU2:7, DFA35",
+									"local_notes": "Let you ignore some penalties when shooting a bow too strong for you",
 									"tags": [
-										"Advantage",
+										"Perk",
 										"Physical"
 									],
 									"base_points": 1,
+									"features": [
+										{
+											"type": "weapon_min_st_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Bow"
+											},
+											"level": {
+												"compare": "at_least",
+												"qualifier": 1
+											},
+											"amount": -1
+										},
+										{
+											"type": "weapon_min_st_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Bow"
+											},
+											"level": {
+												"compare": "at_least",
+												"qualifier": 2
+											},
+											"amount": -1
+										}
+									],
 									"calc": {
 										"points": 1
 									}

--- a/Library/Dungeon Fantasy RPG/Classes/Scout.gct
+++ b/Library/Dungeon Fantasy RPG/Classes/Scout.gct
@@ -876,13 +876,47 @@
 								},
 								{
 									"id": "tdP0zMkulgqEqwWaz",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Martial Arts/Martial Arts Traits.adq",
+										"id": "tHAfA2lKnn4OT6QIN"
+									},
 									"name": "Strongbow",
-									"reference": "DFA35",
+									"reference": "MA51, PU2:7, DFA35",
+									"local_notes": "Let you ignore some penalties when shooting a bow too strong for you",
 									"tags": [
-										"Advantage",
+										"Perk",
 										"Physical"
 									],
 									"base_points": 1,
+									"features": [
+										{
+											"type": "weapon_min_st_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Bow"
+											},
+											"level": {
+												"compare": "at_least",
+												"qualifier": 1
+											},
+											"amount": -1
+										},
+										{
+											"type": "weapon_min_st_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Bow"
+											},
+											"level": {
+												"compare": "at_least",
+												"qualifier": 2
+											},
+											"amount": -1
+										}
+									],
 									"calc": {
 										"points": 1
 									}

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -8644,11 +8644,16 @@
 		},
 		{
 			"id": "tl3O8RxtWmUHo3osJ",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Martial Arts/Martial Arts Traits.adq",
+				"id": "tHAfA2lKnn4OT6QIN"
+			},
 			"name": "Strongbow",
-			"reference": "DFA35",
-			"local_notes": "Manually adjust Rated ST for purchased bow(s).",
+			"reference": "MA51, PU2:7, DFA35",
+			"local_notes": "Let you ignore some penalties when shooting a bow too strong for you",
 			"tags": [
-				"Advantage",
+				"Perk",
 				"Physical"
 			],
 			"base_points": 1,

--- a/Library/Fantasy Folk/Winged Folk/Martial Arts/Al Imroses.gct
+++ b/Library/Fantasy Folk/Winged Folk/Martial Arts/Al Imroses.gct
@@ -59,15 +59,48 @@
 						},
 						{
 							"id": "tyzjkGlAP5Wt3NJoM",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Martial Arts/Martial Arts Traits.adq",
+								"id": "tHAfA2lKnn4OT6QIN"
+							},
 							"name": "Strongbow",
-							"reference": "MA51",
+							"reference": "MA51, PU2:7, DFA35",
 							"local_notes": "Let you ignore some penalties when shooting a bow too strong for you",
 							"tags": [
-								"Mental",
-								"Perk"
+								"Perk",
+								"Physical"
 							],
 							"disabled": true,
 							"base_points": 1,
+							"features": [
+								{
+									"type": "weapon_min_st_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Bow"
+									},
+									"level": {
+										"compare": "at_least",
+										"qualifier": 1
+									},
+									"amount": -1
+								},
+								{
+									"type": "weapon_min_st_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Bow"
+									},
+									"level": {
+										"compare": "at_least",
+										"qualifier": 2
+									},
+									"amount": -1
+								}
+							],
 							"calc": {
 								"points": 0
 							}

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Archer.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Archer.gct
@@ -1436,13 +1436,41 @@
 								"id": "tHAfA2lKnn4OT6QIN"
 							},
 							"name": "Strongbow",
-							"reference": "MA51",
+							"reference": "MA51, PU2:7, DFA35",
 							"local_notes": "Let you ignore some penalties when shooting a bow too strong for you",
 							"tags": [
-								"Mental",
-								"Perk"
+								"Perk",
+								"Physical"
 							],
 							"base_points": 1,
+							"features": [
+								{
+									"type": "weapon_min_st_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Bow"
+									},
+									"level": {
+										"compare": "at_least",
+										"qualifier": 1
+									},
+									"amount": -1
+								},
+								{
+									"type": "weapon_min_st_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Bow"
+									},
+									"level": {
+										"compare": "at_least",
+										"qualifier": 2
+									},
+									"amount": -1
+								}
+							],
 							"calc": {
 								"points": 1
 							}

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Scout.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Scout.gct
@@ -3810,7 +3810,7 @@
 								"id": "t5R0c_iujWXeXusIu"
 							},
 							"name": "Vow",
-							"reference": "B161",
+							"reference": "B160",
 							"local_notes": "@Subject@",
 							"tags": [
 								"Disadvantage",
@@ -3854,7 +3854,7 @@
 								"id": "t5R0c_iujWXeXusIu"
 							},
 							"name": "Vow",
-							"reference": "B161",
+							"reference": "B160",
 							"local_notes": "@Subject@",
 							"tags": [
 								"Disadvantage",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Scout.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Classes/Scout.gct
@@ -1687,13 +1687,41 @@
 								"id": "tHAfA2lKnn4OT6QIN"
 							},
 							"name": "Strongbow",
-							"reference": "MA51",
+							"reference": "MA51, PU2:7, DFA35",
 							"local_notes": "Let you ignore some penalties when shooting a bow too strong for you",
 							"tags": [
-								"Mental",
-								"Perk"
+								"Perk",
+								"Physical"
 							],
 							"base_points": 1,
+							"features": [
+								{
+									"type": "weapon_min_st_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Bow"
+									},
+									"level": {
+										"compare": "at_least",
+										"qualifier": 1
+									},
+									"amount": -1
+								},
+								{
+									"type": "weapon_min_st_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Bow"
+									},
+									"level": {
+										"compare": "at_least",
+										"qualifier": 2
+									},
+									"amount": -1
+								}
+							],
 							"calc": {
 								"points": 1
 							}

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Races/Wood Elf.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Races/Wood Elf.gct
@@ -470,25 +470,39 @@
 								"id": "tHAfA2lKnn4OT6QIN"
 							},
 							"name": "Strongbow",
-							"reference": "MA51",
+							"reference": "MA51, PU2:7, DFA35",
 							"local_notes": "Let you ignore some penalties when shooting a bow too strong for you",
 							"tags": [
-								"Mental",
-								"Perk"
+								"Perk",
+								"Physical"
 							],
 							"base_points": 1,
 							"features": [
 								{
-									"type": "weapon_effective_st_bonus",
+									"type": "weapon_min_st_bonus",
 									"selection_type": "weapons_with_required_skill",
 									"name": {
 										"compare": "is",
 										"qualifier": "Bow"
 									},
 									"level": {
-										"compare": "at_least"
+										"compare": "at_least",
+										"qualifier": 1
 									},
-									"amount": 2
+									"amount": -1
+								},
+								{
+									"type": "weapon_min_st_bonus",
+									"selection_type": "weapons_with_required_skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Bow"
+									},
+									"level": {
+										"compare": "at_least",
+										"qualifier": 2
+									},
+									"amount": -1
 								}
 							],
 							"calc": {

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Races/Wood Elf.gct
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Races/Wood Elf.gct
@@ -134,7 +134,7 @@
 								"path": "Basic Set/Basic Set Traits.adq",
 								"id": "tJTfFdHM7YI5IZR7I"
 							},
-							"name": "Resistant to Disease",
+							"name": "Resistant",
 							"reference": "B81,P71,MA47",
 							"tags": [
 								"Advantage",

--- a/Library/Martial Arts/Martial Arts Traits.adq
+++ b/Library/Martial Arts/Martial Arts Traits.adq
@@ -686,13 +686,41 @@
 		{
 			"id": "tHAfA2lKnn4OT6QIN",
 			"name": "Strongbow",
-			"reference": "MA51",
+			"reference": "MA51, PU2:7, DFA35",
 			"local_notes": "Let you ignore some penalties when shooting a bow too strong for you",
 			"tags": [
-				"Mental",
-				"Perk"
+				"Perk",
+				"Physical"
 			],
 			"base_points": 1,
+			"features": [
+				{
+					"type": "weapon_min_st_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Bow"
+					},
+					"level": {
+						"compare": "at_least",
+						"qualifier": 1
+					},
+					"amount": -1
+				},
+				{
+					"type": "weapon_min_st_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Bow"
+					},
+					"level": {
+						"compare": "at_least",
+						"qualifier": 2
+					},
+					"amount": -1
+				}
+			],
 			"calc": {
 				"points": 1
 			}

--- a/Library/Power Ups/Power Ups Traits.adq
+++ b/Library/Power Ups/Power Ups Traits.adq
@@ -12695,14 +12695,48 @@
 			}
 		},
 		{
-			"id": "tVKDScQm-E2N246eI",
+			"id": "tNwVb4V-A7nm7-uoH",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Martial Arts/Martial Arts Traits.adq",
+				"id": "tHAfA2lKnn4OT6QIN"
+			},
 			"name": "Strongbow",
-			"reference": "PU2:7",
+			"reference": "MA51, PU2:7, DFA35",
+			"local_notes": "Let you ignore some penalties when shooting a bow too strong for you",
 			"tags": [
 				"Perk",
 				"Physical"
 			],
 			"base_points": 1,
+			"features": [
+				{
+					"type": "weapon_min_st_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Bow"
+					},
+					"level": {
+						"compare": "at_least",
+						"qualifier": 1
+					},
+					"amount": -1
+				},
+				{
+					"type": "weapon_min_st_bonus",
+					"selection_type": "weapons_with_required_skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Bow"
+					},
+					"level": {
+						"compare": "at_least",
+						"qualifier": 2
+					},
+					"amount": -1
+				}
+			],
 			"calc": {
 				"points": 1
 			}

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Master Archer 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Master Archer 2.gct
@@ -140,13 +140,47 @@
 								},
 								{
 									"id": "tdP0zMkulgqEqwWaz",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Martial Arts/Martial Arts Traits.adq",
+										"id": "tHAfA2lKnn4OT6QIN"
+									},
 									"name": "Strongbow",
-									"reference": "DFA35",
+									"reference": "MA51, PU2:7, DFA35",
+									"local_notes": "Let you ignore some penalties when shooting a bow too strong for you",
 									"tags": [
-										"Advantage",
+										"Perk",
 										"Physical"
 									],
 									"base_points": 1,
+									"features": [
+										{
+											"type": "weapon_min_st_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Bow"
+											},
+											"level": {
+												"compare": "at_least",
+												"qualifier": 1
+											},
+											"amount": -1
+										},
+										{
+											"type": "weapon_min_st_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Bow"
+											},
+											"level": {
+												"compare": "at_least",
+												"qualifier": 2
+											},
+											"amount": -1
+										}
+									],
 									"calc": {
 										"points": 1
 									}

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Master Archer.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Master Archer.gct
@@ -134,13 +134,47 @@
 								},
 								{
 									"id": "tdP0zMkulgqEqwWaz",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Martial Arts/Martial Arts Traits.adq",
+										"id": "tHAfA2lKnn4OT6QIN"
+									},
 									"name": "Strongbow",
-									"reference": "DFA35",
+									"reference": "MA51, PU2:7, DFA35",
+									"local_notes": "Let you ignore some penalties when shooting a bow too strong for you",
 									"tags": [
-										"Advantage",
+										"Perk",
 										"Physical"
 									],
 									"base_points": 1,
+									"features": [
+										{
+											"type": "weapon_min_st_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Bow"
+											},
+											"level": {
+												"compare": "at_least",
+												"qualifier": 1
+											},
+											"amount": -1
+										},
+										{
+											"type": "weapon_min_st_bonus",
+											"selection_type": "weapons_with_required_skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Bow"
+											},
+											"level": {
+												"compare": "at_least",
+												"qualifier": 2
+											},
+											"amount": -1
+										}
+									],
 									"calc": {
 										"points": 1
 									}


### PR DESCRIPTION
Previously, Strongbow had features to reduce the ST required to wield bows only in the DFRPG Traits list.

This makes them identical across Martial Arts Traits, Power Ups Traits and Dungeon Fantasy RPG Traits, using the features, and sharing page references to their respective books.

It also updates all the templates that use Strongbow.