### PR TITLE
Add support for Ritual Magic from Basic Set and Magic

### DIFF
--- a/Library/Basic Set/Basic Set Skills.skl
+++ b/Library/Basic Set/Basic Set Skills.skl
@@ -21804,6 +21804,56 @@
 			"points": 1
 		},
 		{
+			"id": "sI_NfZOq4jCXMBCTM",
+			"name": "Ritual Magic College",
+			"reference": "B242,  M200",
+			"reference_highlight": "Ritual Magic",
+			"local_notes": "AKA \"College of @College@\" or \"Path of @College@\"",
+			"tags": [
+				"Magical",
+				"Occult"
+			],
+			"specialization": "@College@",
+			"difficulty": "iq/vh",
+			"defaults": [
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "@Core Skill@"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
+					"modifier": -6
+				}
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "@Core Skill@"
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "@Specialty@"
+						}
+					},
+					{
+						"type": "script_prereq",
+						"script": "(entity.exists && entity.skillLevel(\"@Core Skill@\", \"@Specialty@\") < self.level) ? \"Skill cannot exceed @Core Skill@ (@Specialty@)\" : \"\""
+					}
+				]
+			},
+			"points": 1
+		},
+		{
 			"id": "qgm1-ljR9tUfkrxFj",
 			"name": "Rope Up",
 			"reference": "B233",

--- a/Library/Basic Set/Basic Set Skills.skl
+++ b/Library/Basic Set/Basic Set Skills.skl
@@ -21801,6 +21801,56 @@
 			"points": 1
 		},
 		{
+			"id": "sI_NfZOq4jCXMBCTM",
+			"name": "Ritual Magic College",
+			"reference": "B242,  M200",
+			"reference_highlight": "Ritual Magic",
+			"local_notes": "AKA \"College of @College@\" or \"Path of @College@\"",
+			"tags": [
+				"Magical",
+				"Occult"
+			],
+			"specialization": "@College@",
+			"difficulty": "iq/vh",
+			"defaults": [
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "@Core Skill@"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
+					"modifier": -6
+				}
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "@Core Skill@"
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "@Specialty@"
+						}
+					},
+					{
+						"type": "script_prereq",
+						"script": "(entity.exists && entity.skillLevel(\"@Core Skill@\", \"@Specialty@\") < self.level) ? \"Skill cannot exceed @Core Skill@ (@Specialty@)\" : \"\""
+					}
+				]
+			},
+			"points": 1
+		},
+		{
 			"id": "qgm1-ljR9tUfkrxFj",
 			"name": "Rope Up",
 			"reference": "B233",

--- a/Library/Basic Set/Basic Set Skills.skl
+++ b/Library/Basic Set/Basic Set Skills.skl
@@ -1526,7 +1526,6 @@
 				"Entertainment"
 			],
 			"specialization": "@Art@",
-			"optional_specialization": "@Medium or Technique@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -1542,6 +1541,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@Medium or Technique@",
 			"points": 1
 		},
 		{
@@ -1627,7 +1627,6 @@
 				"Entertainment"
 			],
 			"specialization": "Body Art",
-			"optional_specialization": "@Medium or Technique@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -1691,6 +1690,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@Medium or Technique@",
 			"points": 1
 		},
 		{
@@ -1776,7 +1776,6 @@
 				"Entertainment"
 			],
 			"specialization": "Calligraphy",
-			"optional_specialization": "@Medium or Technique@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -1840,6 +1839,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@Medium or Technique@",
 			"points": 1
 		},
 		{
@@ -1925,7 +1925,6 @@
 				"Entertainment"
 			],
 			"specialization": "Drawing",
-			"optional_specialization": "@Medium or Technique@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -1989,6 +1988,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@Medium or Technique@",
 			"points": 1
 		},
 		{
@@ -2074,7 +2074,6 @@
 				"Entertainment"
 			],
 			"specialization": "Illumination",
-			"optional_specialization": "@Medium or Technique@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -2138,6 +2137,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@Medium or Technique@",
 			"points": 1
 		},
 		{
@@ -2175,7 +2175,6 @@
 				"Entertainment"
 			],
 			"specialization": "Illusion",
-			"optional_specialization": "@Medium or Technique@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -2191,6 +2190,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@Medium or Technique@",
 			"points": 1
 		},
 		{
@@ -2260,7 +2260,6 @@
 				"Entertainment"
 			],
 			"specialization": "Interior Decorating",
-			"optional_specialization": "@Medium or Technique@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -2308,6 +2307,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@Medium or Technique@",
 			"points": 1
 		},
 		{
@@ -2393,7 +2393,6 @@
 				"Entertainment"
 			],
 			"specialization": "Painting",
-			"optional_specialization": "@Medium or Technique@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -2457,6 +2456,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@Medium or Technique@",
 			"points": 1
 		},
 		{
@@ -2496,7 +2496,6 @@
 				"Entertainment"
 			],
 			"specialization": "Pottery",
-			"optional_specialization": "@Medium or Technique@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -2512,6 +2511,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@Medium or Technique@",
 			"points": 1
 		},
 		{
@@ -2581,7 +2581,6 @@
 				"Entertainment"
 			],
 			"specialization": "Scene Design",
-			"optional_specialization": "@Medium or Technique@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -2629,6 +2628,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@Medium or Technique@",
 			"points": 1
 		},
 		{
@@ -2668,7 +2668,6 @@
 				"Entertainment"
 			],
 			"specialization": "Sculpting",
-			"optional_specialization": "@Medium or Technique@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -2684,6 +2683,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@Medium or Technique@",
 			"points": 1
 		},
 		{
@@ -2755,7 +2755,6 @@
 				"Entertainment"
 			],
 			"specialization": "Woodworking",
-			"optional_specialization": "@Medium or Technique@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -2803,6 +2802,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@Medium or Technique@",
 			"points": 1
 		},
 		{
@@ -2848,7 +2848,6 @@
 			"tags": [
 				"Natural Science"
 			],
-			"optional_specialization": "Observational",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -2856,6 +2855,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "Observational",
 			"tech_level": "",
 			"points": 1
 		},
@@ -3353,7 +3353,6 @@
 				"Plant"
 			],
 			"specialization": "@Planet Type@",
-			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -3369,6 +3368,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"tech_level": "",
 			"points": 1
 		},
@@ -3381,7 +3381,6 @@
 				"Plant"
 			],
 			"specialization": "@Planet Type@",
-			"optional_specialization": "Biochemistry",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -3397,6 +3396,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "Biochemistry",
 			"tech_level": "",
 			"points": 1
 		},
@@ -3409,7 +3409,6 @@
 				"Plant"
 			],
 			"specialization": "@Planet Type@",
-			"optional_specialization": "Botany",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -3425,6 +3424,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "Botany",
 			"tech_level": "",
 			"points": 1
 		},
@@ -3437,7 +3437,6 @@
 				"Plant"
 			],
 			"specialization": "@Planet Type@",
-			"optional_specialization": "Ecology",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -3453,6 +3452,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "Ecology",
 			"tech_level": "",
 			"points": 1
 		},
@@ -3465,7 +3465,6 @@
 				"Plant"
 			],
 			"specialization": "@Planet Type@",
-			"optional_specialization": "Genetics",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -3481,6 +3480,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "Genetics",
 			"tech_level": "",
 			"points": 1
 		},
@@ -3493,7 +3493,6 @@
 				"Plant"
 			],
 			"specialization": "@Planet Type@",
-			"optional_specialization": "Marine Biology",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -3509,6 +3508,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "Marine Biology",
 			"tech_level": "",
 			"points": 1
 		},
@@ -3521,7 +3521,6 @@
 				"Plant"
 			],
 			"specialization": "@Planet Type@",
-			"optional_specialization": "Microbiology",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -3537,6 +3536,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "Microbiology",
 			"tech_level": "",
 			"points": 1
 		},
@@ -3548,7 +3548,6 @@
 				"Natural Science"
 			],
 			"specialization": "@Planet Type@",
-			"optional_specialization": "Zoology",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -3564,6 +3563,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "Zoology",
 			"tech_level": "",
 			"points": 1
 		},
@@ -3603,7 +3603,6 @@
 				"Plant"
 			],
 			"specialization": "Earthlike",
-			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -3619,6 +3618,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"tech_level": "",
 			"points": 1
 		},
@@ -3658,7 +3658,6 @@
 				"Plant"
 			],
 			"specialization": "Gas Giants",
-			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -3674,6 +3673,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"tech_level": "",
 			"points": 1
 		},
@@ -3713,7 +3713,6 @@
 				"Plant"
 			],
 			"specialization": "Hostile Terrestrial",
-			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -3729,6 +3728,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"tech_level": "",
 			"points": 1
 		},
@@ -3768,7 +3768,6 @@
 				"Plant"
 			],
 			"specialization": "Ice Dwarfs",
-			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -3784,6 +3783,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"tech_level": "",
 			"points": 1
 		},
@@ -3823,7 +3823,6 @@
 				"Plant"
 			],
 			"specialization": "Ice Worlds",
-			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -3839,6 +3838,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"tech_level": "",
 			"points": 1
 		},
@@ -3878,7 +3878,6 @@
 				"Plant"
 			],
 			"specialization": "Rock Worlds",
-			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -3894,6 +3893,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"tech_level": "",
 			"points": 1
 		},
@@ -4778,7 +4778,6 @@
 			"tags": [
 				"Natural Science"
 			],
-			"optional_specialization": "@Optional Specialty@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -4794,6 +4793,7 @@
 					"modifier": -3
 				}
 			],
+			"optional_specialization": "@Optional Specialty@",
 			"tech_level": "",
 			"points": 1
 		},
@@ -5428,7 +5428,6 @@
 			"tags": [
 				"Everyman"
 			],
-			"optional_specialization": "@Optional Specialty@",
 			"difficulty": "iq/a",
 			"defaults": [
 				{
@@ -5444,6 +5443,7 @@
 					"modifier": -5
 				}
 			],
+			"optional_specialization": "@Optional Specialty@",
 			"points": 1
 		},
 		{
@@ -5453,7 +5453,6 @@
 			"tags": [
 				"Everyman"
 			],
-			"optional_specialization": "Baking",
 			"difficulty": "iq/a",
 			"defaults": [
 				{
@@ -5469,6 +5468,7 @@
 					"modifier": -5
 				}
 			],
+			"optional_specialization": "Baking",
 			"points": 1
 		},
 		{
@@ -5478,7 +5478,6 @@
 			"tags": [
 				"Everyman"
 			],
-			"optional_specialization": "Beverage Making",
 			"difficulty": "iq/a",
 			"defaults": [
 				{
@@ -5494,6 +5493,7 @@
 					"modifier": -5
 				}
 			],
+			"optional_specialization": "Beverage Making",
 			"points": 1
 		},
 		{
@@ -5601,7 +5601,6 @@
 				"Military",
 				"Spy"
 			],
-			"optional_specialization": "Code Design",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -5617,6 +5616,7 @@
 					"modifier": -5
 				}
 			],
+			"optional_specialization": "Code Design",
 			"tech_level": "",
 			"points": 1
 		},
@@ -5628,7 +5628,6 @@
 				"Military",
 				"Spy"
 			],
-			"optional_specialization": "Cryptanalysis",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -5644,6 +5643,7 @@
 					"modifier": -5
 				}
 			],
+			"optional_specialization": "Cryptanalysis",
 			"tech_level": "",
 			"points": 1
 		},
@@ -14243,7 +14243,6 @@
 				"Police",
 				"Spy"
 			],
-			"optional_specialization": "@Optional Specialty@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -14259,6 +14258,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@Optional Specialty@",
 			"tech_level": "",
 			"points": 1
 		},
@@ -14271,7 +14271,6 @@
 				"Police",
 				"Spy"
 			],
-			"optional_specialization": "Traffic Analysis",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -14287,6 +14286,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "Traffic Analysis",
 			"tech_level": "",
 			"points": 1
 		},
@@ -14663,6 +14663,9 @@
 			"difficulty": "h",
 			"default": {
 				"type": "dx",
+				"name": {
+					"compare": "is"
+				},
 				"modifier": -2
 			},
 			"limit": 0,
@@ -15245,7 +15248,6 @@
 				"Scholarly",
 				"Social Sciences"
 			],
-			"optional_specialization": "@Optional Specialty@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -15253,6 +15255,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "@Optional Specialty@",
 			"points": 1
 		},
 		{
@@ -15579,7 +15582,6 @@
 			"tags": [
 				"Natural Science"
 			],
-			"optional_specialization": "Pure: @Optional specialty@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -15587,6 +15589,7 @@
 					"modifier": -6
 				}
 			],
+			"optional_specialization": "Pure: @Optional specialty@",
 			"tech_level": "",
 			"points": 1
 		},
@@ -17890,7 +17893,6 @@
 				"Business",
 				"Social"
 			],
-			"optional_specialization": "@Class of Goods@",
 			"difficulty": "iq/a",
 			"defaults": [
 				{
@@ -17914,6 +17916,7 @@
 					"modifier": -4
 				}
 			],
+			"optional_specialization": "@Class of Goods@",
 			"points": 1
 		},
 		{
@@ -19745,7 +19748,6 @@
 			"tags": [
 				"Natural Science"
 			],
-			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -19771,6 +19773,7 @@
 					}
 				]
 			},
+			"optional_specialization": "@TL 6+ Optional Specialty@",
 			"tech_level": "",
 			"points": 1
 		},
@@ -21072,7 +21075,6 @@
 				"Scholarly",
 				"Social"
 			],
-			"optional_specialization": "@Optional Specialty@",
 			"difficulty": "iq/a",
 			"defaults": [
 				{
@@ -21104,6 +21106,7 @@
 					"modifier": -5
 				}
 			],
+			"optional_specialization": "@Optional Specialty@",
 			"points": 1
 		},
 		{
@@ -21115,7 +21118,6 @@
 				"Scholarly",
 				"Social"
 			],
-			"optional_specialization": "Debate",
 			"difficulty": "iq/a",
 			"defaults": [
 				{
@@ -21147,6 +21149,7 @@
 					"modifier": -5
 				}
 			],
+			"optional_specialization": "Debate",
 			"points": 1
 		},
 		{
@@ -21158,7 +21161,6 @@
 				"Scholarly",
 				"Social"
 			],
-			"optional_specialization": "Oratory",
 			"difficulty": "iq/a",
 			"defaults": [
 				{
@@ -21190,6 +21192,7 @@
 					"modifier": -5
 				}
 			],
+			"optional_specialization": "Oratory",
 			"points": 1
 		},
 		{
@@ -21201,7 +21204,6 @@
 				"Scholarly",
 				"Social"
 			],
-			"optional_specialization": "Rhetoric",
 			"difficulty": "iq/a",
 			"defaults": [
 				{
@@ -21233,6 +21235,7 @@
 					"modifier": -5
 				}
 			],
+			"optional_specialization": "Rhetoric",
 			"points": 1
 		},
 		{
@@ -21244,7 +21247,6 @@
 				"Scholarly",
 				"Social"
 			],
-			"optional_specialization": "Punning",
 			"difficulty": "iq/a",
 			"defaults": [
 				{
@@ -21276,6 +21278,7 @@
 					"modifier": -5
 				}
 			],
+			"optional_specialization": "Punning",
 			"points": 1
 		},
 		{
@@ -21287,7 +21290,6 @@
 				"Scholarly",
 				"Social"
 			],
-			"optional_specialization": "Storytelling",
 			"difficulty": "iq/a",
 			"defaults": [
 				{
@@ -21319,6 +21321,7 @@
 					"modifier": -5
 				}
 			],
+			"optional_specialization": "Storytelling",
 			"points": 1
 		},
 		{
@@ -23929,7 +23932,6 @@
 			"tags": [
 				"Medical"
 			],
-			"optional_specialization": "@Body Part@",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -23987,6 +23989,7 @@
 					}
 				]
 			},
+			"optional_specialization": "@Body Part@",
 			"tech_level": "",
 			"points": 1
 		},
@@ -23997,7 +24000,6 @@
 			"tags": [
 				"Medical"
 			],
-			"optional_specialization": "@Surgery Type@",
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
@@ -24055,6 +24057,7 @@
 					}
 				]
 			},
+			"optional_specialization": "@Surgery Type@",
 			"tech_level": "",
 			"points": 1
 		},
@@ -27123,7 +27126,6 @@
 				"Animal",
 				"Medical"
 			],
-			"optional_specialization": "@Optional Specialty@",
 			"difficulty": "iq/h",
 			"defaults": [
 				{
@@ -27151,6 +27153,7 @@
 					"modifier": -5
 				}
 			],
+			"optional_specialization": "@Optional Specialty@",
 			"tech_level": "",
 			"points": 1
 		},

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -2077,7 +2077,10 @@
 					"reference": "B87",
 					"local_notes": "@One class: Mammals, Birds, etc.@",
 					"cost_adj": "-50%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@One class@"
+					}
 				},
 				{
 					"id": "mPb5yzAX_9PswxxPo",
@@ -2085,7 +2088,10 @@
 					"reference": "B87",
 					"local_notes": "@One family: Felines, Parrots, etc.@",
 					"cost_adj": "-60%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@One family@"
+					}
 				},
 				{
 					"id": "mw40SoSKMsftC66E0",
@@ -2093,7 +2099,10 @@
 					"reference": "B87",
 					"local_notes": "@One species: House Cats, Macaws, etc.@",
 					"cost_adj": "-80%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@One species@"
+					}
 				}
 			],
 			"base_points": 5,
@@ -6033,7 +6042,10 @@
 							"reference": "B47",
 							"local_notes": "@Direction: Back, Right, Left, Top or Underside@",
 							"cost_adj": "-40%",
-							"disabled": true
+							"disabled": true,
+							"calc": {
+								"resolved_notes": "@Direction@"
+							}
 						},
 						{
 							"id": "mdXLyaSji8XL7ogcm",
@@ -20012,7 +20024,10 @@
 					"reference": "B47, FUR13",
 					"local_notes": "@Direction: Back, Right, Left, Top or Underside@",
 					"cost_adj": "-40%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Direction@"
+					}
 				}
 			],
 			"base_points": 3,
@@ -24481,7 +24496,10 @@
 					"reference": "B74",
 					"local_notes": "@Common substance: Plastic, Stone, Wood, etc.@",
 					"cost_adj": "-30%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Common substance@"
+					}
 				},
 				{
 					"id": "mQ4yxsIJwb6o3orOx",
@@ -24489,7 +24507,10 @@
 					"reference": "B74",
 					"local_notes": "@Less common substance: Brick, Asphalt, etc.@",
 					"cost_adj": "-20%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Less common substance@"
+					}
 				},
 				{
 					"id": "mFn1dAN0j-nfAbTM6",
@@ -24497,7 +24518,10 @@
 					"reference": "B74",
 					"local_notes": "@One specific material: Lead, etc.@",
 					"cost_adj": "-10%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@One specific material@"
+					}
 				},
 				{
 					"id": "mPhcnGGAW2EfxudMb",
@@ -24505,7 +24529,10 @@
 					"reference": "B74",
 					"local_notes": "@Common substance: Brick, Metal, Wood, etc.@",
 					"cost_adj": "-40%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Common substance@"
+					}
 				},
 				{
 					"id": "mDWpQc14R-p5S8i_x",
@@ -24513,7 +24540,10 @@
 					"reference": "B74",
 					"local_notes": "@Uncommon substance: ice, adobe, etc.@",
 					"cost_adj": "-60%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Uncommon substance@"
+					}
 				},
 				{
 					"id": "m5r8rs0QH8TOXhcDq",
@@ -24521,7 +24551,10 @@
 					"reference": "B74",
 					"local_notes": "@Absurd substance: chocolate, silk, etc.@",
 					"cost_adj": "-80%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Absurd substance@"
+					}
 				}
 			],
 			"points_per_level": 10,
@@ -24966,7 +24999,10 @@
 					"reference": "P77",
 					"local_notes": "@Large Subset: Herbs, Trees@",
 					"cost_adj": "-50%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Large Subset@"
