### PR TITLE
Psionics Traits: fix typo in name of Dream Projection

### DIFF
--- a/Library/Psionics/Psionics Traits.adq
+++ b/Library/Psionics/Psionics Traits.adq
@@ -2421,7 +2421,7 @@
 						},
 						{
 							"id": "tph-la_wrZgghoDVT",
-							"name": "Dream Projetion",
+							"name": "Dream Projection",
 							"reference": "PSI73",
 							"tags": [
 								"Dream Control",


### PR DESCRIPTION
It was "Dream Projetion", missing a c.