+					}
 				},
 				{
 					"id": "mirzqtzRf11pTbHFv",
@@ -24974,7 +25010,10 @@
 					"reference": "P77",
 					"local_notes": "@Small Subset: Evergreens, Medicinals@",
 					"cost_adj": "-60%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Small Subset@"
+					}
 				}
 			],
 			"base_points": 5,
@@ -25174,7 +25213,10 @@
 					"reference": "P67",
 					"local_notes": "@Basis: Carbon Based@",
 					"cost_adj": "-10%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Basis@"
+					}
 				},
 				{
 					"id": "msdVo96-lwklhRGNH",
@@ -25182,7 +25224,10 @@
 					"reference": "P67",
 					"local_notes": "@Planet of Origin: Terran@",
 					"cost_adj": "-20%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Planet of Origin@"
+					}
 				},
 				{
 					"id": "mOuLSb6bfqrMxCv34",
@@ -25190,7 +25235,10 @@
 					"reference": "P67",
 					"local_notes": "@Kingdom: Animalia@",
 					"cost_adj": "-25%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Kingdom@"
+					}
 				},
 				{
 					"id": "moDInHVznBPytTLtw",
@@ -25198,7 +25246,10 @@
 					"reference": "P67",
 					"local_notes": "@Class: Mammalia@",
 					"cost_adj": "-30%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Class@"
+					}
 				},
 				{
 					"id": "mRmsWOCf-5wqAc3D1",
@@ -25206,14 +25257,20 @@
 					"reference": "P67",
 					"local_notes": "@Species: Canis Lupus@",
 					"cost_adj": "-40%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Species@"
+					}
 				},
 				{
 					"id": "mmcLChNGYhHWXtn5M",
 					"name": "Specialized",
 					"local_notes": "@Family: Canidae@",
 					"cost_adj": "-35%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Family@"
+					}
 				},
 				{
 					"id": "mAP9nYw_3XnkV9qkq",
@@ -27677,7 +27734,10 @@
 					"reference": "B47, FUR13",
 					"local_notes": "@Direction: Back, Right, Left, Top or Underside@",
 					"cost_adj": "-40%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Direction@"
+					}
 				}
 			],
 			"base_points": 1,
@@ -28477,6 +28537,7 @@
 			"levels": 1,
 			"calc": {
 				"points": 5,
+				"resolved_notes": "@Type@: @Reason@",
 				"current_level": 1
 			}
 		},
@@ -28916,7 +28977,10 @@
 					"reference": "B87",
 					"local_notes": "@One class: Mammals, Birds, etc.@",
 					"cost_adj": "-50%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@One class@"
+					}
 				},
 				{
 					"id": "mOcRtg1r-KytcsdYm",
@@ -28924,7 +28988,10 @@
 					"reference": "B87",
 					"local_notes": "@One family: Felines, Parrots, etc.@",
 					"cost_adj": "-60%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@One family@"
+					}
 				},
 				{
 					"id": "muqzxuyupRQzTgZtA",
@@ -28932,7 +28999,10 @@
 					"reference": "B87",
 					"local_notes": "@One species: House Cats, Macaws, etc.@",
 					"cost_adj": "-80%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@One species@"
+					}
 				},
 				{
 					"id": "myNJXwBmTbYvxopmV",
@@ -28986,7 +29056,10 @@
 					"reference": "P77",
 					"local_notes": "@Large Subset: Herbs, Trees@",
 					"cost_adj": "-50%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Large Subset@"
+					}
 				},
 				{
 					"id": "mibsjtd5DpFbJhfe4",
@@ -28994,7 +29067,10 @@
 					"reference": "P77",
 					"local_notes": "@Small Subset: Evergreens, Medicinals@",
 					"cost_adj": "-60%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Small Subset@"
+					}
 				},
 				{
 					"id": "mk3t1DhUO2QQVmrA_",
@@ -29087,7 +29163,10 @@
 					"reference": "B87",
 					"local_notes": "@Type: Angels, Demons, Elementals, Faerie, Ghosts, etc.@",
 					"cost_adj": "-50%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Type@"
+					}
 				},
 				{
 					"id": "mtbPV82y2Xl_-A6zb",
@@ -34603,7 +34682,10 @@
 					"reference": "B99",
 					"local_notes": "@Type: Mental, Physical, Magical or Chi@",
 					"cost_adj": "-20%",
-					"disabled": true
+					"disabled": true,
+					"calc": {
+						"resolved_notes": "@Type@"
+					}
 				},
 				{
 					"id": "mIuMy_a5MFRMSDT9S",

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -26539,7 +26539,7 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "thaumatology"
+						"qualifier": "Ritual Magic College"
 					},
 					"amount": 1,
 					"per_level": true
@@ -26549,7 +26549,17 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "ritual magic"
+						"qualifier": "Thaumatology"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Ritual Magic"
 					},
 					"amount": 1,
 					"per_level": true

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -26682,7 +26682,7 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "thaumatology"
+						"qualifier": "Ritual Magic College"
 					},
 					"amount": 1,
 					"per_level": true
@@ -26692,7 +26692,17 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "ritual magic"
+						"qualifier": "Thaumatology"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Ritual Magic"
 					},
 					"amount": 1,
 					"per_level": true

--- a/Library/Basic Set/Characters/William Headley.gcs
+++ b/Library/Basic Set/Characters/William Headley.gcs
@@ -35,16 +35,185 @@
 			"bottom_margin": "0.25 in",
 			"right_margin": "0.25 in"
 		},
-		"block_layout": [
-			"reactions conditional_modifiers",
-			"melee",
-			"ranged",
-			"traits skills",
-			"spells",
-			"equipment",
-			"other_equipment",
-			"notes"
-		],
+		"layout": {
+			"root": {
+				"type": "column",
+				"weight": 1,
+				"children": [
+					{
+						"type": "row",
+						"weight": 1,
+						"children": [
+							{
+								"type": "block",
+								"key": "portrait",
+								"weight": 1,
+								"square": true
+							},
+							{
+								"type": "column",
+								"weight": 4.3,
+								"children": [
+									{
+										"type": "row",
+										"weight": 1,
+										"children": [
+											{
+												"type": "block",
+												"key": "identity",
+												"weight": 1.6
+											},
+											{
+												"type": "block",
+												"key": "miscellaneous",
+												"weight": 1
+											}
+										]
+									},
+									{
+										"type": "block",
+										"key": "description",
+										"weight": 1
+									}
+								]
+							},
+							{
+								"type": "block",
+								"key": "points",
+								"weight": 1
+							}
+						]
+					},
+					{
+						"type": "row",
+						"weight": 1,
+						"children": [
+							{
+								"type": "column",
+								"weight": 1.5,
+								"children": [
+									{
+										"type": "row",
+										"weight": 1,
+										"children": [
+											{
+												"type": "column",
+												"weight": 1,
+												"children": [
+													{
+														"type": "block",
+														"key": "primary_attributes",
+														"weight": 1
+													},
+													{
+														"type": "block",
+														"key": "damage",
+														"weight": 1
+													}
+												]
+											},
+											{
+												"type": "block",
+												"key": "secondary_attributes",
+												"weight": 1
+											}
+										]
+									},
+									{
+										"type": "block",
+										"key": "point_pools",
+										"weight": 1
+									}
+								]
+							},
+							{
+								"type": "block",
+								"key": "body",
+								"weight": 1
+							},
+							{
+								"type": "column",
+								"weight": 1.6,
+								"children": [
+									{
+										"type": "block",
+										"key": "encumbrance",
+										"weight": 1
+									},
+									{
+										"type": "block",
+										"key": "lifting",
+										"weight": 1
+									}
+								]
+							}
+						]
+					},
+					{
+						"type": "row",
+						"weight": 1,
+						"children": [
+							{
+								"type": "block",
+								"key": "reactions",
+								"weight": 1
+							},
+							{
+								"type": "block",
+								"key": "conditional_modifiers",
+								"weight": 1
+							}
+						]
+					},
+					{
+						"type": "block",
+						"key": "melee",
+						"weight": 1
+					},
+					{
+						"type": "block",
+						"key": "ranged",
+						"weight": 1
+					},
+					{
+						"type": "row",
+						"weight": 1,
+						"children": [
+							{
+								"type": "block",
+								"key": "traits",
+								"weight": 1
+							},
+							{
+								"type": "block",
+								"key": "skills",
+								"weight": 1
+							}
+						]
+					},
+					{
+						"type": "block",
+						"key": "spells",
+						"weight": 1
+					},
+					{
+						"type": "block",
+						"key": "equipment",
+						"weight": 1
+					},
+					{
+						"type": "block",
+						"key": "other_equipment",
+						"weight": 1
+					},
+					{
+						"type": "block",
+						"key": "notes",
+						"weight": 1
+					}
+				]
+			}
+		},
 		"attributes": [
 			{
 				"id": "st",
@@ -118,7 +287,7 @@
 			{
 				"id": "taste_smell",
 				"type": "integer",
-				"name": "Taste \u0026 Smell",
+				"name": "Taste & Smell",
 				"base": "$per",
 				"cost_per_point": 2
 			},
@@ -612,7 +781,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -637,15 +809,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -670,16 +851,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling",
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Kicking"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kicking"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate",
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							},
 							"modifier": -2
 						}
 					],
@@ -1746,13 +1936,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Paleontology",
-					"specialization": "Paleoanthropology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Paleontology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Paleoanthropology"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Sociology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Sociology"
+					},
 					"modifier": -3
 				}
 			],
@@ -1786,7 +1985,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1821,7 +2023,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Psychology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Psychology"
+					},
 					"modifier": -4
 				}
 			],
@@ -1856,19 +2061,31 @@
 				},
 				{
 					"type": "skill",
-					"name": "Body Language",
+					"name": {
+						"compare": "is",
+						"qualifier": "Body Language"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Psychology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Psychology"
+					},
 					"modifier": -4
 				}
 			],
 			"points": 2,
 			"defaulted_from": {
 				"type": "skill",
-				"name": "Psychology",
+				"name": {
+					"compare": "is",
+					"qualifier": "Psychology"
+				},
+				"specialization": {
+					"compare": "is"
+				},
 				"modifier": -4,
 				"level": 10,
 				"adjusted_level": 10,
@@ -1894,17 +2111,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "First Aid",
+					"name": {
+						"compare": "is",
+						"qualifier": "First Aid"
+					},
 					"modifier": -8
 				},
 				{
 					"type": "skill",
-					"name": "Physician",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Veterinary",
+					"name": {
+						"compare": "is",
+						"qualifier": "Veterinary"
+					},
 					"modifier": -5
 				}
 			],
@@ -1965,25 +2191,40 @@
 				},
 				{
 					"type": "skill",
-					"name": "Religious Ritual",
+					"name": {
+						"compare": "is",
+						"qualifier": "Religious Ritual"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Ritual Magic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Ritual Magic"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Theology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Theology"
+					},
 					"modifier": -3
 				}
 			],
 			"points": 1,
 			"defaulted_from": {
 				"type": "skill",
-				"name": "Ritual Magic",
-				"specialization": "Hermetic",
+				"name": {
+					"compare": "is",
+					"qualifier": "Ritual Magic"
+				},
+				"specialization": {
+					"compare": "is",
+					"qualifier": "Hermetic"
+				},
 				"modifier": -3,
 				"level": 13,
 				"adjusted_level": 13,
@@ -2028,22 +2269,37 @@
 				},
 				{
 					"type": "skill",
-					"name": "Esoteric Medicine"
+					"name": {
+						"compare": "is",
+						"qualifier": "Esoteric Medicine"
+					}
 				},
 				{
 					"type": "skill",
-					"name": "Physician"
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					}
 				},
 				{
 					"type": "skill",
-					"name": "Veterinary",
+					"name": {
+						"compare": "is",
+						"qualifier": "Veterinary"
+					},
 					"modifier": -4
 				}
 			],
 			"tech_level": "7",
 			"defaulted_from": {
 				"type": "skill",
-				"name": "Physician",
+				"name": {
+					"compare": "is",
+					"qualifier": "Physician"
+				},
+				"specialization": {
+					"compare": "is"
+				},
 				"level": 14,
 				"adjusted_level": 14,
 				"points": -14
@@ -2068,7 +2324,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Criminology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Criminology"
+					},
 					"modifier": -4
 				}
 			],
@@ -2076,7 +2335,13 @@
 			"points": 1,
 			"defaulted_from": {
 				"type": "skill",
-				"name": "Criminology",
+				"name": {
+					"compare": "is",
+					"qualifier": "Criminology"
+				},
+				"specialization": {
+					"compare": "is"
+				},
 				"modifier": -4,
 				"level": 12,
 				"adjusted_level": 12,
@@ -2105,56 +2370,110 @@
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Grenade Launcher",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Grenade Launcher"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Gyroc",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Gyroc"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Anti-Armor Weapon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Anti-Armor Weapon"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Machine Gun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Machine Gun"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Musket",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Musket"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Beam Weapons",
-					"specialization": "Pistol",
+					"name": {
+						"compare": "is",
+						"qualifier": "Beam Weapons"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Pistol"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Rifle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Rifle"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Shotgun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Shotgun"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Submachine Gun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Submachine Gun"
+					},
 					"modifier": -2
 				}
 			],
@@ -2290,12 +2609,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Chemistry",
+					"name": {
+						"compare": "is",
+						"qualifier": "Chemistry"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Physician",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					},
 					"modifier": -5
 				}
 			],
@@ -2328,12 +2653,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "First Aid",
+					"name": {
+						"compare": "is",
+						"qualifier": "First Aid"
+					},
 					"modifier": -11
 				},
 				{
 					"type": "skill",
-					"name": "Veterinary",
+					"name": {
+						"compare": "is",
+						"qualifier": "Veterinary"
+					},
 					"modifier": -5
 				}
 			],
@@ -2367,7 +2698,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Sociology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Sociology"
+					},
 					"modifier": -4
 				}
 			],
@@ -2401,17 +2735,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acting"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Performance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Performance"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Politics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Politics"
+					},
 					"modifier": -5
 				}
 			],
@@ -2444,7 +2787,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Writing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Writing"
+					},
 					"modifier": -3
 				}
 			],
@@ -2522,7 +2868,13 @@
 			"points": 4,
 			"defaulted_from": {
 				"type": "skill",
-				"name": "Writing",
+				"name": {
+					"compare": "is",
+					"qualifier": "Writing"
+				},
+				"specialization": {
+					"compare": "is"
+				},
 				"modifier": -3,
 				"level": 12,
 				"adjusted_level": 12,
@@ -2546,7 +2898,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Ritual Magic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Ritual Magic"
+					},
 					"modifier": -6
 				}
 			],
@@ -2675,8 +3030,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Religious Ritual",
-					"specialization": "Satanism",
+					"name": {
+						"compare": "is",
+						"qualifier": "Religious Ritual"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Satanism"
+					},
 					"modifier": -4
 				}
 			],
@@ -2782,8 +3143,7 @@
 			"prereq_count": 11,
 			"points": 6,
 			"calc": {
-				"level": 5,
-				"rsl": "-12"
+				"unsatisfied_reason": "Prerequisites have not been met:\n- Requires a skill named Ritual Magic (Necromancy)"
 			}
 		},
 		{
@@ -2808,8 +3168,7 @@
 			"prereq_count": 11,
 			"points": 5,
 			"calc": {
-				"level": 4,
-				"rsl": "-13"
+				"unsatisfied_reason": "Prerequisites have not been met:\n- Requires a skill named Ritual Magic (Gate)"
 			}
 		},
 		{
@@ -2834,8 +3193,7 @@
 			"prereq_count": 12,
 			"points": 6,
 			"calc": {
-				"level": 4,
-				"rsl": "-13"
+				"unsatisfied_reason": "Prerequisites have not been met:\n- Requires a skill named Ritual Magic (Gate)"
 			}
 		},
 		{
@@ -2843,12 +3201,12 @@
 			"name": "Sense Emotion",
 			"reference": "M45",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -2860,8 +3218,7 @@
 			"prereq_count": 1,
 			"points": 2,
 			"calc": {
-				"level": 11,
-				"rsl": "-6"
+				"unsatisfied_reason": "Prerequisites have not been met:\n- Requires a skill named Ritual Magic (Communication & Empathy)"
 			}
 		},
 		{
@@ -2886,8 +3243,7 @@
 			"prereq_count": 2,
 			"points": 2,
 			"calc": {
-				"level": 10,
-				"rsl": "-7"
+				"unsatisfied_reason": "Prerequisites have not been met:\n- Requires a skill named Ritual Magic (Necromancy)"
 			}
 		},
 		{
@@ -2895,12 +3251,12 @@
 			"name": "Truthsayer",
 			"reference": "M45",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Info",
@@ -2912,8 +3268,7 @@
 			"prereq_count": 2,
 			"points": 2,
 			"calc": {
-				"level": 10,
-				"rsl": "-7"
+				"unsatisfied_reason": "Prerequisites have not been met:\n- Requires a skill named Ritual Magic (Communication & Empathy)"
 			}
 		}
 	],

--- a/Library/Basic Set/Characters/William Headley.gcs
+++ b/Library/Basic Set/Characters/William Headley.gcs
@@ -118,7 +118,7 @@
 			{
 				"id": "taste_smell",
 				"type": "integer",
-				"name": "Taste \u0026 Smell",
+				"name": "Taste & Smell",
 				"base": "$per",
 				"cost_per_point": 2
 			},
@@ -612,7 +612,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -637,15 +640,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -670,16 +682,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling",
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Kicking"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kicking"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate",
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							},
 							"modifier": -2
 						}
 					],
@@ -1746,13 +1767,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Paleontology",
-					"specialization": "Paleoanthropology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Paleontology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Paleoanthropology"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Sociology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Sociology"
+					},
 					"modifier": -3
 				}
 			],
@@ -1786,7 +1816,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1821,7 +1854,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Psychology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Psychology"
+					},
 					"modifier": -4
 				}
 			],
@@ -1856,19 +1892,31 @@
 				},
 				{
 					"type": "skill",
-					"name": "Body Language",
+					"name": {
+						"compare": "is",
+						"qualifier": "Body Language"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Psychology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Psychology"
+					},
 					"modifier": -4
 				}
 			],
 			"points": 2,
 			"defaulted_from": {
 				"type": "skill",
-				"name": "Psychology",
+				"name": {
+					"compare": "is",
+					"qualifier": "Psychology"
+				},
+				"specialization": {
+					"compare": "is"
+				},
 				"modifier": -4,
 				"level": 10,
 				"adjusted_level": 10,
@@ -1894,17 +1942,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "First Aid",
+					"name": {
+						"compare": "is",
+						"qualifier": "First Aid"
+					},
 					"modifier": -8
 				},
 				{
 					"type": "skill",
-					"name": "Physician",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Veterinary",
+					"name": {
+						"compare": "is",
+						"qualifier": "Veterinary"
+					},
 					"modifier": -5
 				}
 			],
@@ -1965,25 +2022,40 @@
 				},
 				{
 					"type": "skill",
-					"name": "Religious Ritual",
+					"name": {
+						"compare": "is",
+						"qualifier": "Religious Ritual"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Ritual Magic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Ritual Magic"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Theology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Theology"
+					},
 					"modifier": -3
 				}
 			],
 			"points": 1,
 			"defaulted_from": {
 				"type": "skill",
-				"name": "Ritual Magic",
-				"specialization": "Hermetic",
+				"name": {
+					"compare": "is",
+					"qualifier": "Ritual Magic"
+				},
+				"specialization": {
+					"compare": "is",
+					"qualifier": "Hermetic"
+				},
 				"modifier": -3,
 				"level": 13,
 				"adjusted_level": 13,
@@ -2028,22 +2100,37 @@
 				},
 				{
 					"type": "skill",
-					"name": "Esoteric Medicine"
+					"name": {
+						"compare": "is",
+						"qualifier": "Esoteric Medicine"
+					}
 				},
 				{
 					"type": "skill",
-					"name": "Physician"
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					}
 				},
 				{
 					"type": "skill",
-					"name": "Veterinary",
+					"name": {
+						"compare": "is",
+						"qualifier": "Veterinary"
+					},
 					"modifier": -4
 				}
 			],
 			"tech_level": "7",
 			"defaulted_from": {
 				"type": "skill",
-				"name": "Physician",
+				"name": {
+					"compare": "is",
+					"qualifier": "Physician"
+				},
+				"specialization": {
+					"compare": "is"
+				},
 				"level": 14,
 				"adjusted_level": 14,
 				"points": -14
@@ -2068,7 +2155,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Criminology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Criminology"
+					},
 					"modifier": -4
 				}
 			],
@@ -2076,7 +2166,13 @@
 			"points": 1,
 			"defaulted_from": {
 				"type": "skill",
-				"name": "Criminology",
+				"name": {
+					"compare": "is",
+					"qualifier": "Criminology"
+				},
+				"specialization": {
+					"compare": "is"
+				},
 				"modifier": -4,
 				"level": 12,
 				"adjusted_level": 12,
@@ -2105,56 +2201,110 @@
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Grenade Launcher",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Grenade Launcher"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Gyroc",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Gyroc"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Anti-Armor Weapon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Anti-Armor Weapon"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Machine Gun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Machine Gun"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Musket",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Musket"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Beam Weapons",
-					"specialization": "Pistol",
+					"name": {
+						"compare": "is",
+						"qualifier": "Beam Weapons"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Pistol"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Rifle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Rifle"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Shotgun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Shotgun"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Submachine Gun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Submachine Gun"
+					},
 					"modifier": -2
 				}
 			],
@@ -2290,12 +2440,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Chemistry",
+					"name": {
+						"compare": "is",
+						"qualifier": "Chemistry"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Physician",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					},
 					"modifier": -5
 				}
 			],
@@ -2328,12 +2484,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "First Aid",
+					"name": {
+						"compare": "is",
+						"qualifier": "First Aid"
+					},
 					"modifier": -11
 				},
 				{
 					"type": "skill",
-					"name": "Veterinary",
+					"name": {
+						"compare": "is",
+						"qualifier": "Veterinary"
+					},
 					"modifier": -5
 				}
 			],
@@ -2367,7 +2529,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Sociology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Sociology"
+					},
 					"modifier": -4
 				}
 			],
@@ -2401,17 +2566,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acting"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Performance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Performance"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Politics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Politics"
+					},
 					"modifier": -5
 				}
 			],
@@ -2444,7 +2618,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Writing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Writing"
+					},
 					"modifier": -3
 				}
 			],
@@ -2522,7 +2699,13 @@
 			"points": 4,
 			"defaulted_from": {
 				"type": "skill",
-				"name": "Writing",
+				"name": {
+					"compare": "is",
+					"qualifier": "Writing"
+				},
+				"specialization": {
+					"compare": "is"
+				},
 				"modifier": -3,
 				"level": 12,
 				"adjusted_level": 12,
@@ -2546,7 +2729,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Ritual Magic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Ritual Magic"
+					},
 					"modifier": -6
 				}
 			],
@@ -2675,8 +2861,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Religious Ritual",
-					"specialization": "Satanism",
+					"name": {
+						"compare": "is",
+						"qualifier": "Religious Ritual"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Satanism"
+					},
 					"modifier": -4
 				}
 			],
@@ -2780,11 +2972,7 @@
 			"duration": "Permanent",
 			"base_skill": "Ritual Magic",
 			"prereq_count": 11,
-			"points": 6,
-			"calc": {
-				"level": 5,
-				"rsl": "-12"
-			}
+			"points": 6
 		},
 		{
 			"id": "rusQq9qdYGAijOGYb",
@@ -2806,11 +2994,7 @@
 			"duration": "1 hr",
 			"base_skill": "Ritual Magic",
 			"prereq_count": 11,
-			"points": 5,
-			"calc": {
-				"level": 4,
-				"rsl": "-13"
-			}
+			"points": 5
 		},
 		{
 			"id": "r9HF9fpnn1ZmYvJyB",
@@ -2832,23 +3016,19 @@
 			"duration": "Instant",
 			"base_skill": "Ritual Magic",
 			"prereq_count": 12,
-			"points": 6,
-			"calc": {
-				"level": 4,
-				"rsl": "-13"
-			}
+			"points": 6
 		},
 		{
 			"id": "rUyCP3ogxPS4O0_3D",
 			"name": "Sense Emotion",
 			"reference": "M45",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -2858,11 +3038,7 @@
 			"duration": "Instant",
 			"base_skill": "Ritual Magic",
 			"prereq_count": 1,
-			"points": 2,
-			"calc": {
-				"level": 11,
-				"rsl": "-6"
-			}
+			"points": 2
 		},
 		{
 			"id": "rPoiyyduReIPte_O4",
@@ -2884,23 +3060,19 @@
 			"duration": "Instant",
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
-			"points": 2,
-			"calc": {
-				"level": 10,
-				"rsl": "-7"
-			}
+			"points": 2
 		},
 		{
 			"id": "rz35yoi_CXcAJjZ3l",
 			"name": "Truthsayer",
 			"reference": "M45",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Info",
@@ -2910,11 +3082,7 @@
 			"duration": "Instant",
 			"base_skill": "Ritual Magic",
 			"prereq_count": 2,
-			"points": 2,
-			"calc": {
-				"level": 10,
-				"rsl": "-7"
-			}
+			"points": 2
 		}
 	],
 	"created_date": "2023-01-14T22:39:22Z",

--- a/Library/Basic Set/Characters/William Headley.gcs
+++ b/Library/Basic Set/Characters/William Headley.gcs
@@ -916,6 +916,11 @@
 		},
 		{
 			"id": "tg8pG9ktbTVktOQfs",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "t2aNupoayCBTTx_I3"
+			},
 			"name": "Ritual Magery",
 			"reference": "B66",
 			"tags": [
@@ -990,7 +995,7 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "thaumatology"
+						"qualifier": "Ritual Magic College"
 					},
 					"amount": 1,
 					"per_level": true
@@ -1000,7 +1005,17 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "ritual magic"
+						"qualifier": "Thaumatology"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Ritual Magic"
 					},
 					"amount": 1,
 					"per_level": true
@@ -3089,32 +3104,242 @@
 			"children": [
 				{
 					"id": "sgSuMjAqQSHz2KbSm",
-					"name": "Path of Communication and Empathy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Skills.skl",
+						"id": "sI_NfZOq4jCXMBCTM"
+					},
+					"name": "Ritual Magic College",
+					"reference": "B242,  M200",
+					"reference_highlight": "Ritual Magic",
+					"local_notes": "AKA \"College of @College@\" or \"Path of @College@\"",
+					"tags": [
+						"Magical",
+						"Occult"
+					],
+					"replacements": {
+						"College": "Communication & Empathy",
+						"Core Skill": "Ritual Magic",
+						"Specialty": "Hermetic"
+					},
+					"specialization": "@College@",
 					"difficulty": "iq/vh",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "@Core Skill@"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Specialty@"
+							},
+							"modifier": -6
+						}
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "@Core Skill@"
+								},
+								"specialization": {
+									"compare": "is",
+									"qualifier": "@Specialty@"
+								}
+							},
+							{
+								"type": "script_prereq",
+								"script": "(entity.exists && entity.skillLevel(\"@Core Skill@\", \"@Specialty@\") < self.level) ? \"Skill cannot exceed @Core Skill@ (@Specialty@)\" : \"\""
+							}
+						]
+					},
 					"points": 4,
+					"defaulted_from": {
+						"type": "skill",
+						"name": {
+							"compare": "is",
+							"qualifier": "Ritual Magic"
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Hermetic"
+						},
+						"modifier": -6,
+						"level": 10,
+						"adjusted_level": 10,
+						"points": -10
+					},
 					"calc": {
-						"level": 15,
-						"rsl": "IQ-1"
+						"level": 16,
+						"rsl": "IQ+0",
+						"resolved_notes": "AKA \"College of Communication & Empathy\" or \"Path of Communication & Empathy\""
 					}
 				},
 				{
 					"id": "svbjfs4J8SCzhgkmu",
-					"name": "Path of Gate",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Skills.skl",
+						"id": "sI_NfZOq4jCXMBCTM"
+					},
+					"name": "Ritual Magic College",
+					"reference": "B242,  M200",
+					"reference_highlight": "Ritual Magic",
+					"local_notes": "AKA \"College of @College@\" or \"Path of @College@\"",
+					"tags": [
+						"Magical",
+						"Occult"
+					],
+					"replacements": {
+						"College": "Gate",
+						"Core Skill": "Ritual Magic",
+						"Specialty": "Hermetic"
+					},
+					"specialization": "@College@",
 					"difficulty": "iq/vh",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "@Core Skill@"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Specialty@"
+							},
+							"modifier": -6
+						}
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "@Core Skill@"
+								},
+								"specialization": {
+									"compare": "is",
+									"qualifier": "@Specialty@"
+								}
+							},
+							{
+								"type": "script_prereq",
+								"script": "(entity.exists && entity.skillLevel(\"@Core Skill@\", \"@Specialty@\") < self.level) ? \"Skill cannot exceed @Core Skill@ (@Specialty@)\" : \"\""
+							}
+						]
+					},
 					"points": 8,
+					"defaulted_from": {
+						"type": "skill",
+						"name": {
+							"compare": "is",
+							"qualifier": "Ritual Magic"
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Hermetic"
+						},
+						"modifier": -6,
+						"level": 10,
+						"adjusted_level": 10,
+						"points": -10
+					},
 					"calc": {
-						"level": 16,
-						"rsl": "IQ+0"
+						"level": 17,
+						"rsl": "IQ+1",
+						"resolved_notes": "AKA \"College of Gate\" or \"Path of Gate\""
 					}
 				},
 				{
 					"id": "s5Lj0LZR3GnZ_VFy4",
-					"name": "Path of Necromancy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Skills.skl",
+						"id": "sI_NfZOq4jCXMBCTM"
+					},
+					"name": "Ritual Magic College",
+					"reference": "B242,  M200",
+					"reference_highlight": "Ritual Magic",
+					"local_notes": "AKA \"College of @College@\" or \"Path of @College@\"",
+					"tags": [
+						"Magical",
+						"Occult"
+					],
+					"replacements": {
+						"College": "Necromancy",
+						"Core Skill": "Ritual Magic",
+						"Specialty": "Hermetic"
+					},
+					"specialization": "@College@",
 					"difficulty": "iq/vh",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "@Core Skill@"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Specialty@"
+							},
+							"modifier": -6
+						}
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "@Core Skill@"
+								},
+								"specialization": {
+									"compare": "is",
+									"qualifier": "@Specialty@"
+								}
+							},
+							{
+								"type": "script_prereq",
+								"script": "(entity.exists && entity.skillLevel(\"@Core Skill@\", \"@Specialty@\") < self.level) ? \"Skill cannot exceed @Core Skill@ (@Specialty@)\" : \"\""
+							}
+						]
+					},
 					"points": 1,
+					"defaulted_from": {
+						"type": "skill",
+						"name": {
+							"compare": "is",
+							"qualifier": "Ritual Magic"
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Hermetic"
+						},
+						"modifier": -6,
+						"level": 10,
+						"adjusted_level": 10,
+						"points": -10
+					},
 					"calc": {
-						"level": 13,
-						"rsl": "IQ-3"
+						"level": 14,
+						"rsl": "IQ-2",
+						"resolved_notes": "AKA \"College of Necromancy\" or \"Path of Necromancy\""
 					}
 				}
 			]
@@ -3123,6 +3348,11 @@
 	"spells": [
 		{
 			"id": "ronRnA7wBMYxMlEsl",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Magic/Ritual Magic Spells.spl",
+				"id": "r23xXtIHIfcUDgl3H"
+			},
 			"name": "Banish",
 			"reference": "M156",
 			"tags": [
@@ -3139,15 +3369,21 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11,
 			"points": 6,
 			"calc": {
-				"unsatisfied_reason": "Prerequisites have not been met:\n- Requires a skill named Ritual Magic (Necromancy)"
+				"level": 8,
+				"rsl": "-6"
 			}
 		},
 		{
 			"id": "rusQq9qdYGAijOGYb",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Magic/Ritual Magic Spells.spl",
+				"id": "rsDbdPLUg1mn2Afnz"
+			},
 			"name": "Planar Summons (@Plane@)",
 			"reference": "M82",
 			"tags": [
@@ -3164,15 +3400,21 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11,
 			"points": 5,
 			"calc": {
-				"unsatisfied_reason": "Prerequisites have not been met:\n- Requires a skill named Ritual Magic (Gate)"
+				"level": 10,
+				"rsl": "-7"
 			}
 		},
 		{
 			"id": "r9HF9fpnn1ZmYvJyB",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Magic/Ritual Magic Spells.spl",
+				"id": "rtHAP3-uFU-uWvorq"
+			},
 			"name": "Plane Shift (@Plane@)",
 			"reference": "M83",
 			"tags": [
@@ -3189,15 +3431,21 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12,
 			"points": 6,
 			"calc": {
-				"unsatisfied_reason": "Prerequisites have not been met:\n- Requires a skill named Ritual Magic (Gate)"
+				"level": 10,
+				"rsl": "-7"
 			}
 		},
 		{
 			"id": "rUyCP3ogxPS4O0_3D",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Magic/Ritual Magic Spells.spl",
+				"id": "rJU5QX798IMkYXJQ4"
+			},
 			"name": "Sense Emotion",
 			"reference": "M45",
 			"tags": [
@@ -3214,15 +3462,21 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1,
 			"points": 2,
 			"calc": {
-				"unsatisfied_reason": "Prerequisites have not been met:\n- Requires a skill named Ritual Magic (Communication & Empathy)"
+				"level": 16,
+				"rsl": "+0"
 			}
 		},
 		{
 			"id": "rPoiyyduReIPte_O4",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Magic/Ritual Magic Spells.spl",
+				"id": "rfqo5eLiKRkPQAiIv"
+			},
 			"name": "Sense Spirit",
 			"reference": "M149",
 			"tags": [
@@ -3239,15 +3493,21 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2,
 			"points": 2,
 			"calc": {
-				"unsatisfied_reason": "Prerequisites have not been met:\n- Requires a skill named Ritual Magic (Necromancy)"
+				"level": 13,
+				"rsl": "-1"
 			}
 		},
 		{
 			"id": "rz35yoi_CXcAJjZ3l",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Magic/Ritual Magic Spells.spl",
+				"id": "r9p-kZkMJnJ_1G8RP"
+			},
 			"name": "Truthsayer",
 			"reference": "M45",
 			"tags": [
@@ -3264,16 +3524,17 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2,
 			"points": 2,
 			"calc": {
-				"unsatisfied_reason": "Prerequisites have not been met:\n- Requires a skill named Ritual Magic (Communication & Empathy)"
+				"level": 15,
+				"rsl": "-1"
 			}
 		}
 	],
 	"created_date": "2023-01-14T22:39:22Z",
-	"modified_date": "2025-06-02T15:59:03-07:00",
+	"modified_date": "2026-07-04T13:07:17+01:00",
 	"calc": {
 		"swing": "1d-1",
 		"thrust": "1d-2",

--- a/Library/Basic Set/Characters/William Headley.gcs
+++ b/Library/Basic Set/Characters/William Headley.gcs
@@ -747,6 +747,11 @@
 		},
 		{
 			"id": "tg8pG9ktbTVktOQfs",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Basic Set/Basic Set Traits.adq",
+				"id": "t2aNupoayCBTTx_I3"
+			},
 			"name": "Ritual Magery",
 			"reference": "B66",
 			"tags": [
@@ -821,7 +826,7 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "thaumatology"
+						"qualifier": "Ritual Magic College"
 					},
 					"amount": 1,
 					"per_level": true
@@ -831,7 +836,17 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "ritual magic"
+						"qualifier": "Thaumatology"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Ritual Magic"
 					},
 					"amount": 1,
 					"per_level": true
@@ -2920,32 +2935,242 @@
 			"children": [
 				{
 					"id": "sgSuMjAqQSHz2KbSm",
-					"name": "Path of Communication and Empathy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Skills.skl",
+						"id": "sI_NfZOq4jCXMBCTM"
+					},
+					"name": "Ritual Magic College",
+					"reference": "B242,  M200",
+					"reference_highlight": "Ritual Magic",
+					"local_notes": "AKA \"College of @College@\" or \"Path of @College@\"",
+					"tags": [
+						"Magical",
+						"Occult"
+					],
+					"replacements": {
+						"College": "Communication & Empathy",
+						"Core Skill": "Ritual Magic",
+						"Specialty": "Hermetic"
+					},
+					"specialization": "@College@",
 					"difficulty": "iq/vh",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "@Core Skill@"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Specialty@"
+							},
+							"modifier": -6
+						}
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "@Core Skill@"
+								},
+								"specialization": {
+									"compare": "is",
+									"qualifier": "@Specialty@"
+								}
+							},
+							{
+								"type": "script_prereq",
+								"script": "(entity.exists && entity.skillLevel(\"@Core Skill@\", \"@Specialty@\") < self.level) ? \"Skill cannot exceed @Core Skill@ (@Specialty@)\" : \"\""
+							}
+						]
+					},
 					"points": 4,
+					"defaulted_from": {
+						"type": "skill",
+						"name": {
+							"compare": "is",
+							"qualifier": "Ritual Magic"
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Hermetic"
+						},
+						"modifier": -6,
+						"level": 10,
+						"adjusted_level": 10,
+						"points": -10
+					},
 					"calc": {
-						"level": 15,
-						"rsl": "IQ-1"
+						"level": 16,
+						"rsl": "IQ+0",
+						"resolved_notes": "AKA \"College of Communication & Empathy\" or \"Path of Communication & Empathy\""
 					}
 				},
 				{
 					"id": "svbjfs4J8SCzhgkmu",
-					"name": "Path of Gate",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Skills.skl",
+						"id": "sI_NfZOq4jCXMBCTM"
+					},
+					"name": "Ritual Magic College",
+					"reference": "B242,  M200",
+					"reference_highlight": "Ritual Magic",
+					"local_notes": "AKA \"College of @College@\" or \"Path of @College@\"",
+					"tags": [
+						"Magical",
+						"Occult"
+					],
+					"replacements": {
+						"College": "Gate",
+						"Core Skill": "Ritual Magic",
+						"Specialty": "Hermetic"
+					},
+					"specialization": "@College@",
 					"difficulty": "iq/vh",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "@Core Skill@"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Specialty@"
+							},
+							"modifier": -6
+						}
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "@Core Skill@"
+								},
+								"specialization": {
+									"compare": "is",
+									"qualifier": "@Specialty@"
+								}
+							},
+							{
+								"type": "script_prereq",
+								"script": "(entity.exists && entity.skillLevel(\"@Core Skill@\", \"@Specialty@\") < self.level) ? \"Skill cannot exceed @Core Skill@ (@Specialty@)\" : \"\""
+							}
+						]
+					},
 					"points": 8,
+					"defaulted_from": {
+						"type": "skill",
+						"name": {
+							"compare": "is",
+							"qualifier": "Ritual Magic"
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Hermetic"
+						},
+						"modifier": -6,
+						"level": 10,
+						"adjusted_level": 10,
+						"points": -10
+					},
 					"calc": {
-						"level": 16,
-						"rsl": "IQ+0"
+						"level": 17,
+						"rsl": "IQ+1",
+						"resolved_notes": "AKA \"College of Gate\" or \"Path of Gate\""
 					}
 				},
 				{
 					"id": "s5Lj0LZR3GnZ_VFy4",
-					"name": "Path of Necromancy",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Skills.skl",
+						"id": "sI_NfZOq4jCXMBCTM"
+					},
+					"name": "Ritual Magic College",
+					"reference": "B242,  M200",
+					"reference_highlight": "Ritual Magic",
+					"local_notes": "AKA \"College of @College@\" or \"Path of @College@\"",
+					"tags": [
+						"Magical",
+						"Occult"
+					],
+					"replacements": {
+						"College": "Necromancy",
+						"Core Skill": "Ritual Magic",
+						"Specialty": "Hermetic"
+					},
+					"specialization": "@College@",
 					"difficulty": "iq/vh",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "@Core Skill@"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Specialty@"
+							},
+							"modifier": -6
+						}
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "skill_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "@Core Skill@"
+								},
+								"specialization": {
+									"compare": "is",
+									"qualifier": "@Specialty@"
+								}
+							},
+							{
+								"type": "script_prereq",
+								"script": "(entity.exists && entity.skillLevel(\"@Core Skill@\", \"@Specialty@\") < self.level) ? \"Skill cannot exceed @Core Skill@ (@Specialty@)\" : \"\""
+							}
+						]
+					},
 					"points": 1,
+					"defaulted_from": {
+						"type": "skill",
+						"name": {
+							"compare": "is",
+							"qualifier": "Ritual Magic"
+						},
+						"specialization": {
+							"compare": "is",
+							"qualifier": "Hermetic"
+						},
+						"modifier": -6,
+						"level": 10,
+						"adjusted_level": 10,
+						"points": -10
+					},
 					"calc": {
-						"level": 13,
-						"rsl": "IQ-3"
+						"level": 14,
+						"rsl": "IQ-2",
+						"resolved_notes": "AKA \"College of Necromancy\" or \"Path of Necromancy\""
 					}
 				}
 			]
@@ -2954,6 +3179,11 @@
 	"spells": [
 		{
 			"id": "ronRnA7wBMYxMlEsl",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Magic/Ritual Magic Spells.spl",
+				"id": "r23xXtIHIfcUDgl3H"
+			},
 			"name": "Banish",
 			"reference": "M156",
 			"tags": [
@@ -2970,12 +3200,21 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11,
-			"points": 6
+			"points": 6,
+			"calc": {
+				"level": 8,
+				"rsl": "-6"
+			}
 		},
 		{
 			"id": "rusQq9qdYGAijOGYb",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Magic/Ritual Magic Spells.spl",
+				"id": "rsDbdPLUg1mn2Afnz"
+			},
 			"name": "Planar Summons (@Plane@)",
 			"reference": "M82",
 			"tags": [
@@ -2992,12 +3231,21 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11,
-			"points": 5
+			"points": 5,
+			"calc": {
+				"level": 10,
+				"rsl": "-7"
+			}
 		},
 		{
 			"id": "r9HF9fpnn1ZmYvJyB",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Magic/Ritual Magic Spells.spl",
+				"id": "rtHAP3-uFU-uWvorq"
+			},
 			"name": "Plane Shift (@Plane@)",
 			"reference": "M83",
 			"tags": [
@@ -3014,12 +3262,21 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12,
-			"points": 6
+			"points": 6,
+			"calc": {
+				"level": 10,
+				"rsl": "-7"
+			}
 		},
 		{
 			"id": "rUyCP3ogxPS4O0_3D",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Magic/Ritual Magic Spells.spl",
+				"id": "rJU5QX798IMkYXJQ4"
+			},
 			"name": "Sense Emotion",
 			"reference": "M45",
 			"tags": [
@@ -3036,12 +3293,21 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1,
-			"points": 2
+			"points": 2,
+			"calc": {
+				"level": 16,
+				"rsl": "+0"
+			}
 		},
 		{
 			"id": "rPoiyyduReIPte_O4",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Magic/Ritual Magic Spells.spl",
+				"id": "rfqo5eLiKRkPQAiIv"
+			},
 			"name": "Sense Spirit",
 			"reference": "M149",
 			"tags": [
@@ -3058,12 +3324,21 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2,
-			"points": 2
+			"points": 2,
+			"calc": {
+				"level": 13,
+				"rsl": "-1"
+			}
 		},
 		{
 			"id": "rz35yoi_CXcAJjZ3l",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Magic/Ritual Magic Spells.spl",
+				"id": "r9p-kZkMJnJ_1G8RP"
+			},
 			"name": "Truthsayer",
 			"reference": "M45",
 			"tags": [
@@ -3080,13 +3355,18 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2,
-			"points": 2
+			"points": 2,
+			"calc": {
+				"level": 15,
+				"rsl": "-1"
+			}
 		}
 	],
+	"equipment": [],
 	"created_date": "2023-01-14T22:39:22Z",
-	"modified_date": "2025-06-02T15:59:03-07:00",
+	"modified_date": "2026-07-04T13:07:17+01:00",
 	"calc": {
 		"swing": "1d-1",
 		"thrust": "1d-2",

--- a/Library/Magic/Ritual Magic Spells.spl
+++ b/Library/Magic/Ritual Magic Spells.spl
@@ -19,7 +19,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 28
 		},
 		{
@@ -40,7 +40,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -61,7 +61,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11,
 			"weapons": [
 				{
@@ -108,7 +108,7 @@
 			"maintenance_cost": "1-3",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11,
 			"weapons": [
 				{
@@ -155,7 +155,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -176,7 +176,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -197,7 +197,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -218,7 +218,7 @@
 			"maintenance_cost": "6",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -239,7 +239,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3,
 			"weapons": [
 				{
@@ -288,7 +288,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -311,7 +311,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "2 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -332,7 +332,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 week",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -353,7 +353,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -374,7 +374,7 @@
 			"maintenance_cost": "6",
 			"casting_time": "2 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -395,7 +395,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "2d days",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -416,7 +416,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -439,7 +439,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -460,7 +460,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -481,7 +481,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -502,7 +502,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -523,7 +523,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min/pt",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -544,7 +544,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -565,7 +565,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -586,7 +586,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -607,7 +607,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -628,7 +628,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -649,7 +649,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -671,7 +671,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "sec=cost",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17,
 			"tech_level": ""
 		},
@@ -693,7 +693,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -715,7 +715,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -736,7 +736,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "2 sec",
 			"duration": "5 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -757,7 +757,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -777,7 +777,7 @@
 			"casting_cost": "Varies",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -799,7 +799,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -820,7 +820,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -841,7 +841,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -864,7 +864,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -885,7 +885,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "6 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -906,7 +906,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -927,7 +927,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -948,7 +948,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -969,7 +969,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -991,7 +991,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12,
 			"tech_level": ""
 		},
@@ -1015,7 +1015,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1036,7 +1036,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1059,7 +1059,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1-3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9,
 			"weapons": [
 				{
@@ -1093,7 +1093,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -1114,7 +1114,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -1137,7 +1137,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "30 sec",
 			"duration": "24 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -1158,7 +1158,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Until next call",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -1179,7 +1179,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1200,7 +1200,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1221,7 +1221,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -1242,7 +1242,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -1263,7 +1263,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -1284,7 +1284,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 hr or reaction roll",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rSwyLWTKKYznbJmt5",
@@ -1304,7 +1304,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "4 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1325,7 +1325,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -1346,7 +1346,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -1367,7 +1367,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -1388,7 +1388,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 21
 		},
 		{
@@ -1409,7 +1409,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "min=cost",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 22
 		},
 		{
@@ -1430,7 +1430,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "1 Crop or Season",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -1451,7 +1451,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "1 Crop or Season",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1474,7 +1474,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -1497,7 +1497,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -1518,7 +1518,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -1539,7 +1539,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1560,7 +1560,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -1581,7 +1581,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -1602,7 +1602,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -1656,7 +1656,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -1679,7 +1679,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9,
 			"weapons": [
 				{
@@ -1734,7 +1734,7 @@
 			"maintenance_cost": "6",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -1756,7 +1756,7 @@
 			"maintenance_cost": "5",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -1777,7 +1777,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -1798,7 +1798,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -1819,7 +1819,7 @@
 			"maintenance_cost": "5",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -1840,7 +1840,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1861,7 +1861,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -1882,7 +1882,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -1903,7 +1903,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "-",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -1924,7 +1924,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -1945,7 +1945,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1966,7 +1966,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1987,7 +1987,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -2008,7 +2008,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -2029,7 +2029,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -2050,7 +2050,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -2071,7 +2071,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -2094,7 +2094,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -2115,7 +2115,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -2163,7 +2163,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -2184,7 +2184,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14,
 			"weapons": [
 				{
@@ -2233,7 +2233,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -2254,7 +2254,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -2277,7 +2277,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14,
 			"weapons": [
 				{
@@ -2332,7 +2332,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -2387,7 +2387,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -2408,7 +2408,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -2429,7 +2429,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -2450,7 +2450,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 min",
 			"duration": "until used",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -2471,7 +2471,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -2492,7 +2492,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "30 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -2513,7 +2513,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -2534,7 +2534,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -2555,7 +2555,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r3N9PqfMRs1xSNAs3",
@@ -2577,7 +2577,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 sec/100 miles",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -2600,7 +2600,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -2623,7 +2623,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -2644,7 +2644,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -2665,7 +2665,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "1 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -2686,7 +2686,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -2707,7 +2707,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -2728,7 +2728,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -2749,7 +2749,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -2770,7 +2770,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "5 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -2791,7 +2791,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "5 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -2812,7 +2812,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -2833,7 +2833,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "4 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -2854,7 +2854,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "3 sec",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -2877,7 +2877,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -2924,7 +2924,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -2946,7 +2946,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2,
 			"tech_level": ""
 		},
@@ -2968,7 +2968,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "2d days",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -2989,7 +2989,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "2d days",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -3010,7 +3010,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "2d days",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -3031,7 +3031,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "3 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -3052,7 +3052,7 @@
 			"maintenance_cost": "Special",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -3073,7 +3073,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19
 		},
 		{
@@ -3094,7 +3094,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -3115,7 +3115,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -3136,7 +3136,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -3157,7 +3157,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -3178,7 +3178,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "5 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -3199,7 +3199,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -3220,7 +3220,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -3240,7 +3240,7 @@
 			"casting_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -3261,7 +3261,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Indefinite #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -3282,7 +3282,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -3305,7 +3305,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -3328,7 +3328,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -3349,7 +3349,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -3370,7 +3370,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -3391,7 +3391,7 @@
 			"maintenance_cost": "6",
 			"casting_time": "3 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 21
 		},
 		{
@@ -3411,7 +3411,7 @@
 			"casting_cost": "Half countered spell",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -3432,7 +3432,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -3453,7 +3453,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "5 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -3474,7 +3474,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Special",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -3495,7 +3495,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec/cost",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -3516,7 +3516,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "5 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -3537,7 +3537,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -3558,7 +3558,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Special",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -3579,7 +3579,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1,
 			"weapons": [
 				{
@@ -3614,7 +3614,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Special",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -3635,7 +3635,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -3657,7 +3657,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10,
 			"tech_level": ""
 		},
@@ -3679,7 +3679,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "Varies",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 24
 		},
 		{
@@ -3700,7 +3700,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -3721,7 +3721,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 22
 		},
 		{
@@ -3742,7 +3742,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec/cost",
 			"duration": "While touching someone",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -3763,7 +3763,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -3784,7 +3784,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -3805,7 +3805,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -3826,7 +3826,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "5 min #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -3847,7 +3847,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19
 		},
 		{
@@ -3868,7 +3868,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -3889,7 +3889,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Special",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -3910,7 +3910,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 21
 		},
 		{
@@ -3931,7 +3931,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -3954,7 +3954,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -3977,7 +3977,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -3998,7 +3998,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2/4/6 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 22
 		},
 		{
@@ -4019,7 +4019,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -4040,7 +4040,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -4061,7 +4061,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -4082,7 +4082,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -4103,7 +4103,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -4124,7 +4124,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -4145,7 +4145,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -4166,7 +4166,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9,
 			"weapons": [
 				{
@@ -4221,7 +4221,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "ricZalAkihamdu0Oh",
@@ -4241,7 +4241,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Semi-permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -4262,7 +4262,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -4283,7 +4283,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -4304,7 +4304,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -4325,7 +4325,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -4346,7 +4346,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -4369,7 +4369,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -4390,7 +4390,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -4425,7 +4425,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "2 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -4446,7 +4446,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "4 sec",
 			"duration": "Indefinite #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -4467,7 +4467,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -4488,7 +4488,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -4509,7 +4509,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -4532,7 +4532,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "-",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -4553,7 +4553,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -4575,7 +4575,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18,
 			"weapons": [
 				{
@@ -4609,7 +4609,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -4630,7 +4630,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -4651,7 +4651,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -4672,7 +4672,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "sec=cost",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -4693,7 +4693,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -4714,7 +4714,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -4735,7 +4735,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "5 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -4758,7 +4758,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -4781,7 +4781,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -4802,7 +4802,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -4823,7 +4823,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -4844,7 +4844,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -4865,7 +4865,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -4886,7 +4886,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -4907,7 +4907,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -4928,7 +4928,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -4949,7 +4949,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -4970,7 +4970,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -4991,7 +4991,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5012,7 +5012,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5033,7 +5033,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5054,7 +5054,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5075,7 +5075,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5096,7 +5096,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5117,7 +5117,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 38
 		},
 		{
@@ -5138,7 +5138,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 24
 		},
 		{
@@ -5159,7 +5159,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -5181,7 +5181,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 23,
 			"tech_level": ""
 		},
@@ -5203,7 +5203,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -5224,7 +5224,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -5245,7 +5245,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -5266,7 +5266,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -5287,7 +5287,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -5308,7 +5308,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r_5Qh2yS_cQQ_HRx_",
@@ -5328,7 +5328,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rHSTJorsaZ8mXZCEx",
@@ -5348,7 +5348,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rrhtA63HB_tocOYAx",
@@ -5368,7 +5368,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rcRwZvLkQVaq1VOj9",
@@ -5388,7 +5388,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rs5ntMZA0Nuj-LUsp",
@@ -5408,7 +5408,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -5429,7 +5429,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec/cost",
 			"duration": "While touching someone",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -5450,7 +5450,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "2d days",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -5473,7 +5473,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -5494,7 +5494,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -5517,7 +5517,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -5540,7 +5540,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "30 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -5561,7 +5561,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "30 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -5584,7 +5584,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -5605,7 +5605,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -5626,7 +5626,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -5647,7 +5647,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -5668,7 +5668,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -5689,7 +5689,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 week",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -5710,7 +5710,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -5731,7 +5731,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "3 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -5752,7 +5752,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -5773,7 +5773,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -5794,7 +5794,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -5815,7 +5815,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -5836,7 +5836,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -5857,7 +5857,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "1 sec",
 			"duration": "5 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -5878,7 +5878,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -5899,7 +5899,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -5920,7 +5920,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -5941,7 +5941,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6,
 			"weapons": [
 				{
@@ -5976,7 +5976,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -5998,7 +5998,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7,
 			"tech_level": ""
 		},
@@ -6020,7 +6020,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -6041,7 +6041,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -6062,7 +6062,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "30 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -6083,7 +6083,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9,
 			"weapons": [
 				{
@@ -6136,7 +6136,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -6158,7 +6158,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10,
 			"weapons": [
 				{
@@ -6192,7 +6192,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -6241,7 +6241,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -6288,7 +6288,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "3 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -6309,7 +6309,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -6331,7 +6331,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -6352,7 +6352,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "10 sec",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -6373,7 +6373,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "5 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -6394,7 +6394,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -6415,7 +6415,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -6436,7 +6436,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -6459,7 +6459,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -6480,7 +6480,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -6501,7 +6501,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -6522,7 +6522,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -6543,7 +6543,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -6566,7 +6566,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -6587,7 +6587,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -6608,7 +6608,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -6629,7 +6629,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1-5 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -6664,7 +6664,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4,
 			"weapons": [
 				{
@@ -6711,7 +6711,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -6732,7 +6732,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3,
 			"weapons": [
 				{
@@ -6780,7 +6780,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -6802,7 +6802,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -6824,7 +6824,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -6846,7 +6846,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2,
 			"weapons": [
 				{
@@ -6880,7 +6880,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -6901,7 +6901,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -6922,7 +6922,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -6943,7 +6943,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "5 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -6966,7 +6966,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -6987,7 +6987,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -7008,7 +7008,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -7029,7 +7029,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -7050,7 +7050,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -7071,7 +7071,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -7092,7 +7092,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -7113,7 +7113,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -7136,7 +7136,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -7157,7 +7157,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -7178,7 +7178,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -7199,7 +7199,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -7222,7 +7222,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -7243,7 +7243,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6,
 			"weapons": [
 				{
@@ -7277,7 +7277,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -7298,7 +7298,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -7319,7 +7319,7 @@
 			"maintenance_cost": "6",
 			"casting_time": "3 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -7340,7 +7340,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "5 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -7361,7 +7361,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -7382,7 +7382,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -7403,7 +7403,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -7424,7 +7424,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -7445,7 +7445,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "5 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -7467,7 +7467,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12,
 			"tech_level": ""
 		},
@@ -7489,7 +7489,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "2d days",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -7510,7 +7510,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "2d days",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -7531,7 +7531,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -7552,7 +7552,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -7573,7 +7573,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -7594,7 +7594,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -7615,7 +7615,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -7636,7 +7636,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -7657,7 +7657,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -7678,7 +7678,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -7699,7 +7699,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -7720,7 +7720,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 26
 		},
 		{
@@ -7741,7 +7741,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -7762,7 +7762,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -7783,7 +7783,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Special",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 41
 		},
 		{
@@ -7807,7 +7807,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -7842,7 +7842,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "5 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -7863,7 +7863,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -7884,7 +7884,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -7905,7 +7905,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 month",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -7926,7 +7926,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19
 		},
 		{
@@ -7947,7 +7947,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -7968,7 +7968,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rFZSJl-qoKYhAu1Et",
@@ -7988,7 +7988,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -8009,7 +8009,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -8030,7 +8030,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -8051,7 +8051,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Up to 8 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -8072,7 +8072,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "1 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8093,7 +8093,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -8114,7 +8114,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -8135,7 +8135,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -8156,7 +8156,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 29
 		},
 		{
@@ -8177,7 +8177,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8198,7 +8198,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8219,7 +8219,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 21
 		},
 		{
@@ -8240,7 +8240,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -8260,7 +8260,7 @@
 			"casting_cost": "Varies",
 			"casting_time": "1 sec/pt",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -8281,7 +8281,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -8302,7 +8302,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -8323,7 +8323,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -8346,7 +8346,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Until eat/rest",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -8367,7 +8367,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "10 sec #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -8388,7 +8388,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8409,7 +8409,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -8456,7 +8456,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -8477,7 +8477,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4,
 			"weapons": [
 				{
@@ -8524,7 +8524,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12,
 			"weapons": [
 				{
@@ -8572,7 +8572,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -8593,7 +8593,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec #",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -8649,7 +8649,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8671,7 +8671,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r8u6b1ZBiC3yDY0Wg",
@@ -8691,7 +8691,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -8713,7 +8713,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rfHc-oyGhzlFkJjAw",
@@ -8733,7 +8733,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -8754,7 +8754,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r5W3vMwQWPc9GzLfr",
@@ -8774,7 +8774,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Until illusion ends",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8795,7 +8795,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8818,7 +8818,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -8839,7 +8839,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -8860,7 +8860,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -8881,7 +8881,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "3 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -8902,7 +8902,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8923,7 +8923,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -8944,7 +8944,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -8967,7 +8967,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -8988,7 +8988,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -9009,7 +9009,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r8-WBPvUId3uKgU5U",
@@ -9029,7 +9029,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -9050,7 +9050,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -9071,7 +9071,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -9092,7 +9092,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -9113,7 +9113,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -9134,7 +9134,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -9155,7 +9155,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -9177,7 +9177,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -9198,7 +9198,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Until scratched",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rQl4kXtcU2utiu6Nw",
@@ -9218,7 +9218,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -9239,7 +9239,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rhavqgnveyVegMQTX",
@@ -9261,7 +9261,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rY2N1rZB2AOE2NZ77",
@@ -9281,7 +9281,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rqStM02UE1TUTTUf7",
@@ -9301,7 +9301,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r9dae0EWZmPEIl6uY",
@@ -9321,7 +9321,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r3ltVFT9dvk1J4T1E",
@@ -9341,7 +9341,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -9362,7 +9362,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -9383,7 +9383,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -9406,7 +9406,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "15 sec",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -9427,7 +9427,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -9448,7 +9448,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 22
 		},
 		{
@@ -9469,7 +9469,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -9490,7 +9490,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -9512,7 +9512,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3,
 			"tech_level": ""
 		},
@@ -9534,7 +9534,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -9555,7 +9555,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -9576,7 +9576,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -9597,7 +9597,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -9618,7 +9618,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Until fulfilled",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -9639,7 +9639,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Special",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -9660,7 +9660,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -9683,7 +9683,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 28
 		},
 		{
@@ -9704,7 +9704,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r7IlFbvHZEygEvMY3",
@@ -9725,7 +9725,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2,
 			"weapons": [
 				{
@@ -9771,7 +9771,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -9792,7 +9792,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -9813,7 +9813,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "3 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -9836,7 +9836,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7,
 			"weapons": [
 				{
@@ -9885,7 +9885,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -9909,7 +9909,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -9932,7 +9932,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9,
 			"weapons": [
 				{
@@ -9982,7 +9982,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -10005,7 +10005,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "2 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -10060,7 +10060,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -10082,7 +10082,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "4 hrs",
 			"duration": "Until triggered",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19
 		},
 		{
@@ -10103,7 +10103,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -10124,7 +10124,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -10145,7 +10145,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -10166,7 +10166,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -10187,7 +10187,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "2 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -10208,7 +10208,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -10230,7 +10230,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11,
 			"tech_level": ""
 		},
@@ -10253,7 +10253,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "30 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16,
 			"tech_level": ""
 		},
@@ -10277,7 +10277,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13,
 			"tech_level": ""
 		},
@@ -10300,7 +10300,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12,
 			"tech_level": ""
 		},
@@ -10322,7 +10322,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -10343,7 +10343,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -10364,7 +10364,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -10385,7 +10385,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -10406,7 +10406,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -10427,7 +10427,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "4 sec",
 			"duration": "6 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -10448,7 +10448,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -10470,7 +10470,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -10491,7 +10491,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -10512,7 +10512,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -10533,7 +10533,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Indefinite #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -10555,7 +10555,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14,
 			"tech_level": ""
 		},
@@ -10577,7 +10577,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -10598,7 +10598,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -10619,7 +10619,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -10640,7 +10640,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "sec=cost",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -10661,7 +10661,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "sec=cost",
 			"duration": "Until awakened",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -10682,7 +10682,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "sec=cost",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -10703,7 +10703,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min per area",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -10724,7 +10724,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -10745,7 +10745,7 @@
 			"maintenance_cost": "5",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -10766,7 +10766,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -10787,7 +10787,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r0K9-j3wavbfZaIZs",
@@ -10807,7 +10807,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -10830,7 +10830,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -10851,7 +10851,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Until recovery roll made",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -10874,7 +10874,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -10898,7 +10898,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "30 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -10919,7 +10919,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -10940,7 +10940,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -10961,7 +10961,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -10982,7 +10982,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -11003,7 +11003,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -11024,7 +11024,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -11045,7 +11045,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -11066,7 +11066,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -11087,7 +11087,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "24 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -11108,7 +11108,7 @@
 			"maintenance_cost": "8",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 48
 		},
 		{
@@ -11131,7 +11131,7 @@
 			"maintenance_cost": "1-3",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9,
 			"weapons": [
 				{
@@ -11178,7 +11178,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -11199,7 +11199,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -11220,7 +11220,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 min",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -11241,7 +11241,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -11262,7 +11262,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -11283,7 +11283,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -11304,7 +11304,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -11325,7 +11325,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -11346,7 +11346,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -11367,7 +11367,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -11388,7 +11388,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "5 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -11409,7 +11409,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -11430,7 +11430,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -11451,7 +11451,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -11472,7 +11472,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -11493,7 +11493,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -11514,7 +11514,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -11535,7 +11535,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6,
 			"weapons": [
 				{
@@ -11588,7 +11588,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 21
 		},
 		{
@@ -11609,7 +11609,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -11630,7 +11630,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -11651,7 +11651,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "8 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -11672,7 +11672,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 24
 		},
 		{
@@ -11693,7 +11693,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -11714,7 +11714,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec/sq foot",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -11735,7 +11735,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -11756,7 +11756,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -11777,7 +11777,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -11798,7 +11798,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -11820,7 +11820,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19,
 			"tech_level": ""
 		},
@@ -11842,7 +11842,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -11863,7 +11863,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -11884,7 +11884,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -11905,7 +11905,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -11926,7 +11926,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -11947,7 +11947,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -11970,7 +11970,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -11991,7 +11991,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -12012,7 +12012,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -12033,7 +12033,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -12054,7 +12054,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "30 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -12075,7 +12075,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -12096,7 +12096,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -12117,7 +12117,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -12138,7 +12138,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -12159,7 +12159,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "30 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -12180,7 +12180,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -12201,7 +12201,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -12222,7 +12222,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -12245,7 +12245,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "30 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -12269,7 +12269,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "30 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -12290,7 +12290,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -12311,7 +12311,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "5 min #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3,
 			"weapons": [
 				{
@@ -12346,7 +12346,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2,
 			"weapons": [
 				{
@@ -12391,7 +12391,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "1 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -12412,7 +12412,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -12433,7 +12433,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -12454,7 +12454,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -12477,7 +12477,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -12498,7 +12498,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr/pt",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -12519,7 +12519,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -12540,7 +12540,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -12561,7 +12561,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 week",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -12583,7 +12583,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 week",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1,
 			"tech_level": ""
 		},
@@ -12605,7 +12605,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -12627,7 +12627,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15,
 			"tech_level": ""
 		},
@@ -12649,7 +12649,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -12670,7 +12670,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -12690,7 +12690,7 @@
 			"casting_cost": "1 per 2 ST of pull",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -12711,7 +12711,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "ryF_bQmJLgE5WDLe1",
@@ -12734,7 +12734,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -12755,7 +12755,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -12777,7 +12777,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2,
 			"tech_level": ""
 		},
@@ -12799,7 +12799,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5-10/gal #",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -12820,7 +12820,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -12841,7 +12841,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -12862,7 +12862,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -12884,7 +12884,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -12906,7 +12906,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -12931,7 +12931,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -12952,7 +12952,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10,
 			"weapons": [
 				{
@@ -12987,7 +12987,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4,
 			"weapons": [
 				{
@@ -13022,7 +13022,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11,
 			"weapons": [
 				{
@@ -13057,7 +13057,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -13078,7 +13078,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6,
 			"weapons": [
 				{
@@ -13115,7 +13115,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -13136,7 +13136,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -13160,7 +13160,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "sec=cost",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 28,
 			"tech_level": ""
 		},
@@ -13184,7 +13184,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -13205,7 +13205,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -13226,7 +13226,7 @@
 			"maintenance_cost": "0",
 			"casting_time": "1 sec",
 			"duration": "Special",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13247,7 +13247,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13268,7 +13268,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -13290,7 +13290,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19
 		},
 		{
@@ -13311,7 +13311,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -13332,7 +13332,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -13353,7 +13353,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "4 sec/10 lbs",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -13374,7 +13374,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -13395,7 +13395,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -13418,7 +13418,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -13439,7 +13439,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -13460,7 +13460,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -13481,7 +13481,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -13502,7 +13502,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -13523,7 +13523,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13544,7 +13544,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -13565,7 +13565,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -13586,7 +13586,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13607,7 +13607,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -13628,7 +13628,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec/lb",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -13648,7 +13648,7 @@
 			"casting_cost": "1 per 2 ST of repulsion",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -13669,7 +13669,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13690,7 +13690,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13711,7 +13711,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13732,7 +13732,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13753,7 +13753,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13774,7 +13774,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13795,7 +13795,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -13816,7 +13816,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -13837,7 +13837,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -13860,7 +13860,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -13881,7 +13881,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -13904,7 +13904,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -13925,7 +13925,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -13946,7 +13946,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -13971,7 +13971,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -13992,7 +13992,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -14015,7 +14015,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -14036,7 +14036,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -14060,7 +14060,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -14083,7 +14083,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -14106,7 +14106,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -14127,7 +14127,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -14148,7 +14148,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "3 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -14169,7 +14169,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -14190,7 +14190,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -14211,7 +14211,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -14232,7 +14232,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -14253,7 +14253,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -14276,7 +14276,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 Hours",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -14297,7 +14297,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "4 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -14318,7 +14318,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -14339,7 +14339,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -14361,7 +14361,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 min",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1,
 			"tech_level": ""
 		},
@@ -14383,7 +14383,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -14404,7 +14404,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "5 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -14426,7 +14426,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -14448,7 +14448,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9,
 			"weapons": [
 				{
@@ -14482,7 +14482,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 min or until free",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -14503,7 +14503,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10,
 			"weapons": [
 				{
@@ -14558,7 +14558,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -14579,7 +14579,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 sec/lb",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -14600,7 +14600,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 30
 		},
 		{
@@ -14621,7 +14621,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -14669,7 +14669,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "Instant #",
 			"duration": "1 min #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -14692,7 +14692,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -14716,7 +14716,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12,
 			"tech_level": ""
 		},
@@ -14738,7 +14738,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -14759,7 +14759,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "days=cost",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -14780,7 +14780,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -14801,7 +14801,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "10 sec",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -14822,7 +14822,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "5 sec",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -14843,7 +14843,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "sec=cost",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -14864,7 +14864,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -14885,7 +14885,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -14907,7 +14907,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rQJfWvQ-ikDxzoZO0",
@@ -14927,7 +14927,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -14948,7 +14948,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rIEhSwbUfVSp-JLtH",
@@ -14968,7 +14968,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -14989,7 +14989,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rXGet_Xt9ORtFjiPu",
@@ -15009,7 +15009,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rT15QJjyen1cAhb-r",
@@ -15029,7 +15029,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "ru2XnQAwGI2UPTPgy",
@@ -15050,7 +15050,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"tech_level": ""
 		},
 		{
@@ -15071,7 +15071,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -15093,7 +15093,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"tech_level": ""
 		},
 		{
@@ -15114,7 +15114,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15135,7 +15135,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15156,7 +15156,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r8LuflncqhT9og__g",
@@ -15177,7 +15177,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rDlWvSZQ0rNdL7L2m",
@@ -15198,7 +15198,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"tech_level": ""
 		},
 		{
@@ -15220,7 +15220,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15241,7 +15241,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rEWQt6kOfcKvmF4Nr",
@@ -15261,7 +15261,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -15282,7 +15282,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15303,7 +15303,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15324,7 +15324,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rL92yKHUL0KKqlOKv",
@@ -15344,7 +15344,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rR-1Z0ktJMtbVKkde",
@@ -15364,7 +15364,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15385,7 +15385,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15406,7 +15406,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15427,7 +15427,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -15448,7 +15448,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15469,7 +15469,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15490,7 +15490,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -15511,7 +15511,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15532,7 +15532,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15553,7 +15553,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15575,7 +15575,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -15596,7 +15596,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15618,7 +15618,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -15639,7 +15639,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -15660,7 +15660,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "30 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -15681,7 +15681,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "3 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -15702,7 +15702,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15723,7 +15723,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec/HP",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -15744,7 +15744,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -15766,7 +15766,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7,
 			"weapons": [
 				{
@@ -15800,7 +15800,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -15821,7 +15821,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r-HPKWDsy_rGI1Y7j",
@@ -15843,7 +15843,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -15898,7 +15898,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -15919,7 +15919,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "3 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -15940,7 +15940,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -15963,7 +15963,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -15984,7 +15984,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -16005,7 +16005,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -16026,7 +16026,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -16047,7 +16047,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 23
 		},
 		{
@@ -16068,7 +16068,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "24 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -16089,7 +16089,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Until awakened",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -16110,7 +16110,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -16131,7 +16131,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "3 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -16152,7 +16152,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -16173,7 +16173,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -16194,7 +16194,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "30 sec",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -16215,7 +16215,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 28
 		},
 		{
@@ -16236,7 +16236,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -16257,7 +16257,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "5 min #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3,
 			"weapons": [
 				{
@@ -16295,7 +16295,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -16316,7 +16316,7 @@
 			"maintenance_cost": "1-3",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6,
 			"weapons": [
 				{
@@ -16363,7 +16363,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -16384,7 +16384,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -16405,7 +16405,7 @@
 			"maintenance_cost": "10",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -16426,7 +16426,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -16447,7 +16447,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -16468,7 +16468,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -16489,7 +16489,7 @@
 			"maintenance_cost": "1/ min",
 			"casting_time": "1 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r-cRAfQqTCqwVLgap",
@@ -16509,7 +16509,7 @@
 			"maintenance_cost": "1-4",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4,
 			"weapons": [
 				{
@@ -16555,7 +16555,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -16578,7 +16578,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-5 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -16615,7 +16615,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "sec=radius in yards",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -16650,7 +16650,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -16672,7 +16672,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -16693,7 +16693,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -16714,7 +16714,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 23
 		},
 		{
@@ -16735,7 +16735,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -16756,7 +16756,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -16777,7 +16777,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19
 		},
 		{
@@ -16798,7 +16798,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -16819,7 +16819,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "sec=cost",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -16841,7 +16841,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3,
 			"weapons": [
 				{
@@ -16886,7 +16886,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14,
 			"weapons": [
 				{
@@ -16933,7 +16933,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -16954,7 +16954,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "24 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 23
 		},
 		{
@@ -16975,7 +16975,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -16996,7 +16996,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min per 3 FP drained",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -17017,7 +17017,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -17039,7 +17039,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"tech_level": ""
 		},
@@ -17061,7 +17061,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "24 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -17082,7 +17082,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "sec=cost",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -17103,7 +17103,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -17124,7 +17124,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min per 3 HP drained",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -17145,7 +17145,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -17166,7 +17166,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -17187,7 +17187,7 @@
 			"maintenance_cost": "1-3",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10,
 			"weapons": [
 				{
@@ -17234,7 +17234,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -17255,7 +17255,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "5 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -17276,7 +17276,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec/lb",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -17297,7 +17297,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -17344,7 +17344,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -17365,7 +17365,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -17386,7 +17386,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -17407,7 +17407,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Until spell dissipates",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -17428,7 +17428,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -17450,7 +17450,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -17473,7 +17473,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -17498,7 +17498,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -17519,7 +17519,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -17542,7 +17542,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -17563,7 +17563,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -17584,7 +17584,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -17605,7 +17605,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -17626,7 +17626,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -17647,7 +17647,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -17668,7 +17668,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -17689,7 +17689,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -17710,7 +17710,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -17731,7 +17731,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -17752,7 +17752,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -17773,7 +17773,7 @@
 			"maintenance_cost": "20",
 			"casting_time": "10 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -17794,7 +17794,7 @@
 			"maintenance_cost": "10",
 			"casting_time": "5 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -17815,7 +17815,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -17836,7 +17836,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7,
 			"weapons": [
 				{
@@ -17883,7 +17883,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -17904,7 +17904,7 @@
 			"maintenance_cost": "10",
 			"casting_time": "1 min",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -17925,7 +17925,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -17946,7 +17946,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 22
 		},
 		{
@@ -17967,7 +17967,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec/pt",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -17988,7 +17988,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 min",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -18009,7 +18009,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -18030,7 +18030,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 30
 		},
 		{
@@ -18051,7 +18051,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Until Awakened",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -18074,7 +18074,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -18095,7 +18095,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -18116,7 +18116,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -18137,7 +18137,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -18158,7 +18158,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "5 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -18179,7 +18179,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -18202,7 +18202,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -18225,7 +18225,7 @@
 			"maintenance_cost": "_",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -18248,7 +18248,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -18269,7 +18269,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -18290,7 +18290,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rGVAP4ce2ppm4H4BM",
@@ -18310,7 +18310,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Indefinite #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -18331,7 +18331,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -18352,7 +18352,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "ra0ikjCKE9n_8jQts",
@@ -18373,7 +18373,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"tech_level": ""
 		},
 		{
@@ -18394,7 +18394,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -18417,7 +18417,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Until drink/rest",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -18439,7 +18439,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Until thrown",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20,
 			"weapons": [
 				{
@@ -18485,7 +18485,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -18506,7 +18506,7 @@
 			"maintenance_cost": "5",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -18529,7 +18529,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -18550,7 +18550,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 30
 		},
 		{
@@ -18571,7 +18571,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -18592,7 +18592,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -18613,7 +18613,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -18634,7 +18634,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -18655,7 +18655,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7,
 			"weapons": [
 				{
@@ -18710,7 +18710,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "ry9KpGfwEmxGu2z2i",
@@ -18730,7 +18730,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -18751,7 +18751,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -18774,7 +18774,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -18795,7 +18795,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -18816,7 +18816,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "cost=sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -18837,7 +18837,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "2 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -18858,7 +18858,7 @@
 			"maintenance_cost": "20",
 			"casting_time": "2 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 27
 		},
 		{
@@ -18879,7 +18879,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -18900,7 +18900,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -18921,7 +18921,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -18942,7 +18942,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -18963,7 +18963,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "4 sec",
 			"duration": "Turned undead will avoid caster for 1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -18986,7 +18986,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -19007,7 +19007,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -19028,7 +19028,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -19049,7 +19049,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -19070,7 +19070,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -19091,7 +19091,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 night",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -19112,7 +19112,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -19133,7 +19133,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -19154,7 +19154,7 @@
 			"maintenance_cost": "10",
 			"casting_time": "1 hr #",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -19175,7 +19175,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -19196,7 +19196,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -19217,7 +19217,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -19238,7 +19238,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -19259,7 +19259,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -19280,7 +19280,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -19301,7 +19301,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -19324,7 +19324,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -19345,7 +19345,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -19366,7 +19366,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "Instant",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -19387,7 +19387,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -19408,7 +19408,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -19431,7 +19431,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -19454,7 +19454,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -19475,7 +19475,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -19496,7 +19496,7 @@
 			"maintenance_cost": "1-3",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4,
 			"weapons": [
 				{
@@ -19544,7 +19544,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -19567,7 +19567,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "30 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -19590,7 +19590,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -19612,7 +19612,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -19648,7 +19648,7 @@
 			"maintenance_cost": "5",
 			"casting_time": "1 sec",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -19669,7 +19669,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -19690,7 +19690,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -19711,7 +19711,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -19734,7 +19734,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "6 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -19755,7 +19755,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "Varies",
 			"duration": "1 min #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -19776,7 +19776,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -19799,7 +19799,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -19820,7 +19820,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "Instant",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -19842,7 +19842,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3,
 			"weapons": [
 				{
@@ -19887,7 +19887,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -19908,7 +19908,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Special",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19
 		},
 		{
@@ -19929,7 +19929,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -19984,7 +19984,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -20005,7 +20005,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -20026,7 +20026,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -20049,7 +20049,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -20074,7 +20074,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -20097,7 +20097,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -20118,7 +20118,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 34
 		},
 		{
@@ -20139,7 +20139,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1",
 			"duration": "Instant; aging starts immediately",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -20160,7 +20160,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "until destroyed",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -20181,7 +20181,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		}
 	]

--- a/Library/Magic/Ritual Magic Spells.spl
+++ b/Library/Magic/Ritual Magic Spells.spl
@@ -80,8 +80,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Projectile"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Projectile"
+							}
 						}
 					],
 					"calc": {
@@ -127,8 +133,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Beam"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Beam"
+							}
 						}
 					],
 					"calc": {
@@ -258,8 +270,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Beam"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Beam"
+							}
 						}
 					],
 					"calc": {
@@ -680,12 +698,12 @@
 			"name": "Animate Object",
 			"reference": "M117",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -807,12 +825,12 @@
 			"name": "Armor",
 			"reference": "M167",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -872,12 +890,12 @@
 			"name": "Atmosphere Dome",
 			"reference": "M169",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -1000,13 +1018,13 @@
 			"name": "Awaken Craft Spirit",
 			"reference": "M115",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Necromancy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Necromancy"
 			],
 			"power_source": "Arcane",
@@ -1333,12 +1351,12 @@
 			"name": "Blackout",
 			"reference": "M112",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -1354,12 +1372,12 @@
 			"name": "Bladeturning",
 			"reference": "M168",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -1505,12 +1523,12 @@
 			"name": "Block",
 			"reference": "M166",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -1547,12 +1565,12 @@
 			"name": "Blur",
 			"reference": "M113",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -1621,15 +1639,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -1698,15 +1725,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -1764,12 +1800,12 @@
 			"name": "Body of Shadow",
 			"reference": "M114",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular/R-HT",
@@ -2016,12 +2052,12 @@
 			"name": "Borrow Language",
 			"reference": "M46",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -2037,12 +2073,12 @@
 			"name": "Borrow Skill",
 			"reference": "M47",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -2134,8 +2170,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Breath"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Breath"
+							}
 						}
 					],
 					"calc": {
@@ -2203,8 +2245,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Breath"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Breath"
+							}
 						}
 					],
 					"calc": {
@@ -2241,12 +2289,12 @@
 			"name": "Bright Vision",
 			"reference": "M111",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -2297,15 +2345,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -2352,15 +2409,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -2395,12 +2461,12 @@
 			"name": "Catch Missile",
 			"reference": "M168",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -2500,12 +2566,12 @@
 			"name": "Clean",
 			"reference": "M116",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -2673,12 +2739,12 @@
 			"name": "Colors",
 			"reference": "M110",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -2736,12 +2802,12 @@
 			"name": "Communication",
 			"reference": "M48",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -2778,12 +2844,12 @@
 			"name": "Compel Truth",
 			"reference": "M47",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Info",
@@ -2799,12 +2865,12 @@
 			"name": "Complex Illusion",
 			"reference": "M96",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -2896,8 +2962,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Projectile"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Projectile"
+							}
 						}
 					],
 					"calc": {
@@ -2955,12 +3027,12 @@
 			"name": "Continual Light",
 			"reference": "M110",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -2976,12 +3048,12 @@
 			"name": "Continual Mage Light",
 			"reference": "M113",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -2997,12 +3069,12 @@
 			"name": "Continual Sunlight",
 			"reference": "M114",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -3018,12 +3090,12 @@
 			"name": "Contract Object",
 			"reference": "M120",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -3060,12 +3132,12 @@
 			"name": "Control Creation",
 			"reference": "M99",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -3144,12 +3216,12 @@
 			"name": "Control Illusion",
 			"reference": "M97",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -3186,12 +3258,12 @@
 			"name": "Control Person",
 			"reference": "M49",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -3313,13 +3385,13 @@
 			"name": "Coolness",
 			"reference": "M187",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic",
 				"Water"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Water"
 			],
 			"power_source": "Arcane",
@@ -3336,12 +3408,12 @@
 			"name": "Copy",
 			"reference": "M116",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -3482,12 +3554,12 @@
 			"name": "Create Animal",
 			"reference": "M98",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -3708,12 +3780,12 @@
 			"name": "Create Mount",
 			"reference": "M99",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -3729,12 +3801,12 @@
 			"name": "Create Object",
 			"reference": "M98",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -3771,12 +3843,12 @@
 			"name": "Create Servant",
 			"reference": "M98",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -3834,12 +3906,12 @@
 			"name": "Create Warrior",
 			"reference": "M98",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -4069,12 +4141,12 @@
 			"name": "Dark Vision",
 			"reference": "M111",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -4090,12 +4162,12 @@
 			"name": "Darkness",
 			"reference": "M111",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -4186,15 +4258,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -4355,13 +4436,13 @@
 			"reference": "M143",
 			"tags": [
 				"Movement",
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
 				"Movement",
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -4518,13 +4599,13 @@
 			"reference": "M166",
 			"tags": [
 				"Healing",
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
 				"Healing",
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area/Info",
@@ -4562,12 +4643,12 @@
 			"reference": "M120",
 			"local_notes": "affects only inanimate objects",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -4617,12 +4698,12 @@
 			"name": "Dispel Creation",
 			"reference": "M99",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -4638,12 +4719,12 @@
 			"name": "Dispel Illusion",
 			"reference": "M97",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -4680,12 +4761,12 @@
 			"name": "Dispel Possession",
 			"reference": "M49",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -5190,12 +5271,12 @@
 			"name": "Dream Projection",
 			"reference": "M46",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -5211,12 +5292,12 @@
 			"name": "Dream Sending",
 			"reference": "M45",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -5232,12 +5313,12 @@
 			"name": "Dream Viewing",
 			"reference": "M45",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -5262,7 +5343,7 @@
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
-			"casting_cost": "1/pt of IQ \u0026 DX loss",
+			"casting_cost": "1/pt of IQ & DX loss",
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
@@ -5416,12 +5497,12 @@
 			"name": "Duplicate",
 			"reference": "M98",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -5437,12 +5518,12 @@
 			"name": "Dye",
 			"reference": "M116",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -5718,12 +5799,12 @@
 			"name": "Enlarge Object",
 			"reference": "M120",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -6101,15 +6182,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Judo"
+							"name": {
+								"compare": "is",
+								"qualifier": "Judo"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Sumo Wrestling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Sumo Wrestling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Wrestling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Wrestling"
+							}
 						}
 					],
 					"calc": {
@@ -6123,12 +6213,12 @@
 			"name": "Exchange Bodies",
 			"reference": "M49",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -6145,12 +6235,12 @@
 			"reference": "M118",
 			"local_notes": "affects only inanimate objects",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -6211,8 +6301,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Projectile"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Projectile"
+							}
 						}
 					],
 					"calc": {
@@ -6260,8 +6356,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Beam"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Beam"
+							}
 						}
 					],
 					"calc": {
@@ -6275,12 +6377,12 @@
 			"name": "Extend Object",
 			"reference": "M120",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -6509,12 +6611,12 @@
 			"name": "Fasten",
 			"reference": "M118",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -6595,12 +6697,12 @@
 			"name": "Find Weakness",
 			"reference": "M116",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Info",
@@ -6683,8 +6785,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Projectile"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Projectile"
+							}
 						}
 					],
 					"calc": {
@@ -6751,8 +6859,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Beam"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Beam"
+							}
 						}
 					],
 					"calc": {
@@ -6833,12 +6947,12 @@
 			"reference": "M112",
 			"local_notes": "HT roll to resist blinding",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -7016,12 +7130,12 @@
 			"name": "Force Dome",
 			"reference": "M170",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -7037,12 +7151,12 @@
 			"name": "Force Wall",
 			"reference": "M170",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -7369,12 +7483,12 @@
 			"name": "Gift of Letters",
 			"reference": "M46",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -7390,12 +7504,12 @@
 			"name": "Gift of Tongues",
 			"reference": "M46",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -7476,12 +7590,12 @@
 			"name": "Gloom",
 			"reference": "M112",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -7497,12 +7611,12 @@
 			"name": "Glow",
 			"reference": "M112",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -7934,12 +8048,12 @@
 			"name": "Hardiness",
 			"reference": "M167",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -7996,12 +8110,12 @@
 			"name": "Hawk Vision",
 			"reference": "M111",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -8101,12 +8215,12 @@
 			"name": "Hide",
 			"reference": "M113",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -8122,12 +8236,12 @@
 			"name": "Hide Emotion",
 			"reference": "M45",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -8185,12 +8299,12 @@
 			"name": "Hide Thoughts",
 			"reference": "M46",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -8428,8 +8542,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Projectile"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Projectile"
+							}
 						}
 					],
 					"calc": {
@@ -8496,8 +8616,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Projectile"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Projectile"
+							}
 						}
 					],
 					"calc": {
@@ -8543,8 +8669,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Breath"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Breath"
+							}
 						}
 					],
 					"calc": {
@@ -8613,15 +8745,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -8761,12 +8902,12 @@
 			"name": "Illusion Disguise",
 			"reference": "M96",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -8782,12 +8923,12 @@
 			"name": "Illusion Shell",
 			"reference": "M96",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -8804,13 +8945,13 @@
 			"reference": "M107",
 			"tags": [
 				"Knowledge",
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
 				"Knowledge",
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -8889,12 +9030,12 @@
 			"name": "Independence",
 			"reference": "M96",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -8910,12 +9051,12 @@
 			"name": "Infravision",
 			"reference": "M111",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -8931,12 +9072,12 @@
 			"name": "Initiative",
 			"reference": "M97",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -8952,14 +9093,14 @@
 			"name": "Inscribe",
 			"reference": "M97",
 			"tags": [
-				"Illusion \u0026 Creation",
-				"Making \u0026 Breaking",
+				"Illusion & Creation",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation",
-				"Making \u0026 Breaking"
+				"Illusion & Creation",
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -8975,12 +9116,12 @@
 			"name": "Insignificance",
 			"reference": "M48",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -8996,12 +9137,12 @@
 			"name": "Inspired Creation",
 			"reference": "M115",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -9079,12 +9220,12 @@
 			"name": "Invisibility",
 			"reference": "M114",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -9142,12 +9283,12 @@
 			"name": "Iron Arm",
 			"reference": "M169",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -9328,12 +9469,12 @@
 			"name": "Knot",
 			"reference": "M117",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -9349,12 +9490,12 @@
 			"name": "Know Illusion",
 			"reference": "M97",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Info",
@@ -9477,12 +9618,12 @@
 			"name": "Lend Language",
 			"reference": "M46",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -9521,12 +9662,12 @@
 			"name": "Lend Skill",
 			"reference": "M47",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -9691,12 +9832,12 @@
 			"name": "Light",
 			"reference": "M110",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -9712,12 +9853,12 @@
 			"reference": "M112",
 			"local_notes": "blinds only when darkness penalty is -5 or more",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -9743,8 +9884,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Beam"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Beam"
+							}
 						}
 					],
 					"calc": {
@@ -9855,8 +10002,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Beam"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Beam"
+							}
 						}
 					],
 					"calc": {
@@ -9951,8 +10104,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Gaze"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gaze"
+							}
 						}
 					],
 					"calc": {
@@ -10023,16 +10182,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -10262,13 +10430,13 @@
 			"name": "Machine Speech",
 			"reference": "M176",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic",
 				"Technological"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -10330,12 +10498,12 @@
 			"name": "Mage Light",
 			"reference": "M113",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -10414,12 +10582,12 @@
 			"name": "Magelock",
 			"reference": "M166",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -10606,12 +10774,12 @@
 			"name": "Mapmaker",
 			"reference": "M118",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Special",
@@ -10859,13 +11027,13 @@
 			"name": "Message",
 			"reference": "M174",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic",
 				"Sound"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Sound"
 			],
 			"power_source": "Arcane",
@@ -10927,12 +11095,12 @@
 			"name": "Mind-Reading",
 			"reference": "M46",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -10948,12 +11116,12 @@
 			"name": "Mind-Search",
 			"reference": "M46",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -10969,12 +11137,12 @@
 			"name": "Mind-Sending",
 			"reference": "M47",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -11032,12 +11200,12 @@
 			"name": "Mirror",
 			"reference": "M112",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -11053,12 +11221,12 @@
 			"name": "Missile Shield",
 			"reference": "M168",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -11150,8 +11318,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Beam"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Beam"
+							}
 						}
 					],
 					"calc": {
@@ -11186,12 +11360,12 @@
 			"name": "Mystic Mark",
 			"reference": "M119",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -11207,12 +11381,12 @@
 			"name": "Mystic Mist",
 			"reference": "M168",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -11291,12 +11465,12 @@
 			"name": "Night Vision",
 			"reference": "M111",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -11312,12 +11486,12 @@
 			"name": "Nightingale",
 			"reference": "M167",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -11553,15 +11727,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -11722,12 +11905,12 @@
 			"name": "Perfect Illusion",
 			"reference": "M96",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -11850,12 +12033,12 @@
 			"name": "Permanent Possession",
 			"reference": "M49",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -11892,12 +12075,12 @@
 			"name": "Persuasion",
 			"reference": "M45",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -11934,12 +12117,12 @@
 			"name": "Phantom",
 			"reference": "M97",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -11956,13 +12139,13 @@
 			"reference": "M73",
 			"tags": [
 				"Fire",
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
 				"Fire",
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -12364,7 +12547,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Throwing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Throwing"
+							}
 						}
 					],
 					"calc": {
@@ -12378,12 +12564,12 @@
 			"name": "Possession",
 			"reference": "M49",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -12527,12 +12713,12 @@
 			"name": "Presence",
 			"reference": "M48",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -13145,13 +13331,13 @@
 			"reference": "M177",
 			"tags": [
 				"Machine",
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic",
 				"Technological"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -13255,12 +13441,12 @@
 			"name": "Reflect Gaze",
 			"reference": "M168",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -13340,12 +13526,12 @@
 			"name": "Rejoin",
 			"reference": "M116",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -13573,12 +13759,12 @@
 			"name": "Remove Reflection",
 			"reference": "M113",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular/R-Will",
@@ -13594,12 +13780,12 @@
 			"name": "Remove Shadow",
 			"reference": "M110",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular/R-Will",
@@ -13615,12 +13801,12 @@
 			"name": "Repair",
 			"reference": "M118",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -13824,12 +14010,12 @@
 			"name": "Reshape",
 			"reference": "M117",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -13845,13 +14031,13 @@
 			"name": "Resist Acid",
 			"reference": "M190",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic",
 				"Water"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Water"
 			],
 			"power_source": "Arcane",
@@ -13890,13 +14076,13 @@
 			"reference": "M90",
 			"tags": [
 				"Healing",
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
 				"Healing",
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -13955,14 +14141,14 @@
 			"reference": "M196",
 			"tags": [
 				"Air",
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic",
 				"Weather"
 			],
 			"difficulty": "h",
 			"college": [
 				"Air",
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Weather"
 			],
 			"power_source": "Arcane",
@@ -14001,13 +14187,13 @@
 			"reference": "M91",
 			"tags": [
 				"Healing",
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
 				"Healing",
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -14023,12 +14209,12 @@
 			"name": "Resist Pressure",
 			"reference": "M169",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -14044,14 +14230,14 @@
 			"name": "Resist Radiation",
 			"reference": "M182",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Radiation",
 				"Ritual Magic",
 				"Technological"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Technological"
 			],
 			"power_source": "Arcane",
@@ -14068,13 +14254,13 @@
 			"name": "Resist Sound",
 			"reference": "M173",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic",
 				"Sound"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Sound"
 			],
 			"power_source": "Arcane",
@@ -14091,13 +14277,13 @@
 			"name": "Resist Water",
 			"reference": "M186",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic",
 				"Water"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Water"
 			],
 			"power_source": "Arcane",
@@ -14135,12 +14321,12 @@
 			"name": "Restore",
 			"reference": "M116",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -14305,12 +14491,12 @@
 			"name": "Retrogression",
 			"reference": "M47",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -14326,12 +14512,12 @@
 			"name": "Return Missile",
 			"reference": "M168",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -14370,12 +14556,12 @@
 			"name": "Reverse Missiles",
 			"reference": "M168",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -14435,12 +14621,12 @@
 			"reference": "M117",
 			"local_notes": "only affects inanimate objects",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -14523,15 +14709,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -14566,12 +14761,12 @@
 			"name": "Ruin",
 			"reference": "M118",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -14639,8 +14834,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Beam"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Beam"
+							}
 						}
 					],
 					"calc": {
@@ -14872,12 +15073,12 @@
 			"name": "See Invisible",
 			"reference": "M113",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -15269,12 +15470,12 @@
 			"name": "Sense Danger",
 			"reference": "M166",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Info",
@@ -15290,12 +15491,12 @@
 			"name": "Sense Emotion",
 			"reference": "M45",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -15311,12 +15512,12 @@
 			"name": "Sense Foes",
 			"reference": "M44",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Info/Area",
@@ -15331,12 +15532,12 @@
 			"name": "Sense Life",
 			"reference": "M45",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Info/Area",
@@ -15372,12 +15573,12 @@
 			"name": "Sense Observation",
 			"reference": "M167",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -15435,12 +15636,12 @@
 			"name": "Shade",
 			"reference": "M169",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -15477,12 +15678,12 @@
 			"name": "Shape Darkness",
 			"reference": "M113",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -15540,12 +15741,12 @@
 			"name": "Shape Light",
 			"reference": "M111",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -15731,12 +15932,12 @@
 			"name": "Sharpen",
 			"reference": "M118",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -15753,12 +15954,12 @@
 			"reference": "M116",
 			"local_notes": "only affects inanimate objects",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -15787,12 +15988,12 @@
 			"name": "Shatterproof",
 			"reference": "M118",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -15808,12 +16009,12 @@
 			"name": "Shield",
 			"reference": "M167",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -15863,15 +16064,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -15906,12 +16116,12 @@
 			"name": "Shrink Object",
 			"reference": "M120",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -16013,12 +16223,12 @@
 			"name": "Simple Illusion",
 			"reference": "M95",
 			"tags": [
-				"Illusion \u0026 Creation",
+				"Illusion & Creation",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Illusion \u0026 Creation"
+				"Illusion & Creation"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -16223,12 +16433,12 @@
 			"name": "Small Vision",
 			"reference": "M111",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -16335,8 +16545,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Beam"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Beam"
+							}
 						}
 					],
 					"calc": {
@@ -16371,12 +16587,12 @@
 			"name": "Soilproof",
 			"reference": "M116",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -16434,12 +16650,12 @@
 			"name": "Soul Rider",
 			"reference": "M49",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -16527,8 +16743,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Beam"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Beam"
+							}
 						}
 					],
 					"calc": {
@@ -16858,8 +17080,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Beam"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Beam"
+							}
 						}
 					],
 					"calc": {
@@ -16905,8 +17133,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Breath"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Breath"
+							}
 						}
 					],
 					"calc": {
@@ -17206,8 +17440,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Beam"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Beam"
+							}
 						}
 					],
 					"calc": {
@@ -17263,12 +17503,12 @@
 			"name": "Stiffen",
 			"reference": "M117",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -17316,8 +17556,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Projectile"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Projectile"
+							}
 						}
 					],
 					"calc": {
@@ -17823,12 +18069,12 @@
 			"name": "Sunbolt",
 			"reference": "M114",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Missile",
@@ -17855,8 +18101,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Beam"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Beam"
+							}
 						}
 					],
 					"calc": {
@@ -17870,12 +18122,12 @@
 			"name": "Sunlight",
 			"reference": "M114",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -18166,12 +18418,12 @@
 			"name": "Telepathy",
 			"reference": "M47",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -18234,13 +18486,13 @@
 			"reference": "M170",
 			"tags": [
 				"Gate",
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
 				"Gate",
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -18457,8 +18709,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Projectile"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Projectile"
+							}
 						}
 					],
 					"calc": {
@@ -18675,15 +18933,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -18717,12 +18984,12 @@
 			"name": "Toughen",
 			"reference": "M119",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -18803,12 +19070,12 @@
 			"name": "Transform Object",
 			"reference": "M120",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -18866,12 +19133,12 @@
 			"name": "Transparency",
 			"reference": "M119",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -18887,12 +19154,12 @@
 			"name": "Truthsayer",
 			"reference": "M45",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Info",
@@ -18908,12 +19175,12 @@
 			"name": "Turn Blade",
 			"reference": "M167",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Blocking",
@@ -18971,13 +19238,13 @@
 			"name": "Umbrella",
 			"reference": "M185",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic",
 				"Water"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Water"
 			],
 			"power_source": "Arcane",
@@ -19015,12 +19282,12 @@
 			"name": "Utter Dome",
 			"reference": "M170",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -19036,12 +19303,12 @@
 			"name": "Utter Wall",
 			"reference": "M170",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -19057,12 +19324,12 @@
 			"name": "Vexation",
 			"reference": "M45",
 			"tags": [
-				"Communication \u0026 Empathy",
+				"Communication & Empathy",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Communication \u0026 Empathy"
+				"Communication & Empathy"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -19288,12 +19555,12 @@
 			"name": "Wall of Light",
 			"reference": "M113",
 			"tags": [
-				"Light \u0026 Darkness",
+				"Light & Darkness",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Light \u0026 Darkness"
+				"Light & Darkness"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -19440,13 +19707,13 @@
 			"reference": "M74",
 			"tags": [
 				"Fire",
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
 				"Fire",
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -19462,12 +19729,12 @@
 			"name": "Watchdog",
 			"reference": "M167",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning"
+				"Protection & Warning"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Area",
@@ -19515,8 +19782,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "Beam"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Beam"
+							}
 						}
 					],
 					"calc": {
@@ -19599,12 +19872,12 @@
 			"reference": "M116",
 			"local_notes": "affects only inanimate objects",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -19677,12 +19950,12 @@
 			"name": "Weapon Self",
 			"reference": "M119",
 			"tags": [
-				"Making \u0026 Breaking",
+				"Making & Breaking",
 				"Ritual Magic"
 			],
 			"difficulty": "h",
 			"college": [
-				"Making \u0026 Breaking"
+				"Making & Breaking"
 			],
 			"power_source": "Arcane",
 			"spell_class": "Regular",
@@ -19719,13 +19992,13 @@
 			"name": "Weather Dome",
 			"reference": "M169",
 			"tags": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Ritual Magic",
 				"Weather"
 			],
 			"difficulty": "h",
 			"college": [
-				"Protection \u0026 Warning",
+				"Protection & Warning",
 				"Weather"
 			],
 			"power_source": "Arcane",
@@ -19860,7 +20133,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Throwing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Throwing"
+							}
 						}
 					],
 					"calc": {
@@ -19949,15 +20225,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {

--- a/Library/Magic/Ritual Magic Spells.spl
+++ b/Library/Magic/Ritual Magic Spells.spl
@@ -19,7 +19,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 28
 		},
 		{
@@ -40,7 +40,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -61,7 +61,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11,
 			"weapons": [
 				{
@@ -114,7 +114,7 @@
 			"maintenance_cost": "1-3",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11,
 			"weapons": [
 				{
@@ -167,7 +167,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -188,7 +188,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -209,7 +209,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -230,7 +230,7 @@
 			"maintenance_cost": "6",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -251,7 +251,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3,
 			"weapons": [
 				{
@@ -306,7 +306,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -329,7 +329,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "2 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -350,7 +350,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 week",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -371,7 +371,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -392,7 +392,7 @@
 			"maintenance_cost": "6",
 			"casting_time": "2 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -413,7 +413,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "2d days",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -434,7 +434,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -457,7 +457,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -478,7 +478,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -499,7 +499,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -520,7 +520,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -541,7 +541,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min/pt",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -562,7 +562,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -583,7 +583,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -604,7 +604,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -625,7 +625,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -646,7 +646,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -667,7 +667,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -689,7 +689,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "sec=cost",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17,
 			"tech_level": ""
 		},
@@ -711,7 +711,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -733,7 +733,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -754,7 +754,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "2 sec",
 			"duration": "5 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -775,7 +775,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -795,7 +795,7 @@
 			"casting_cost": "Varies",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -817,7 +817,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -838,7 +838,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -859,7 +859,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -882,7 +882,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -903,7 +903,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "6 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -924,7 +924,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -945,7 +945,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -966,7 +966,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -987,7 +987,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -1009,7 +1009,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12,
 			"tech_level": ""
 		},
@@ -1033,7 +1033,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1054,7 +1054,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1077,7 +1077,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1-3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9,
 			"weapons": [
 				{
@@ -1111,7 +1111,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -1132,7 +1132,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -1155,7 +1155,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "30 sec",
 			"duration": "24 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -1176,7 +1176,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Until next call",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -1197,7 +1197,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1218,7 +1218,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1239,7 +1239,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -1260,7 +1260,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -1281,7 +1281,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -1302,7 +1302,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 hr or reaction roll",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rSwyLWTKKYznbJmt5",
@@ -1322,7 +1322,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "4 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1343,7 +1343,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -1364,7 +1364,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -1385,7 +1385,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -1406,7 +1406,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 21
 		},
 		{
@@ -1427,7 +1427,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "min=cost",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 22
 		},
 		{
@@ -1448,7 +1448,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "1 Crop or Season",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -1469,7 +1469,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "1 Crop or Season",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1492,7 +1492,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -1515,7 +1515,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -1536,7 +1536,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -1557,7 +1557,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1578,7 +1578,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -1599,7 +1599,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -1620,7 +1620,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -1683,7 +1683,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -1706,7 +1706,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9,
 			"weapons": [
 				{
@@ -1770,7 +1770,7 @@
 			"maintenance_cost": "6",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -1792,7 +1792,7 @@
 			"maintenance_cost": "5",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -1813,7 +1813,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -1834,7 +1834,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -1855,7 +1855,7 @@
 			"maintenance_cost": "5",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -1876,7 +1876,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -1897,7 +1897,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -1918,7 +1918,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -1939,7 +1939,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "-",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -1960,7 +1960,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -1981,7 +1981,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -2002,7 +2002,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -2023,7 +2023,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -2044,7 +2044,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -2065,7 +2065,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -2086,7 +2086,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -2107,7 +2107,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -2130,7 +2130,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -2151,7 +2151,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -2205,7 +2205,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -2226,7 +2226,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14,
 			"weapons": [
 				{
@@ -2281,7 +2281,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -2302,7 +2302,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -2325,7 +2325,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14,
 			"weapons": [
 				{
@@ -2389,7 +2389,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -2453,7 +2453,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -2474,7 +2474,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -2495,7 +2495,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -2516,7 +2516,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 min",
 			"duration": "until used",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -2537,7 +2537,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -2558,7 +2558,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "30 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -2579,7 +2579,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -2600,7 +2600,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -2621,7 +2621,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r3N9PqfMRs1xSNAs3",
@@ -2643,7 +2643,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 sec/100 miles",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -2666,7 +2666,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -2689,7 +2689,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -2710,7 +2710,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -2731,7 +2731,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "1 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -2752,7 +2752,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -2773,7 +2773,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -2794,7 +2794,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -2815,7 +2815,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -2836,7 +2836,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "5 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -2857,7 +2857,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "5 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -2878,7 +2878,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -2899,7 +2899,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "4 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -2920,7 +2920,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "3 sec",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -2943,7 +2943,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -2996,7 +2996,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -3018,7 +3018,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2,
 			"tech_level": ""
 		},
@@ -3040,7 +3040,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "2d days",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -3061,7 +3061,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "2d days",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -3082,7 +3082,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "2d days",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -3103,7 +3103,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "3 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -3124,7 +3124,7 @@
 			"maintenance_cost": "Special",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -3145,7 +3145,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19
 		},
 		{
@@ -3166,7 +3166,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -3187,7 +3187,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -3208,7 +3208,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -3229,7 +3229,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -3250,7 +3250,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "5 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -3271,7 +3271,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -3292,7 +3292,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -3312,7 +3312,7 @@
 			"casting_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -3333,7 +3333,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Indefinite #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -3354,7 +3354,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -3377,7 +3377,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -3400,7 +3400,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -3421,7 +3421,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -3442,7 +3442,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -3463,7 +3463,7 @@
 			"maintenance_cost": "6",
 			"casting_time": "3 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 21
 		},
 		{
@@ -3483,7 +3483,7 @@
 			"casting_cost": "Half countered spell",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -3504,7 +3504,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -3525,7 +3525,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "5 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -3546,7 +3546,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Special",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -3567,7 +3567,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec/cost",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -3588,7 +3588,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "5 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -3609,7 +3609,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -3630,7 +3630,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Special",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -3651,7 +3651,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1,
 			"weapons": [
 				{
@@ -3686,7 +3686,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Special",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -3707,7 +3707,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -3729,7 +3729,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10,
 			"tech_level": ""
 		},
@@ -3751,7 +3751,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "Varies",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 24
 		},
 		{
@@ -3772,7 +3772,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -3793,7 +3793,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 22
 		},
 		{
@@ -3814,7 +3814,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec/cost",
 			"duration": "While touching someone",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -3835,7 +3835,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -3856,7 +3856,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -3877,7 +3877,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -3898,7 +3898,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "5 min #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -3919,7 +3919,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19
 		},
 		{
@@ -3940,7 +3940,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -3961,7 +3961,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Special",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -3982,7 +3982,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 21
 		},
 		{
@@ -4003,7 +4003,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -4026,7 +4026,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -4049,7 +4049,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -4070,7 +4070,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2/4/6 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 22
 		},
 		{
@@ -4091,7 +4091,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -4112,7 +4112,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -4133,7 +4133,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -4154,7 +4154,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -4175,7 +4175,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -4196,7 +4196,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -4217,7 +4217,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -4238,7 +4238,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9,
 			"weapons": [
 				{
@@ -4302,7 +4302,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "ricZalAkihamdu0Oh",
@@ -4322,7 +4322,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Semi-permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -4343,7 +4343,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -4364,7 +4364,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -4385,7 +4385,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -4406,7 +4406,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -4427,7 +4427,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -4450,7 +4450,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -4471,7 +4471,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -4506,7 +4506,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "2 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -4527,7 +4527,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "4 sec",
 			"duration": "Indefinite #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -4548,7 +4548,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -4569,7 +4569,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -4590,7 +4590,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -4613,7 +4613,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "-",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -4634,7 +4634,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -4656,7 +4656,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18,
 			"weapons": [
 				{
@@ -4690,7 +4690,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -4711,7 +4711,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -4732,7 +4732,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -4753,7 +4753,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "sec=cost",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -4774,7 +4774,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -4795,7 +4795,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -4816,7 +4816,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "5 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -4839,7 +4839,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -4862,7 +4862,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -4883,7 +4883,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -4904,7 +4904,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -4925,7 +4925,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -4946,7 +4946,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -4967,7 +4967,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -4988,7 +4988,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5009,7 +5009,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5030,7 +5030,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5051,7 +5051,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5072,7 +5072,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5093,7 +5093,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5114,7 +5114,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5135,7 +5135,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5156,7 +5156,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5177,7 +5177,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -5198,7 +5198,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 38
 		},
 		{
@@ -5219,7 +5219,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 24
 		},
 		{
@@ -5240,7 +5240,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -5262,7 +5262,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 23,
 			"tech_level": ""
 		},
@@ -5284,7 +5284,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -5305,7 +5305,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -5326,7 +5326,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -5347,7 +5347,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -5368,7 +5368,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -5389,7 +5389,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r_5Qh2yS_cQQ_HRx_",
@@ -5409,7 +5409,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rHSTJorsaZ8mXZCEx",
@@ -5429,7 +5429,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rrhtA63HB_tocOYAx",
@@ -5449,7 +5449,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rcRwZvLkQVaq1VOj9",
@@ -5469,7 +5469,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rs5ntMZA0Nuj-LUsp",
@@ -5489,7 +5489,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -5510,7 +5510,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec/cost",
 			"duration": "While touching someone",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -5531,7 +5531,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "2d days",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -5554,7 +5554,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -5575,7 +5575,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -5598,7 +5598,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -5621,7 +5621,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "30 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -5642,7 +5642,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "30 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -5665,7 +5665,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -5686,7 +5686,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -5707,7 +5707,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -5728,7 +5728,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -5749,7 +5749,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -5770,7 +5770,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 week",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -5791,7 +5791,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -5812,7 +5812,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "3 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -5833,7 +5833,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -5854,7 +5854,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -5875,7 +5875,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -5896,7 +5896,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -5917,7 +5917,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -5938,7 +5938,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "1 sec",
 			"duration": "5 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -5959,7 +5959,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -5980,7 +5980,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -6001,7 +6001,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -6022,7 +6022,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6,
 			"weapons": [
 				{
@@ -6057,7 +6057,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -6079,7 +6079,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7,
 			"tech_level": ""
 		},
@@ -6101,7 +6101,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -6122,7 +6122,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -6143,7 +6143,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "30 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -6164,7 +6164,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9,
 			"weapons": [
 				{
@@ -6226,7 +6226,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -6248,7 +6248,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10,
 			"weapons": [
 				{
@@ -6282,7 +6282,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -6337,7 +6337,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -6390,7 +6390,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "3 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -6411,7 +6411,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -6433,7 +6433,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -6454,7 +6454,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "10 sec",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -6475,7 +6475,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "5 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -6496,7 +6496,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -6517,7 +6517,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -6538,7 +6538,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -6561,7 +6561,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -6582,7 +6582,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -6603,7 +6603,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -6624,7 +6624,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -6645,7 +6645,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -6668,7 +6668,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -6689,7 +6689,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -6710,7 +6710,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -6731,7 +6731,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1-5 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -6766,7 +6766,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4,
 			"weapons": [
 				{
@@ -6819,7 +6819,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -6840,7 +6840,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3,
 			"weapons": [
 				{
@@ -6894,7 +6894,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -6916,7 +6916,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -6938,7 +6938,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -6960,7 +6960,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2,
 			"weapons": [
 				{
@@ -6994,7 +6994,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -7015,7 +7015,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -7036,7 +7036,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -7057,7 +7057,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "5 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -7080,7 +7080,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -7101,7 +7101,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -7122,7 +7122,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -7143,7 +7143,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -7164,7 +7164,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -7185,7 +7185,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -7206,7 +7206,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -7227,7 +7227,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -7250,7 +7250,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -7271,7 +7271,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -7292,7 +7292,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -7313,7 +7313,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -7336,7 +7336,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -7357,7 +7357,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6,
 			"weapons": [
 				{
@@ -7391,7 +7391,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -7412,7 +7412,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -7433,7 +7433,7 @@
 			"maintenance_cost": "6",
 			"casting_time": "3 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -7454,7 +7454,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "5 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -7475,7 +7475,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -7496,7 +7496,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -7517,7 +7517,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -7538,7 +7538,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -7559,7 +7559,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "5 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -7581,7 +7581,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12,
 			"tech_level": ""
 		},
@@ -7603,7 +7603,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "2d days",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -7624,7 +7624,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "2d days",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -7645,7 +7645,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -7666,7 +7666,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -7687,7 +7687,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -7708,7 +7708,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -7729,7 +7729,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -7750,7 +7750,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -7771,7 +7771,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -7792,7 +7792,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -7813,7 +7813,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -7834,7 +7834,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 26
 		},
 		{
@@ -7855,7 +7855,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -7876,7 +7876,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -7897,7 +7897,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Special",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 41
 		},
 		{
@@ -7921,7 +7921,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -7956,7 +7956,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "5 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -7977,7 +7977,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -7998,7 +7998,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -8019,7 +8019,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 month",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -8040,7 +8040,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19
 		},
 		{
@@ -8061,7 +8061,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -8082,7 +8082,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rFZSJl-qoKYhAu1Et",
@@ -8102,7 +8102,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -8123,7 +8123,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -8144,7 +8144,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -8165,7 +8165,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Up to 8 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -8186,7 +8186,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "1 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8207,7 +8207,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -8228,7 +8228,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -8249,7 +8249,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -8270,7 +8270,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 29
 		},
 		{
@@ -8291,7 +8291,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8312,7 +8312,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8333,7 +8333,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 21
 		},
 		{
@@ -8354,7 +8354,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -8374,7 +8374,7 @@
 			"casting_cost": "Varies",
 			"casting_time": "1 sec/pt",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -8395,7 +8395,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -8416,7 +8416,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -8437,7 +8437,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -8460,7 +8460,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Until eat/rest",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -8481,7 +8481,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "10 sec #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -8502,7 +8502,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8523,7 +8523,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -8576,7 +8576,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -8597,7 +8597,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4,
 			"weapons": [
 				{
@@ -8650,7 +8650,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12,
 			"weapons": [
 				{
@@ -8704,7 +8704,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -8725,7 +8725,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec #",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -8790,7 +8790,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8812,7 +8812,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r8u6b1ZBiC3yDY0Wg",
@@ -8832,7 +8832,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -8854,7 +8854,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rfHc-oyGhzlFkJjAw",
@@ -8874,7 +8874,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -8895,7 +8895,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r5W3vMwQWPc9GzLfr",
@@ -8915,7 +8915,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Until illusion ends",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8936,7 +8936,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -8959,7 +8959,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -8980,7 +8980,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -9001,7 +9001,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -9022,7 +9022,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "3 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -9043,7 +9043,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -9064,7 +9064,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -9085,7 +9085,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -9108,7 +9108,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -9129,7 +9129,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -9150,7 +9150,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r8-WBPvUId3uKgU5U",
@@ -9170,7 +9170,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -9191,7 +9191,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -9212,7 +9212,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -9233,7 +9233,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -9254,7 +9254,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -9275,7 +9275,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -9296,7 +9296,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -9318,7 +9318,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -9339,7 +9339,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Until scratched",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rQl4kXtcU2utiu6Nw",
@@ -9359,7 +9359,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -9380,7 +9380,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rhavqgnveyVegMQTX",
@@ -9402,7 +9402,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rY2N1rZB2AOE2NZ77",
@@ -9422,7 +9422,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rqStM02UE1TUTTUf7",
@@ -9442,7 +9442,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r9dae0EWZmPEIl6uY",
@@ -9462,7 +9462,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "30 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r3ltVFT9dvk1J4T1E",
@@ -9482,7 +9482,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -9503,7 +9503,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -9524,7 +9524,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -9547,7 +9547,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "15 sec",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -9568,7 +9568,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -9589,7 +9589,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 22
 		},
 		{
@@ -9610,7 +9610,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -9631,7 +9631,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -9653,7 +9653,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3,
 			"tech_level": ""
 		},
@@ -9675,7 +9675,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -9696,7 +9696,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -9717,7 +9717,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -9738,7 +9738,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -9759,7 +9759,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Until fulfilled",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -9780,7 +9780,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Special",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -9801,7 +9801,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -9824,7 +9824,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 28
 		},
 		{
@@ -9845,7 +9845,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r7IlFbvHZEygEvMY3",
@@ -9866,7 +9866,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2,
 			"weapons": [
 				{
@@ -9918,7 +9918,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -9939,7 +9939,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -9960,7 +9960,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "3 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -9983,7 +9983,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7,
 			"weapons": [
 				{
@@ -10038,7 +10038,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -10062,7 +10062,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -10085,7 +10085,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9,
 			"weapons": [
 				{
@@ -10141,7 +10141,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -10164,7 +10164,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "2 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -10228,7 +10228,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -10250,7 +10250,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "4 hrs",
 			"duration": "Until triggered",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19
 		},
 		{
@@ -10271,7 +10271,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -10292,7 +10292,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -10313,7 +10313,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -10334,7 +10334,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -10355,7 +10355,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "2 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -10376,7 +10376,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -10398,7 +10398,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11,
 			"tech_level": ""
 		},
@@ -10421,7 +10421,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "30 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16,
 			"tech_level": ""
 		},
@@ -10445,7 +10445,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13,
 			"tech_level": ""
 		},
@@ -10468,7 +10468,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12,
 			"tech_level": ""
 		},
@@ -10490,7 +10490,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -10511,7 +10511,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -10532,7 +10532,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -10553,7 +10553,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -10574,7 +10574,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -10595,7 +10595,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "4 sec",
 			"duration": "6 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -10616,7 +10616,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -10638,7 +10638,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -10659,7 +10659,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -10680,7 +10680,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -10701,7 +10701,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Indefinite #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -10723,7 +10723,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14,
 			"tech_level": ""
 		},
@@ -10745,7 +10745,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -10766,7 +10766,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -10787,7 +10787,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -10808,7 +10808,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "sec=cost",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -10829,7 +10829,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "sec=cost",
 			"duration": "Until awakened",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -10850,7 +10850,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "sec=cost",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -10871,7 +10871,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min per area",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -10892,7 +10892,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -10913,7 +10913,7 @@
 			"maintenance_cost": "5",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -10934,7 +10934,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -10955,7 +10955,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r0K9-j3wavbfZaIZs",
@@ -10975,7 +10975,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -10998,7 +10998,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -11019,7 +11019,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Until recovery roll made",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -11042,7 +11042,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -11066,7 +11066,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "30 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -11087,7 +11087,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -11108,7 +11108,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -11129,7 +11129,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -11150,7 +11150,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -11171,7 +11171,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -11192,7 +11192,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -11213,7 +11213,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -11234,7 +11234,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -11255,7 +11255,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "24 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -11276,7 +11276,7 @@
 			"maintenance_cost": "8",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 48
 		},
 		{
@@ -11299,7 +11299,7 @@
 			"maintenance_cost": "1-3",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9,
 			"weapons": [
 				{
@@ -11352,7 +11352,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -11373,7 +11373,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -11394,7 +11394,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 min",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -11415,7 +11415,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -11436,7 +11436,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -11457,7 +11457,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -11478,7 +11478,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -11499,7 +11499,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -11520,7 +11520,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -11541,7 +11541,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -11562,7 +11562,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "5 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -11583,7 +11583,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -11604,7 +11604,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -11625,7 +11625,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -11646,7 +11646,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -11667,7 +11667,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -11688,7 +11688,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -11709,7 +11709,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6,
 			"weapons": [
 				{
@@ -11771,7 +11771,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 21
 		},
 		{
@@ -11792,7 +11792,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -11813,7 +11813,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -11834,7 +11834,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "8 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -11855,7 +11855,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 24
 		},
 		{
@@ -11876,7 +11876,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -11897,7 +11897,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec/sq foot",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -11918,7 +11918,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -11939,7 +11939,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -11960,7 +11960,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -11981,7 +11981,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -12003,7 +12003,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19,
 			"tech_level": ""
 		},
@@ -12025,7 +12025,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -12046,7 +12046,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -12067,7 +12067,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Indefinite",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -12088,7 +12088,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -12109,7 +12109,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -12130,7 +12130,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -12153,7 +12153,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -12174,7 +12174,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -12195,7 +12195,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -12216,7 +12216,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -12237,7 +12237,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "30 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -12258,7 +12258,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -12279,7 +12279,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -12300,7 +12300,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -12321,7 +12321,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -12342,7 +12342,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "30 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -12363,7 +12363,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -12384,7 +12384,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -12405,7 +12405,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -12428,7 +12428,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "30 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -12452,7 +12452,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "30 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -12473,7 +12473,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -12494,7 +12494,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "5 min #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3,
 			"weapons": [
 				{
@@ -12529,7 +12529,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2,
 			"weapons": [
 				{
@@ -12577,7 +12577,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "1 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -12598,7 +12598,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -12619,7 +12619,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -12640,7 +12640,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -12663,7 +12663,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -12684,7 +12684,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr/pt",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -12705,7 +12705,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -12726,7 +12726,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -12747,7 +12747,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 week",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -12769,7 +12769,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 week",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1,
 			"tech_level": ""
 		},
@@ -12791,7 +12791,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -12813,7 +12813,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15,
 			"tech_level": ""
 		},
@@ -12835,7 +12835,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -12856,7 +12856,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -12876,7 +12876,7 @@
 			"casting_cost": "1 per 2 ST of pull",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -12897,7 +12897,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "ryF_bQmJLgE5WDLe1",
@@ -12920,7 +12920,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -12941,7 +12941,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -12963,7 +12963,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2,
 			"tech_level": ""
 		},
@@ -12985,7 +12985,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5-10/gal #",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -13006,7 +13006,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13027,7 +13027,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -13048,7 +13048,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -13070,7 +13070,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -13092,7 +13092,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -13117,7 +13117,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -13138,7 +13138,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10,
 			"weapons": [
 				{
@@ -13173,7 +13173,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4,
 			"weapons": [
 				{
@@ -13208,7 +13208,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11,
 			"weapons": [
 				{
@@ -13243,7 +13243,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -13264,7 +13264,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6,
 			"weapons": [
 				{
@@ -13301,7 +13301,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -13322,7 +13322,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -13346,7 +13346,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "sec=cost",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 28,
 			"tech_level": ""
 		},
@@ -13370,7 +13370,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -13391,7 +13391,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -13412,7 +13412,7 @@
 			"maintenance_cost": "0",
 			"casting_time": "1 sec",
 			"duration": "Special",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13433,7 +13433,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13454,7 +13454,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -13476,7 +13476,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19
 		},
 		{
@@ -13497,7 +13497,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -13518,7 +13518,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -13539,7 +13539,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "4 sec/10 lbs",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -13560,7 +13560,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -13581,7 +13581,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -13604,7 +13604,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -13625,7 +13625,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -13646,7 +13646,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -13667,7 +13667,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -13688,7 +13688,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -13709,7 +13709,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13730,7 +13730,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -13751,7 +13751,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -13772,7 +13772,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13793,7 +13793,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -13814,7 +13814,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec/lb",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -13834,7 +13834,7 @@
 			"casting_cost": "1 per 2 ST of repulsion",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -13855,7 +13855,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13876,7 +13876,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13897,7 +13897,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13918,7 +13918,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13939,7 +13939,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13960,7 +13960,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -13981,7 +13981,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -14002,7 +14002,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -14023,7 +14023,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -14046,7 +14046,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -14067,7 +14067,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -14090,7 +14090,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -14111,7 +14111,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -14132,7 +14132,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -14157,7 +14157,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -14178,7 +14178,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -14201,7 +14201,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -14222,7 +14222,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -14246,7 +14246,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -14269,7 +14269,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -14292,7 +14292,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -14313,7 +14313,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -14334,7 +14334,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "3 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -14355,7 +14355,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -14376,7 +14376,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -14397,7 +14397,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -14418,7 +14418,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -14439,7 +14439,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -14462,7 +14462,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 Hours",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -14483,7 +14483,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "4 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -14504,7 +14504,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -14525,7 +14525,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -14547,7 +14547,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 min",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1,
 			"tech_level": ""
 		},
@@ -14569,7 +14569,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -14590,7 +14590,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "5 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -14612,7 +14612,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -14634,7 +14634,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9,
 			"weapons": [
 				{
@@ -14668,7 +14668,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 min or until free",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -14689,7 +14689,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10,
 			"weapons": [
 				{
@@ -14753,7 +14753,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -14774,7 +14774,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 sec/lb",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -14795,7 +14795,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 30
 		},
 		{
@@ -14816,7 +14816,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -14870,7 +14870,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "Instant #",
 			"duration": "1 min #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -14893,7 +14893,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -14917,7 +14917,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12,
 			"tech_level": ""
 		},
@@ -14939,7 +14939,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -14960,7 +14960,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "days=cost",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -14981,7 +14981,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -15002,7 +15002,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "10 sec",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -15023,7 +15023,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "5 sec",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15044,7 +15044,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "sec=cost",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15065,7 +15065,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15086,7 +15086,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -15108,7 +15108,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rQJfWvQ-ikDxzoZO0",
@@ -15128,7 +15128,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -15149,7 +15149,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rIEhSwbUfVSp-JLtH",
@@ -15169,7 +15169,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15190,7 +15190,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rXGet_Xt9ORtFjiPu",
@@ -15210,7 +15210,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rT15QJjyen1cAhb-r",
@@ -15230,7 +15230,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "ru2XnQAwGI2UPTPgy",
@@ -15251,7 +15251,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"tech_level": ""
 		},
 		{
@@ -15272,7 +15272,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -15294,7 +15294,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"tech_level": ""
 		},
 		{
@@ -15315,7 +15315,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15336,7 +15336,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15357,7 +15357,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r8LuflncqhT9og__g",
@@ -15378,7 +15378,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rDlWvSZQ0rNdL7L2m",
@@ -15399,7 +15399,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"tech_level": ""
 		},
 		{
@@ -15421,7 +15421,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15442,7 +15442,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rEWQt6kOfcKvmF4Nr",
@@ -15462,7 +15462,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -15483,7 +15483,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15504,7 +15504,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15525,7 +15525,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rL92yKHUL0KKqlOKv",
@@ -15545,7 +15545,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rR-1Z0ktJMtbVKkde",
@@ -15565,7 +15565,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15586,7 +15586,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15607,7 +15607,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15628,7 +15628,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -15649,7 +15649,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15670,7 +15670,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15691,7 +15691,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -15712,7 +15712,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15733,7 +15733,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15754,7 +15754,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -15776,7 +15776,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -15797,7 +15797,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15819,7 +15819,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -15840,7 +15840,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -15861,7 +15861,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "30 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -15882,7 +15882,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "3 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -15903,7 +15903,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -15924,7 +15924,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec/HP",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -15945,7 +15945,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -15967,7 +15967,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7,
 			"weapons": [
 				{
@@ -16001,7 +16001,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -16022,7 +16022,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r-HPKWDsy_rGI1Y7j",
@@ -16044,7 +16044,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -16108,7 +16108,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -16129,7 +16129,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "3 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -16150,7 +16150,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -16173,7 +16173,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -16194,7 +16194,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -16215,7 +16215,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -16236,7 +16236,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -16257,7 +16257,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 23
 		},
 		{
@@ -16278,7 +16278,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "24 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -16299,7 +16299,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "3 sec",
 			"duration": "Until awakened",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -16320,7 +16320,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -16341,7 +16341,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "3 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -16362,7 +16362,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -16383,7 +16383,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -16404,7 +16404,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "30 sec",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -16425,7 +16425,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 28
 		},
 		{
@@ -16446,7 +16446,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -16467,7 +16467,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "5 min #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3,
 			"weapons": [
 				{
@@ -16505,7 +16505,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -16526,7 +16526,7 @@
 			"maintenance_cost": "1-3",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6,
 			"weapons": [
 				{
@@ -16579,7 +16579,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -16600,7 +16600,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -16621,7 +16621,7 @@
 			"maintenance_cost": "10",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -16642,7 +16642,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -16663,7 +16663,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -16684,7 +16684,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -16705,7 +16705,7 @@
 			"maintenance_cost": "1/ min",
 			"casting_time": "1 sec",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "r-cRAfQqTCqwVLgap",
@@ -16725,7 +16725,7 @@
 			"maintenance_cost": "1-4",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4,
 			"weapons": [
 				{
@@ -16777,7 +16777,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -16800,7 +16800,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-5 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -16837,7 +16837,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "sec=radius in yards",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -16872,7 +16872,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -16894,7 +16894,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -16915,7 +16915,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -16936,7 +16936,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 23
 		},
 		{
@@ -16957,7 +16957,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -16978,7 +16978,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -16999,7 +16999,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19
 		},
 		{
@@ -17020,7 +17020,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -17041,7 +17041,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "sec=cost",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -17063,7 +17063,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3,
 			"weapons": [
 				{
@@ -17114,7 +17114,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "2 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14,
 			"weapons": [
 				{
@@ -17167,7 +17167,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -17188,7 +17188,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "24 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 23
 		},
 		{
@@ -17209,7 +17209,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -17230,7 +17230,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min per 3 FP drained",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -17251,7 +17251,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -17273,7 +17273,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"tech_level": ""
 		},
@@ -17295,7 +17295,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "24 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -17316,7 +17316,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "sec=cost",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -17337,7 +17337,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -17358,7 +17358,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min per 3 HP drained",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -17379,7 +17379,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -17400,7 +17400,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 hr",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -17421,7 +17421,7 @@
 			"maintenance_cost": "1-3",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10,
 			"weapons": [
 				{
@@ -17474,7 +17474,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -17495,7 +17495,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "5 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -17516,7 +17516,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2 sec/lb",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -17537,7 +17537,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -17590,7 +17590,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -17611,7 +17611,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -17632,7 +17632,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -17653,7 +17653,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Until spell dissipates",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -17674,7 +17674,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -17696,7 +17696,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -17719,7 +17719,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -17744,7 +17744,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -17765,7 +17765,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -17788,7 +17788,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -17809,7 +17809,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -17830,7 +17830,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -17851,7 +17851,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -17872,7 +17872,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -17893,7 +17893,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -17914,7 +17914,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "10 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -17935,7 +17935,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -17956,7 +17956,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 11
 		},
 		{
@@ -17977,7 +17977,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -17998,7 +17998,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -18019,7 +18019,7 @@
 			"maintenance_cost": "20",
 			"casting_time": "10 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -18040,7 +18040,7 @@
 			"maintenance_cost": "10",
 			"casting_time": "5 min",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -18061,7 +18061,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -18082,7 +18082,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1-3 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7,
 			"weapons": [
 				{
@@ -18135,7 +18135,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -18156,7 +18156,7 @@
 			"maintenance_cost": "10",
 			"casting_time": "1 min",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -18177,7 +18177,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -18198,7 +18198,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 22
 		},
 		{
@@ -18219,7 +18219,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec/pt",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -18240,7 +18240,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 min",
 			"duration": "Varies",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -18261,7 +18261,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -18282,7 +18282,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 min",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 30
 		},
 		{
@@ -18303,7 +18303,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "30 sec",
 			"duration": "Until Awakened",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -18326,7 +18326,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -18347,7 +18347,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -18368,7 +18368,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "2",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -18389,7 +18389,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -18410,7 +18410,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "5 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 17
 		},
 		{
@@ -18431,7 +18431,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -18454,7 +18454,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -18477,7 +18477,7 @@
 			"maintenance_cost": "_",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -18500,7 +18500,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -18521,7 +18521,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -18542,7 +18542,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "rGVAP4ce2ppm4H4BM",
@@ -18562,7 +18562,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Indefinite #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -18583,7 +18583,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -18604,7 +18604,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "ra0ikjCKE9n_8jQts",
@@ -18625,7 +18625,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"tech_level": ""
 		},
 		{
@@ -18646,7 +18646,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -18669,7 +18669,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Until drink/rest",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -18691,7 +18691,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Until thrown",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20,
 			"weapons": [
 				{
@@ -18743,7 +18743,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -18764,7 +18764,7 @@
 			"maintenance_cost": "5",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -18787,7 +18787,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -18808,7 +18808,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 min",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 30
 		},
 		{
@@ -18829,7 +18829,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -18850,7 +18850,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -18871,7 +18871,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 9
 		},
 		{
@@ -18892,7 +18892,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -18913,7 +18913,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7,
 			"weapons": [
 				{
@@ -18977,7 +18977,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic"
+			"base_skill": "Ritual Magic College"
 		},
 		{
 			"id": "ry9KpGfwEmxGu2z2i",
@@ -18997,7 +18997,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "5 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -19018,7 +19018,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -19041,7 +19041,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -19062,7 +19062,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -19083,7 +19083,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "cost=sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 15
 		},
 		{
@@ -19104,7 +19104,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "2 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 20
 		},
 		{
@@ -19125,7 +19125,7 @@
 			"maintenance_cost": "20",
 			"casting_time": "2 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 27
 		},
 		{
@@ -19146,7 +19146,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "10 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 12
 		},
 		{
@@ -19167,7 +19167,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -19188,7 +19188,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -19209,7 +19209,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -19230,7 +19230,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "4 sec",
 			"duration": "Turned undead will avoid caster for 1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -19253,7 +19253,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "2 sec",
 			"duration": "10 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -19274,7 +19274,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -19295,7 +19295,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 16
 		},
 		{
@@ -19316,7 +19316,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 18
 		},
 		{
@@ -19337,7 +19337,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -19358,7 +19358,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "1 night",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 10
 		},
 		{
@@ -19379,7 +19379,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -19400,7 +19400,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -19421,7 +19421,7 @@
 			"maintenance_cost": "10",
 			"casting_time": "1 hr #",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -19442,7 +19442,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -19463,7 +19463,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -19484,7 +19484,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "10 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -19505,7 +19505,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -19526,7 +19526,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "3 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -19547,7 +19547,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -19568,7 +19568,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -19591,7 +19591,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -19612,7 +19612,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -19633,7 +19633,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "Instant",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -19654,7 +19654,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -19675,7 +19675,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 1
 		},
 		{
@@ -19698,7 +19698,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -19721,7 +19721,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "10 sec",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -19742,7 +19742,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "10 sec",
 			"duration": "10 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 2
 		},
 		{
@@ -19763,7 +19763,7 @@
 			"maintenance_cost": "1-3",
 			"casting_time": "1 sec",
 			"duration": "1 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4,
 			"weapons": [
 				{
@@ -19817,7 +19817,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -19840,7 +19840,7 @@
 			"maintenance_cost": "1",
 			"casting_time": "1 sec",
 			"duration": "30 sec",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -19863,7 +19863,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -19885,7 +19885,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "5 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5,
 			"weapons": [
 				{
@@ -19921,7 +19921,7 @@
 			"maintenance_cost": "5",
 			"casting_time": "1 sec",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -19942,7 +19942,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -19963,7 +19963,7 @@
 			"maintenance_cost": "4",
 			"casting_time": "5 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -19984,7 +19984,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 14
 		},
 		{
@@ -20007,7 +20007,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "1 sec",
 			"duration": "6 hrs",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -20028,7 +20028,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "Varies",
 			"duration": "1 min #",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -20049,7 +20049,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "Varies",
 			"duration": "1 day",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -20072,7 +20072,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 min",
 			"duration": "1 hr",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -20093,7 +20093,7 @@
 			"maintenance_cost": "Half",
 			"casting_time": "Instant",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -20115,7 +20115,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Instant",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3,
 			"weapons": [
 				{
@@ -20163,7 +20163,7 @@
 			"maintenance_cost": "Same",
 			"casting_time": "1 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -20184,7 +20184,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "-",
 			"duration": "Special",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 19
 		},
 		{
@@ -20205,7 +20205,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8,
 			"weapons": [
 				{
@@ -20269,7 +20269,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "10 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -20290,7 +20290,7 @@
 			"maintenance_cost": "3",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		},
 		{
@@ -20311,7 +20311,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 3
 		},
 		{
@@ -20334,7 +20334,7 @@
 			"maintenance_cost": "Varies",
 			"casting_time": "3 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 5
 		},
 		{
@@ -20359,7 +20359,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 8
 		},
 		{
@@ -20382,7 +20382,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "2 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 4
 		},
 		{
@@ -20403,7 +20403,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 sec",
 			"duration": "Permanent",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 34
 		},
 		{
@@ -20424,7 +20424,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1",
 			"duration": "Instant; aging starts immediately",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 13
 		},
 		{
@@ -20445,7 +20445,7 @@
 			"maintenance_cost": "-",
 			"casting_time": "1 min",
 			"duration": "until destroyed",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 6
 		},
 		{
@@ -20466,7 +20466,7 @@
 			"maintenance_cost": "2",
 			"casting_time": "4 sec",
 			"duration": "1 min",
-			"base_skill": "Ritual Magic",
+			"base_skill": "Ritual Magic College",
 			"prereq_count": 7
 		}
 	]


### PR DESCRIPTION
Context
===
The Ritual Magic system from Basic Set p.242 and Magic p.200, has one core skill, one skill per college, and one technique per skill.

It was raised in https://github.com/richardwilkes/gcs/issues/810 that defaults misbehave when there's a mixture of skills with specializations and skills without specialization.

I had a look at the problem, and it seems that Ritual Magic needs a separate skill for the core Ritual Magic skill, and a skill for each college that defaults to the core ritual magic skill, otherwise the Ritual Magic (Hermetic) skill could attempt to default to the Ritual Magic (Communication & Empathy) skill.

As of gcs v5.43.0, there is a context menu option to change the order that traits default to each other, but I think there could still be confusion over what the player needs to do.

Changes
===

* I created a new skill, Ritual Magic College (@College@), which defaults to a core skill and has prerequisites set up to warn if it exceeds its core skill.
  - The skill uses substitutions for the core skill (e.g. it could be Thaumatology instead of Ritual Magic); tradition (e.g. Hermetic, Voodoo or Witchcraft), since Ritual Magic specializes by tradition; and each individual college.
* I changed all of the ritual magic spells from the Ritual Magic Spells list to be based off "Ritual Magic College" instead of "Ritual Magic".
* I updated the Ritual Magery trait in Basic Set Traits to give a bonus to the Ritual Magic College skill too.
* I updated the Basic Set example character, William Headley, to use the new Ritual Magic College skills and the updated Ritual Magery and Ritual Magic Spells.

Potential issues
===

* I may be ignorant of some of the technicalities that led to Ritual Magic college skills using the Ritual Magic skill in the first place.
* The prerequisite counts for some of the Ritual Magic spells on William Headley's sheet differs from the counts listed in the spell table of GURPS Magic. I don't know if this is an error in gcs or errata that I can't find.
* Perhaps I should create a version of Ritual Magic College for every college, in addition to having the substitution.
* I have not checked over the entire master library whether there are other uses or implementations of Ritual Magic that should also be updated.