### PR TITLE
Add updated optional specialties

### DIFF
--- a/Library/Basic Set/Basic Set Skills.skl
+++ b/Library/Basic Set/Basic Set Skills.skl
@@ -1260,6 +1260,29 @@
 			"points": 1
 		},
 		{
+			"id": "sfK9axZ_b-gCStIjJ",
+			"name": "Artist",
+			"reference": "B179",
+			"tags": [
+				"Arts",
+				"Entertainment"
+			],
+			"specialization": "@Art@, @Medium or Technique@",
+			"difficulty": "iq/a",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"modifier": -6
+				}
+			],
+			"points": 1
+		},
+		{
 			"id": "sJtFqogZvXvdp98HU",
 			"name": "Artist",
 			"reference": "B179",
@@ -1269,6 +1292,53 @@
 			],
 			"specialization": "Body Art",
 			"difficulty": "iq/h",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Calligraphy",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Drawing",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Illumination",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Painting",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"modifier": -6
+				}
+			],
+			"points": 1
+		},
+		{
+			"id": "siHDPnzTG7zagkf_U",
+			"name": "Artist",
+			"reference": "B179",
+			"tags": [
+				"Arts",
+				"Entertainment"
+			],
+			"specialization": "Body Art, @Medium or Technique@",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -1354,6 +1424,53 @@
 			"points": 1
 		},
 		{
+			"id": "s6tvgrKxkCCqdNUgB",
+			"name": "Artist",
+			"reference": "B179",
+			"tags": [
+				"Arts",
+				"Entertainment"
+			],
+			"specialization": "Calligraphy, @Medium or Technique@",
+			"difficulty": "iq/a",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Drawing",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Illumination",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Painting",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Body Art",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"modifier": -6
+				}
+			],
+			"points": 1
+		},
+		{
 			"id": "sY280WwWVjW5xMSDT",
 			"name": "Artist",
 			"reference": "B179",
@@ -1363,6 +1480,53 @@
 			],
 			"specialization": "Drawing",
 			"difficulty": "iq/h",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Calligraphy",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Illumination",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Painting",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Body Art",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"modifier": -6
+				}
+			],
+			"points": 1
+		},
+		{
+			"id": "sixGcxJUCjtVjNvvw",
+			"name": "Artist",
+			"reference": "B179",
+			"tags": [
+				"Arts",
+				"Entertainment"
+			],
+			"specialization": "Drawing, @Medium or Technique@",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -1448,6 +1612,53 @@
 			"points": 1
 		},
 		{
+			"id": "slv6Ngy1wrsxNPERt",
+			"name": "Artist",
+			"reference": "B179",
+			"tags": [
+				"Arts",
+				"Entertainment"
+			],
+			"specialization": "Illumination, @Medium or Technique@",
+			"difficulty": "iq/a",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Calligraphy",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Drawing",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Painting",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Body Art",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"modifier": -6
+				}
+			],
+			"points": 1
+		},
+		{
 			"id": "sfTqnqvKxU4iwgY5n",
 			"name": "Artist",
 			"reference": "B179",
@@ -1471,6 +1682,29 @@
 			"points": 1
 		},
 		{
+			"id": "sXXHhjn0fqCZn_fQv",
+			"name": "Artist",
+			"reference": "B179",
+			"tags": [
+				"Arts",
+				"Entertainment"
+			],
+			"specialization": "Illusion, @Medium or Technique@",
+			"difficulty": "iq/a",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"modifier": -6
+				}
+			],
+			"points": 1
+		},
+		{
 			"id": "sTYnd1Hfq4_eb2LK1",
 			"name": "Artist",
 			"reference": "B179",
@@ -1480,6 +1714,46 @@
 			],
 			"specialization": "Interior Decorating",
 			"difficulty": "iq/h",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Architecture",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Scene Design",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Woodworking",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"modifier": -6
+				}
+			],
+			"points": 1
+		},
+		{
+			"id": "sM_6o84xKEAf8cjRu",
+			"name": "Artist",
+			"reference": "B179",
+			"tags": [
+				"Arts",
+				"Entertainment"
+			],
+			"specialization": "Interior Decorating, @Medium or Technique@",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -1558,6 +1832,53 @@
 			"points": 1
 		},
 		{
+			"id": "s5IQwnsVXcIl3d_Nf",
+			"name": "Artist",
+			"reference": "B179",
+			"tags": [
+				"Arts",
+				"Entertainment"
+			],
+			"specialization": "Painting, @Medium or Technique@",
+			"difficulty": "iq/a",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Calligraphy",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Drawing",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Illumination",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Body Art",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"modifier": -6
+				}
+			],
+			"points": 1
+		},
+		{
 			"id": "skVQStZ2N2L_MyNFv",
 			"name": "Artist",
 			"reference": "B179",
@@ -1582,6 +1903,30 @@
 			"points": 1
 		},
 		{
+			"id": "swsFR9PpagVmDICzd",
+			"name": "Artist",
+			"reference": "B179",
+			"tags": [
+				"Arts",
+				"Craft",
+				"Entertainment"
+			],
+			"specialization": "Pottery, @Medium or Technique@",
+			"difficulty": "iq/a",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"modifier": -6
+				}
+			],
+			"points": 1
+		},
+		{
 			"id": "sJOrjo0jHAGua61_P",
 			"name": "Artist",
 			"reference": "B179",
@@ -1591,6 +1936,46 @@
 			],
 			"specialization": "Scene Design",
 			"difficulty": "iq/h",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Architecture",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Interior Decorating",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Woodworking",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"modifier": -6
+				}
+			],
+			"points": 1
+		},
+		{
+			"id": "ssND2-0x5rr4cQzv7",
+			"name": "Artist",
+			"reference": "B179",
+			"tags": [
+				"Arts",
+				"Entertainment"
+			],
+			"specialization": "Scene Design, @Medium or Technique@",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -1646,6 +2031,30 @@
 			"points": 1
 		},
 		{
+			"id": "sM_di9y39TqbTQokP",
+			"name": "Artist",
+			"reference": "B179",
+			"tags": [
+				"Arts",
+				"Craft",
+				"Entertainment"
+			],
+			"specialization": "Sculpting, @Medium or Technique@",
+			"difficulty": "iq/a",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"modifier": -6
+				}
+			],
+			"points": 1
+		},
+		{
 			"id": "s38HO2qYj0r9TPpp9",
 			"name": "Artist",
 			"reference": "B179",
@@ -1656,6 +2065,47 @@
 			],
 			"specialization": "Woodworking",
 			"difficulty": "iq/h",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Carpentry",
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Interior Decorating",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"specialization": "Scene Design",
+					"modifier": -4
+				},
+				{
+					"type": "skill",
+					"name": "Artist",
+					"modifier": -6
+				}
+			],
+			"points": 1
+		},
+		{
+			"id": "scbjqPHc79vyk21Vs",
+			"name": "Artist",
+			"reference": "B179",
+			"tags": [
+				"Arts",
+				"Craft",
+				"Entertainment"
+			],
+			"specialization": "Woodworking, @Medium or Technique@",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2122,8 +2572,32 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "@Specialty@",
+			"specialization": "@Planet Type@",
 			"difficulty": "iq/vh",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Naturalist",
+					"modifier": -6
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
+			"id": "s6JkH6Dij5PLKRrZA",
+			"name": "Biology",
+			"reference": "B180",
+			"tags": [
+				"Natural Science",
+				"Plant"
+			],
+			"specialization": "@Planet Type@, @TL 6+ Optional Specialty@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2146,8 +2620,8 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "Biochemistry",
-			"difficulty": "iq/vh",
+			"specialization": "@Planet Type@, Biochemistry",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2170,8 +2644,8 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "Botany",
-			"difficulty": "iq/vh",
+			"specialization": "@Planet Type@, Botany",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2211,6 +2685,30 @@
 			"points": 1
 		},
 		{
+			"id": "shrYid3RrPGk2i5Bc",
+			"name": "Biology",
+			"reference": "B180",
+			"tags": [
+				"Natural Science",
+				"Plant"
+			],
+			"specialization": "Earthlike, @TL 6+ Optional Specialty@",
+			"difficulty": "iq/h",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Naturalist",
+					"modifier": -6
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
 			"id": "sO2sQPjUCQNumo8zY",
 			"name": "Biology",
 			"reference": "B180",
@@ -2218,8 +2716,8 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "Ecology",
-			"difficulty": "iq/vh",
+			"specialization": "@Planet Type@, Ecology",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2259,6 +2757,30 @@
 			"points": 1
 		},
 		{
+			"id": "sTBFbvMzwLv_8WbCt",
+			"name": "Biology",
+			"reference": "B180",
+			"tags": [
+				"Natural Science",
+				"Plant"
+			],
+			"specialization": "Gas Giants, @TL 6+ Optional Specialty@",
+			"difficulty": "iq/h",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Naturalist",
+					"modifier": -6
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
 			"id": "sZb5qju0ItFw6MC5t",
 			"name": "Biology",
 			"reference": "B180",
@@ -2266,8 +2788,8 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "Genetics",
-			"difficulty": "iq/vh",
+			"specialization": "@Planet Type@, Genetics",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2307,6 +2829,30 @@
 			"points": 1
 		},
 		{
+			"id": "sF1pvdUamZHFV8ODy",
+			"name": "Biology",
+			"reference": "B180",
+			"tags": [
+				"Natural Science",
+				"Plant"
+			],
+			"specialization": "Hostile Terrestrial, @TL 6+ Optional Specialty@",
+			"difficulty": "iq/h",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Naturalist",
+					"modifier": -6
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
 			"id": "slcsH6hlZt-hqBja9",
 			"name": "Biology",
 			"reference": "B180",
@@ -2316,6 +2862,30 @@
 			],
 			"specialization": "Ice Dwarfs",
 			"difficulty": "iq/vh",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Naturalist",
+					"modifier": -6
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
+			"id": "sb9wSZDGkAmhMtfMO",
+			"name": "Biology",
+			"reference": "B180",
+			"tags": [
+				"Natural Science",
+				"Plant"
+			],
+			"specialization": "Ice Dwarfs, @TL 6+ Optional Specialty@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2355,6 +2925,30 @@
 			"points": 1
 		},
 		{
+			"id": "s-JF1qbNw-nWGfrmS",
+			"name": "Biology",
+			"reference": "B180",
+			"tags": [
+				"Natural Science",
+				"Plant"
+			],
+			"specialization": "Ice Worlds, @TL 6+ Optional Specialty@",
+			"difficulty": "iq/h",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Naturalist",
+					"modifier": -6
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
 			"id": "sjwJIejxzqb2ukpSd",
 			"name": "Biology",
 			"reference": "B180",
@@ -2362,8 +2956,8 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "Marine Biology",
-			"difficulty": "iq/vh",
+			"specialization": "@Planet Type@, Marine Biology",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2386,8 +2980,8 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "Microbiology",
-			"difficulty": "iq/vh",
+			"specialization": "@Planet Type@, Microbiology",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2410,8 +3004,8 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "Rock Worlds",
-			"difficulty": "iq/vh",
+			"specialization": "Rock Worlds, @TL 6+ Optional Specialty@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2433,8 +3027,8 @@
 			"tags": [
 				"Natural Science"
 			],
-			"specialization": "Zoology",
-			"difficulty": "iq/vh",
+			"specialization": "@Planet Type@, Zoology",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -3165,6 +3759,34 @@
 			"difficulty": "iq/h",
 			"defaults": [
 				{
+					"type": "skill",
+					"name": "Chemistry",
+					"modifier": -2
+				},
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Alchemy",
+					"modifier": -3
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
+			"id": "sQUS7IvTc0UCF4atT",
+			"name": "Chemistry",
+			"reference": "B183",
+			"tags": [
+				"Natural Science"
+			],
+			"specialization": "@Optional Specialty@",
+			"difficulty": "iq/a",
+			"defaults": [
+				{
 					"type": "iq",
 					"modifier": -6
 				},
@@ -3692,6 +4314,11 @@
 			"difficulty": "iq/a",
 			"defaults": [
 				{
+					"type": "skill",
+					"name": "Cooking",
+					"modifier": -2
+				},
+				{
 					"type": "iq",
 					"modifier": -5
 				},
@@ -3710,7 +4337,7 @@
 			"tags": [
 				"Everyman"
 			],
-			"specialization": "@Specialty@",
+			"specialization": "@Optional Specialty@",
 			"difficulty": "iq/e",
 			"defaults": [
 				{
@@ -10855,6 +11482,61 @@
 			"difficulty": "iq/h",
 			"defaults": [
 				{
+					"type": "skill",
+					"name": "Intelligence Analysis",
+					"modifier": -2
+				},
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Strategy",
+					"modifier": -6
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
+			"id": "sUGrqFOK8iCyjAOiq",
+			"name": "Intelligence Analysis",
+			"reference": "B201",
+			"tags": [
+				"Military",
+				"Police",
+				"Spy"
+			],
+			"specialization": "@Optional Specialty@",
+			"difficulty": "iq/a",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Strategy",
+					"modifier": -6
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
+			"id": "sDWPPGbydybj2llAe",
+			"name": "Intelligence Analysis",
+			"reference": "B201",
+			"tags": [
+				"Military",
+				"Police",
+				"Spy"
+			],
+			"specialization": "Traffic Analysis",
+			"difficulty": "iq/a",
+			"defaults": [
+				{
 					"type": "iq",
 					"modifier": -6
 				},
@@ -11683,6 +12365,30 @@
 				"Social Sciences"
 			],
 			"difficulty": "iq/h",
+			"defaults": [
+				{
+					"type": "skill",
+					"name": "Literature",
+					"modifier": -2
+				},
+				{
+					"type": "iq",
+					"modifier": -6
+				}
+			],
+			"points": 1
+		},
+		{
+			"id": "shjAotp-MouDKt35p",
+			"name": "Literature",
+			"reference": "B205",
+			"tags": [
+				"Humanities",
+				"Scholarly",
+				"Social Sciences"
+			],
+			"specialization": "@Optional Specialty@",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -13671,6 +14377,39 @@
 				},
 				{
 					"type": "skill",
+					"name": "Merchant",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Finance",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Market Analysis",
+					"modifier": -4
+				}
+			],
+			"points": 1
+		},
+		{
+			"id": "sXR5SC1i1KPL7DcMI",
+			"name": "Merchant",
+			"reference": "B209",
+			"tags": [
+				"Business",
+				"Social"
+			],
+			"specialization": "@Class of Goods@",
+			"difficulty": "iq/e",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
 					"name": "Finance",
 					"modifier": -6
 				},
@@ -15169,6 +15908,15 @@
 			"difficulty": "iq/vh",
 			"defaults": [
 				{
+					"type": "skill",
+					"name": "Physics",
+					"modifier": -2,
+					"when_tl": {
+						"compare": "at_least",
+						"qualifier": 6
+					}
+				},
+				{
 					"type": "iq",
 					"modifier": -6
 				}
@@ -16195,6 +16943,215 @@
 				"Social"
 			],
 			"difficulty": "iq/a",
+			"defaults": [
+				{
+					"type": "skill",
+					"name": "Public Speaking",
+					"modifier": -2
+				},
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Acting",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Performance",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Politics",
+					"modifier": -5
+				}
+			],
+			"points": 1
+		},
+		{
+			"id": "sduFaSDlp484-vLqq",
+			"name": "Public Speaking",
+			"reference": "B216",
+			"tags": [
+				"Business",
+				"Scholarly",
+				"Social"
+			],
+			"specialization": "@Optional Specialty@",
+			"difficulty": "iq/e",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Acting",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Performance",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Politics",
+					"modifier": -5
+				}
+			],
+			"points": 1
+		},
+		{
+			"id": "sENARxxD9bmvIUBcl",
+			"name": "Public Speaking",
+			"reference": "B216",
+			"tags": [
+				"Business",
+				"Scholarly",
+				"Social"
+			],
+			"specialization": "Debate",
+			"difficulty": "iq/e",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Acting",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Performance",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Politics",
+					"modifier": -5
+				}
+			],
+			"points": 1
+		},
+		{
+			"id": "sL1uEO0p0zqGlT4wi",
+			"name": "Public Speaking",
+			"reference": "B216",
+			"tags": [
+				"Business",
+				"Scholarly",
+				"Social"
+			],
+			"specialization": "Oratory",
+			"difficulty": "iq/e",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Acting",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Performance",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Politics",
+					"modifier": -5
+				}
+			],
+			"points": 1
+		},
+		{
+			"id": "svoDODF761s2ht-Ex",
+			"name": "Public Speaking",
+			"reference": "B216",
+			"tags": [
+				"Business",
+				"Scholarly",
+				"Social"
+			],
+			"specialization": "Rhetoric",
+			"difficulty": "iq/e",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Acting",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Performance",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Politics",
+					"modifier": -5
+				}
+			],
+			"points": 1
+		},
+		{
+			"id": "szo5nYH4aBSIFdDN8",
+			"name": "Public Speaking",
+			"reference": "B216",
+			"tags": [
+				"Business",
+				"Scholarly",
+				"Social"
+			],
+			"specialization": "Punning",
+			"difficulty": "iq/e",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Acting",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Performance",
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": "Politics",
+					"modifier": -5
+				}
+			],
+			"points": 1
+		},
+		{
+			"id": "sOMSi8TaDp7zLc2jd",
+			"name": "Public Speaking",
+			"reference": "B216",
+			"tags": [
+				"Business",
+				"Scholarly",
+				"Social"
+			],
+			"specialization": "Storytelling",
+			"difficulty": "iq/e",
 			"defaults": [
 				{
 					"type": "iq",
@@ -20473,6 +21430,36 @@
 				"Medical"
 			],
 			"difficulty": "iq/h",
+			"defaults": [
+				{
+					"type": "skill",
+					"name": "Animal Handling",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": "Physician",
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": "Surgery",
+					"modifier": -5
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
+			"id": "s8Bm4Y9uWLXH2qkWX",
+			"name": "Veterinary",
+			"reference": "B228",
+			"tags": [
+				"Animal",
+				"Medical"
+			],
+			"specialization": "@Optional Specialty@",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "skill",

--- a/Library/Basic Set/Basic Set Skills.skl
+++ b/Library/Basic Set/Basic Set Skills.skl
@@ -23853,6 +23853,142 @@
 			"points": 1
 		},
 		{
+			"id": "saj9W_CJzsy9wTWmv",
+			"name": "Surgery",
+			"reference": "B223",
+			"tags": [
+				"Medical"
+			],
+			"optional_specialization": "@Body Part@",
+			"difficulty": "iq/vh",
+			"defaults": [
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "First Aid"
+					},
+					"modifier": -12
+				},
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					},
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physiology"
+					},
+					"modifier": -8
+				},
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Veterinary"
+					},
+					"modifier": -5
+				}
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": false,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "first aid"
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "physician"
+						}
+					}
+				]
+			},
+			"tech_level": "",
+			"points": 1
+		},
+		{
+			"id": "sDBopoRbLn7X-VUv6",
+			"name": "Surgery",
+			"reference": "B223",
+			"tags": [
+				"Medical"
+			],
+			"optional_specialization": "@Surgery Type@",
+			"difficulty": "iq/vh",
+			"defaults": [
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "First Aid"
+					},
+					"modifier": -12
+				},
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					},
+					"modifier": -5
+				},
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physiology"
+					},
+					"modifier": -8
+				},
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Veterinary"
+					},
+					"modifier": -5
+				}
+			],
+			"prereqs": {
+				"type": "prereq_list",
+				"all": false,
+				"prereqs": [
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "first aid"
+						}
+					},
+					{
+						"type": "skill_prereq",
+						"has": true,
+						"name": {
+							"compare": "is",
+							"qualifier": "physician"
+						}
+					}
+				]
+			},
+			"tech_level": "",
+			"points": 1
+		},
+		{
 			"id": "swx1BRcN-EGMO4e1Y",
 			"name": "Survival",
 			"reference": "B223",

--- a/Library/Basic Set/Basic Set Skills.skl
+++ b/Library/Basic Set/Basic Set Skills.skl
@@ -16,18 +16,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Finance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Finance"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Mathematics",
-					"specialization": "Statistics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mathematics"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Statistics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Merchant",
+					"name": {
+						"compare": "is",
+						"qualifier": "Merchant"
+					},
 					"modifier": -5
 				}
 			],
@@ -48,12 +60,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Aerobatics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Aerobatics"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Aquabatics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Aquabatics"
+					},
 					"modifier": -4
 				}
 			],
@@ -75,12 +93,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Performance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Performance"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Public Speaking",
+					"name": {
+						"compare": "is",
+						"qualifier": "Public Speaking"
+					},
 					"modifier": -5
 				}
 			],
@@ -98,7 +122,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Merchant",
+					"name": {
+						"compare": "is",
+						"qualifier": "Merchant"
+					},
 					"modifier": -3
 				},
 				{
@@ -123,12 +150,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acrobatics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acrobatics"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Aquabatics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Aquabatics"
+					},
 					"modifier": -4
 				}
 			],
@@ -266,13 +299,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Paleontology",
-					"specialization": "Paleoanthropology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Paleontology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Paleoanthropology"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Sociology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Sociology"
+					},
 					"modifier": -3
 				}
 			],
@@ -293,12 +335,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acrobatics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acrobatics"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Aerobatics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Aerobatics"
+					},
 					"modifier": -4
 				}
 			],
@@ -337,8 +385,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Civil",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Civil"
+					},
 					"modifier": -4
 				}
 			],
@@ -359,8 +413,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -384,8 +444,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -405,8 +471,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -430,8 +502,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -451,8 +529,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -476,8 +560,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -497,8 +587,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -522,8 +618,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -543,8 +645,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -568,8 +676,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -589,8 +703,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -614,8 +734,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -635,8 +761,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -660,8 +792,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -681,8 +819,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -706,8 +850,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -727,8 +877,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -752,8 +908,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -772,7 +934,10 @@
 			"difficulty": "a",
 			"default": {
 				"type": "skill",
-				"name": "Judo"
+				"name": {
+					"compare": "is",
+					"qualifier": "Judo"
+				}
 			},
 			"limit": 4,
 			"points": 1
@@ -790,7 +955,10 @@
 			"difficulty": "a",
 			"default": {
 				"type": "skill",
-				"name": "Wrestling"
+				"name": {
+					"compare": "is",
+					"qualifier": "Wrestling"
+				}
 			},
 			"limit": 4,
 			"points": 1
@@ -813,8 +981,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "@Armor type@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Armor type@"
+					},
 					"modifier": -4
 				}
 			],
@@ -839,8 +1013,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Battlesuits",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Battlesuits"
+					},
 					"modifier": -4
 				}
 			],
@@ -865,14 +1045,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Body Armor",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Body Armor"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Smith",
-					"specialization": "Bronze",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smith"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Bronze"
+					},
 					"modifier": -3,
 					"when_tl": {
 						"compare": "is",
@@ -881,8 +1073,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Smith",
-					"specialization": "Iron",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smith"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Iron"
+					},
 					"modifier": -3,
 					"when_tl": {
 						"compare": "at_most",
@@ -891,7 +1089,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -3,
 					"when_tl": {
 						"compare": "at_least",
@@ -920,8 +1121,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Force Shields",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Force Shields"
+					},
 					"modifier": -4
 				}
 			],
@@ -946,8 +1153,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Heavy Weapons",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Heavy Weapons"
+					},
 					"modifier": -4
 				}
 			],
@@ -972,14 +1185,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Melee Weapons",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Melee Weapons"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Smith",
-					"specialization": "Bronze",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smith"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Bronze"
+					},
 					"modifier": -3,
 					"when_tl": {
 						"compare": "is",
@@ -988,8 +1213,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Smith",
-					"specialization": "Iron",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smith"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Iron"
+					},
 					"modifier": -3,
 					"when_tl": {
 						"compare": "at_most",
@@ -998,7 +1229,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -3,
 					"when_tl": {
 						"compare": "at_least",
@@ -1027,8 +1261,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Missile Weapons",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Missile Weapons"
+					},
 					"modifier": -4
 				}
 			],
@@ -1053,13 +1293,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Small Arms",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Small Arms"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5,
 					"when_tl": {
 						"compare": "at_least",
@@ -1088,8 +1337,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Vehicular Armor",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Vehicular Armor"
+					},
 					"modifier": -4
 				}
 			],
@@ -1253,7 +1508,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1267,8 +1525,9 @@
 				"Arts",
 				"Entertainment"
 			],
-			"specialization": "@Art@, @Medium or Technique@",
-			"difficulty": "iq/a",
+			"specialization": "@Art@",
+			"optional_specialization": "@Medium or Technique@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -1276,7 +1535,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1299,31 +1561,58 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Calligraphy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Calligraphy"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Drawing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Drawing"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Illumination",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Illumination"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Painting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Painting"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1337,8 +1626,9 @@
 				"Arts",
 				"Entertainment"
 			],
-			"specialization": "Body Art, @Medium or Technique@",
-			"difficulty": "iq/a",
+			"specialization": "Body Art",
+			"optional_specialization": "@Medium or Technique@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -1346,31 +1636,58 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Calligraphy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Calligraphy"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Drawing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Drawing"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Illumination",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Illumination"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Painting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Painting"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1393,31 +1710,58 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Drawing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Drawing"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Illumination",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Illumination"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Painting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Painting"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Body Art",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Body Art"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1431,8 +1775,9 @@
 				"Arts",
 				"Entertainment"
 			],
-			"specialization": "Calligraphy, @Medium or Technique@",
-			"difficulty": "iq/a",
+			"specialization": "Calligraphy",
+			"optional_specialization": "@Medium or Technique@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -1440,31 +1785,58 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Drawing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Drawing"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Illumination",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Illumination"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Painting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Painting"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Body Art",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Body Art"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1487,31 +1859,58 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Calligraphy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Calligraphy"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Illumination",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Illumination"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Painting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Painting"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Body Art",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Body Art"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1525,8 +1924,9 @@
 				"Arts",
 				"Entertainment"
 			],
-			"specialization": "Drawing, @Medium or Technique@",
-			"difficulty": "iq/a",
+			"specialization": "Drawing",
+			"optional_specialization": "@Medium or Technique@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -1534,31 +1934,58 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Calligraphy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Calligraphy"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Illumination",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Illumination"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Painting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Painting"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Body Art",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Body Art"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1581,31 +2008,58 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Calligraphy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Calligraphy"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Drawing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Drawing"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Painting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Painting"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Body Art",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Body Art"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1619,8 +2073,9 @@
 				"Arts",
 				"Entertainment"
 			],
-			"specialization": "Illumination, @Medium or Technique@",
-			"difficulty": "iq/a",
+			"specialization": "Illumination",
+			"optional_specialization": "@Medium or Technique@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -1628,31 +2083,58 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Calligraphy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Calligraphy"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Drawing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Drawing"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Painting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Painting"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Body Art",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Body Art"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1675,7 +2157,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1689,8 +2174,9 @@
 				"Arts",
 				"Entertainment"
 			],
-			"specialization": "Illusion, @Medium or Technique@",
-			"difficulty": "iq/a",
+			"specialization": "Illusion",
+			"optional_specialization": "@Medium or Technique@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -1698,7 +2184,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1721,24 +2210,42 @@
 				},
 				{
 					"type": "skill",
-					"name": "Architecture",
+					"name": {
+						"compare": "is",
+						"qualifier": "Architecture"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Scene Design",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Scene Design"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Woodworking",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Woodworking"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1752,8 +2259,9 @@
 				"Arts",
 				"Entertainment"
 			],
-			"specialization": "Interior Decorating, @Medium or Technique@",
-			"difficulty": "iq/a",
+			"specialization": "Interior Decorating",
+			"optional_specialization": "@Medium or Technique@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -1761,24 +2269,42 @@
 				},
 				{
 					"type": "skill",
-					"name": "Architecture",
+					"name": {
+						"compare": "is",
+						"qualifier": "Architecture"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Scene Design",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Scene Design"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Woodworking",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Woodworking"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1801,31 +2327,58 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Calligraphy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Calligraphy"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Drawing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Drawing"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Illumination",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Illumination"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Body Art",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Body Art"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1839,8 +2392,9 @@
 				"Arts",
 				"Entertainment"
 			],
-			"specialization": "Painting, @Medium or Technique@",
-			"difficulty": "iq/a",
+			"specialization": "Painting",
+			"optional_specialization": "@Medium or Technique@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -1848,31 +2402,58 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Calligraphy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Calligraphy"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Drawing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Drawing"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Illumination",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Illumination"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Body Art",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Body Art"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1896,7 +2477,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1911,8 +2495,9 @@
 				"Craft",
 				"Entertainment"
 			],
-			"specialization": "Pottery, @Medium or Technique@",
-			"difficulty": "iq/a",
+			"specialization": "Pottery",
+			"optional_specialization": "@Medium or Technique@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -1920,7 +2505,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1943,24 +2531,42 @@
 				},
 				{
 					"type": "skill",
-					"name": "Architecture",
+					"name": {
+						"compare": "is",
+						"qualifier": "Architecture"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Interior Decorating",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Interior Decorating"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Woodworking",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Woodworking"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -1974,8 +2580,9 @@
 				"Arts",
 				"Entertainment"
 			],
-			"specialization": "Scene Design, @Medium or Technique@",
-			"difficulty": "iq/a",
+			"specialization": "Scene Design",
+			"optional_specialization": "@Medium or Technique@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -1983,24 +2590,42 @@
 				},
 				{
 					"type": "skill",
-					"name": "Architecture",
+					"name": {
+						"compare": "is",
+						"qualifier": "Architecture"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Interior Decorating",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Interior Decorating"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Woodworking",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Woodworking"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2024,7 +2649,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2039,8 +2667,9 @@
 				"Craft",
 				"Entertainment"
 			],
-			"specialization": "Sculpting, @Medium or Technique@",
-			"difficulty": "iq/a",
+			"specialization": "Sculpting",
+			"optional_specialization": "@Medium or Technique@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2048,7 +2677,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2072,24 +2704,42 @@
 				},
 				{
 					"type": "skill",
-					"name": "Carpentry",
+					"name": {
+						"compare": "is",
+						"qualifier": "Carpentry"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Interior Decorating",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Interior Decorating"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Scene Design",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Scene Design"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2104,8 +2754,9 @@
 				"Craft",
 				"Entertainment"
 			],
-			"specialization": "Woodworking, @Medium or Technique@",
-			"difficulty": "iq/a",
+			"specialization": "Woodworking",
+			"optional_specialization": "@Medium or Technique@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2113,24 +2764,42 @@
 				},
 				{
 					"type": "skill",
-					"name": "Carpentry",
+					"name": {
+						"compare": "is",
+						"qualifier": "Carpentry"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Interior Decorating",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Interior Decorating"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
-					"specialization": "Scene Design",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Scene Design"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Artist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2179,8 +2848,8 @@
 			"tags": [
 				"Natural Science"
 			],
-			"specialization": "Observational",
-			"difficulty": "iq/a",
+			"optional_specialization": "Observational",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2201,7 +2870,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Meditation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Meditation"
+					},
 					"modifier": -4
 				}
 			],
@@ -2224,12 +2896,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Two-Handed Axe/Mace",
+					"name": {
+						"compare": "is",
+						"qualifier": "Two-Handed Axe/Mace"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Flail",
+					"name": {
+						"compare": "is",
+						"qualifier": "Flail"
+					},
 					"modifier": -4
 				}
 			],
@@ -2248,7 +2926,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Karate",
+				"name": {
+					"compare": "is",
+					"qualifier": "Karate"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -2284,7 +2965,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Carousing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Carousing"
+					},
 					"modifier": -3
 				}
 			],
@@ -2306,17 +2990,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Diving Suit",
+					"name": {
+						"compare": "is",
+						"qualifier": "Diving Suit"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Vacc Suit",
+					"name": {
+						"compare": "is",
+						"qualifier": "Vacc Suit"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "NBC Suit",
+					"name": {
+						"compare": "is",
+						"qualifier": "NBC Suit"
+					},
 					"modifier": -2
 				}
 			],
@@ -2341,13 +3034,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Beam Weapons",
+					"name": {
+						"compare": "is",
+						"qualifier": "Beam Weapons"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Pistol",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Pistol"
+					},
 					"modifier": -4
 				}
 			],
@@ -2372,13 +3074,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Beam Weapons",
+					"name": {
+						"compare": "is",
+						"qualifier": "Beam Weapons"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Pistol",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Pistol"
+					},
 					"modifier": -4
 				}
 			],
@@ -2403,7 +3114,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Beam Weapons",
+					"name": {
+						"compare": "is",
+						"qualifier": "Beam Weapons"
+					},
 					"modifier": -4
 				}
 			],
@@ -2428,13 +3142,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Beam Weapons",
+					"name": {
+						"compare": "is",
+						"qualifier": "Beam Weapons"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Rifle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Rifle"
+					},
 					"modifier": -4
 				}
 			],
@@ -2457,8 +3180,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
-					"specialization": "Motorcycle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Motorcycle"
+					},
 					"modifier": -4
 				}
 			],
@@ -2477,12 +3206,18 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Bioengineering",
+					"name": {
+						"compare": "is",
+						"qualifier": "Bioengineering"
+					},
 					"modifier": -4
 				}
 			],
@@ -2502,12 +3237,18 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Bioengineering",
+					"name": {
+						"compare": "is",
+						"qualifier": "Bioengineering"
+					},
 					"modifier": -4
 				}
 			],
@@ -2527,12 +3268,18 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Bioengineering",
+					"name": {
+						"compare": "is",
+						"qualifier": "Bioengineering"
+					},
 					"modifier": -4
 				}
 			],
@@ -2552,12 +3299,18 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Bioengineering",
+					"name": {
+						"compare": "is",
+						"qualifier": "Bioengineering"
+					},
 					"modifier": -4
 				}
 			],
@@ -2581,7 +3334,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2596,8 +3352,9 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "@Planet Type@, @TL 6+ Optional Specialty@",
-			"difficulty": "iq/h",
+			"specialization": "@Planet Type@",
+			"optional_specialization": "@TL 6+ Optional Specialty@",
+			"difficulty": "iq/vh",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2605,7 +3362,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2620,8 +3380,9 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "@Planet Type@, Biochemistry",
-			"difficulty": "iq/h",
+			"specialization": "@Planet Type@",
+			"optional_specialization": "Biochemistry",
+			"difficulty": "iq/vh",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2629,7 +3390,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2644,8 +3408,9 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "@Planet Type@, Botany",
-			"difficulty": "iq/h",
+			"specialization": "@Planet Type@",
+			"optional_specialization": "Botany",
+			"difficulty": "iq/vh",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2653,7 +3418,149 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
+					"modifier": -6
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
+			"id": "sO2sQPjUCQNumo8zY",
+			"name": "Biology",
+			"reference": "B180",
+			"tags": [
+				"Natural Science",
+				"Plant"
+			],
+			"specialization": "@Planet Type@",
+			"optional_specialization": "Ecology",
+			"difficulty": "iq/vh",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
+					"modifier": -6
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
+			"id": "sZb5qju0ItFw6MC5t",
+			"name": "Biology",
+			"reference": "B180",
+			"tags": [
+				"Natural Science",
+				"Plant"
+			],
+			"specialization": "@Planet Type@",
+			"optional_specialization": "Genetics",
+			"difficulty": "iq/vh",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
+					"modifier": -6
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
+			"id": "sjwJIejxzqb2ukpSd",
+			"name": "Biology",
+			"reference": "B180",
+			"tags": [
+				"Natural Science",
+				"Plant"
+			],
+			"specialization": "@Planet Type@",
+			"optional_specialization": "Marine Biology",
+			"difficulty": "iq/vh",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
+					"modifier": -6
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
+			"id": "skC2ImJazwN5G2_IJ",
+			"name": "Biology",
+			"reference": "B180",
+			"tags": [
+				"Natural Science",
+				"Plant"
+			],
+			"specialization": "@Planet Type@",
+			"optional_specialization": "Microbiology",
+			"difficulty": "iq/vh",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
+					"modifier": -6
+				}
+			],
+			"tech_level": "",
+			"points": 1
+		},
+		{
+			"id": "scJ6BI--q0ylmNovM",
+			"name": "Biology",
+			"reference": "B180",
+			"tags": [
+				"Natural Science"
+			],
+			"specialization": "@Planet Type@",
+			"optional_specialization": "Zoology",
+			"difficulty": "iq/vh",
+			"defaults": [
+				{
+					"type": "iq",
+					"modifier": -6
+				},
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2677,7 +3584,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2692,8 +3602,9 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "Earthlike, @TL 6+ Optional Specialty@",
-			"difficulty": "iq/h",
+			"specialization": "Earthlike",
+			"optional_specialization": "@TL 6+ Optional Specialty@",
+			"difficulty": "iq/vh",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2701,31 +3612,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
-					"modifier": -6
-				}
-			],
-			"tech_level": "",
-			"points": 1
-		},
-		{
-			"id": "sO2sQPjUCQNumo8zY",
-			"name": "Biology",
-			"reference": "B180",
-			"tags": [
-				"Natural Science",
-				"Plant"
-			],
-			"specialization": "@Planet Type@, Ecology",
-			"difficulty": "iq/h",
-			"defaults": [
-				{
-					"type": "iq",
-					"modifier": -6
-				},
-				{
-					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2749,7 +3639,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2764,8 +3657,9 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "Gas Giants, @TL 6+ Optional Specialty@",
-			"difficulty": "iq/h",
+			"specialization": "Gas Giants",
+			"optional_specialization": "@TL 6+ Optional Specialty@",
+			"difficulty": "iq/vh",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2773,31 +3667,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
-					"modifier": -6
-				}
-			],
-			"tech_level": "",
-			"points": 1
-		},
-		{
-			"id": "sZb5qju0ItFw6MC5t",
-			"name": "Biology",
-			"reference": "B180",
-			"tags": [
-				"Natural Science",
-				"Plant"
-			],
-			"specialization": "@Planet Type@, Genetics",
-			"difficulty": "iq/h",
-			"defaults": [
-				{
-					"type": "iq",
-					"modifier": -6
-				},
-				{
-					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2821,7 +3694,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2836,8 +3712,9 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "Hostile Terrestrial, @TL 6+ Optional Specialty@",
-			"difficulty": "iq/h",
+			"specialization": "Hostile Terrestrial",
+			"optional_specialization": "@TL 6+ Optional Specialty@",
+			"difficulty": "iq/vh",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2845,7 +3722,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2869,7 +3749,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2884,8 +3767,9 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "Ice Dwarfs, @TL 6+ Optional Specialty@",
-			"difficulty": "iq/h",
+			"specialization": "Ice Dwarfs",
+			"optional_specialization": "@TL 6+ Optional Specialty@",
+			"difficulty": "iq/vh",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2893,7 +3777,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2917,7 +3804,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2932,8 +3822,9 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "Ice Worlds, @TL 6+ Optional Specialty@",
-			"difficulty": "iq/h",
+			"specialization": "Ice Worlds",
+			"optional_specialization": "@TL 6+ Optional Specialty@",
+			"difficulty": "iq/vh",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2941,7 +3832,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -2949,15 +3843,15 @@
 			"points": 1
 		},
 		{
-			"id": "sjwJIejxzqb2ukpSd",
+			"id": "se-92ZK9UuK67cAAB",
 			"name": "Biology",
 			"reference": "B180",
 			"tags": [
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "@Planet Type@, Marine Biology",
-			"difficulty": "iq/h",
+			"specialization": "Rock Worlds",
+			"difficulty": "iq/vh",
 			"defaults": [
 				{
 					"type": "iq",
@@ -2965,31 +3859,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
-					"modifier": -6
-				}
-			],
-			"tech_level": "",
-			"points": 1
-		},
-		{
-			"id": "skC2ImJazwN5G2_IJ",
-			"name": "Biology",
-			"reference": "B180",
-			"tags": [
-				"Natural Science",
-				"Plant"
-			],
-			"specialization": "@Planet Type@, Microbiology",
-			"difficulty": "iq/h",
-			"defaults": [
-				{
-					"type": "iq",
-					"modifier": -6
-				},
-				{
-					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -3004,8 +3877,9 @@
 				"Natural Science",
 				"Plant"
 			],
-			"specialization": "Rock Worlds, @TL 6+ Optional Specialty@",
-			"difficulty": "iq/h",
+			"specialization": "Rock Worlds",
+			"optional_specialization": "@TL 6+ Optional Specialty@",
+			"difficulty": "iq/vh",
 			"defaults": [
 				{
 					"type": "iq",
@@ -3013,30 +3887,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
-					"modifier": -6
-				}
-			],
-			"tech_level": "",
-			"points": 1
-		},
-		{
-			"id": "scJ6BI--q0ylmNovM",
-			"name": "Biology",
-			"reference": "B180",
-			"tags": [
-				"Natural Science"
-			],
-			"specialization": "@Planet Type@, Zoology",
-			"difficulty": "iq/h",
-			"defaults": [
-				{
-					"type": "iq",
-					"modifier": -6
-				},
-				{
-					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				}
 			],
@@ -3113,25 +3967,46 @@
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Motorboat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Motorboat"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Sailboat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Sailboat"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Unpowered",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Unpowered"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Seamanship",
+					"name": {
+						"compare": "is",
+						"qualifier": "Seamanship"
+					},
 					"modifier": -4
 				}
 			],
@@ -3158,25 +4033,46 @@
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Motorboat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Motorboat"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Sailboat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Sailboat"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Unpowered",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Unpowered"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Seamanship",
+					"name": {
+						"compare": "is",
+						"qualifier": "Seamanship"
+					},
 					"modifier": -4
 				}
 			],
@@ -3203,20 +4099,38 @@
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Large Powerboat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Large Powerboat"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Sailboat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Sailboat"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Unpowered",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Unpowered"
+					},
 					"modifier": -3
 				}
 			],
@@ -3243,20 +4157,38 @@
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Large Powerboat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Large Powerboat"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Motorboat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Motorboat"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Unpowered",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Unpowered"
+					},
 					"modifier": -3
 				}
 			],
@@ -3283,20 +4215,38 @@
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Large Powerboat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Large Powerboat"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Motorboat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Motorboat"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Sailboat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Sailboat"
+					},
 					"modifier": -3
 				}
 			],
@@ -3356,12 +4306,18 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Detect Lies",
+					"name": {
+						"compare": "is",
+						"qualifier": "Detect Lies"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Psychology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Psychology"
+					},
 					"modifier": -4
 				}
 			],
@@ -3382,7 +4338,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acrobatics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acrobatics"
+					},
 					"modifier": -3
 				}
 			],
@@ -3574,27 +4533,42 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Force Sword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Force Sword"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Rapier",
+					"name": {
+						"compare": "is",
+						"qualifier": "Rapier"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Saber",
+					"name": {
+						"compare": "is",
+						"qualifier": "Saber"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Shortsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Shortsword"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Two-Handed Sword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Two-Handed Sword"
+					},
 					"modifier": -4
 				},
 				{
@@ -3621,7 +4595,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
 					"modifier": -2
 				}
 			],
@@ -3731,18 +4708,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Mathematics",
-					"specialization": "Surveying",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mathematics"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Surveying"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Navigation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Navigation"
+					},
 					"modifier": -4
 				}
 			],
@@ -3760,7 +4749,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Chemistry",
+					"name": {
+						"compare": "is",
+						"qualifier": "Chemistry"
+					},
 					"modifier": -2
 				},
 				{
@@ -3769,7 +4761,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Alchemy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Alchemy"
+					},
 					"modifier": -3
 				}
 			],
@@ -3783,8 +4778,8 @@
 			"tags": [
 				"Natural Science"
 			],
-			"specialization": "@Optional Specialty@",
-			"difficulty": "iq/a",
+			"optional_specialization": "@Optional Specialty@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -3792,7 +4787,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Alchemy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Alchemy"
+					},
 					"modifier": -3
 				}
 			],
@@ -3812,7 +4810,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Judo",
+				"name": {
+					"compare": "is",
+					"qualifier": "Judo"
+				},
 				"modifier": -2
 			},
 			"limit": 0,
@@ -3845,7 +4846,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Wrestling",
+				"name": {
+					"compare": "is",
+					"qualifier": "Wrestling"
+				},
 				"modifier": -3
 			},
 			"limit": 0,
@@ -3903,12 +4907,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Net",
+					"name": {
+						"compare": "is",
+						"qualifier": "Net"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Shield",
+					"name": {
+						"compare": "is",
+						"qualifier": "Shield"
+					},
 					"modifier": -4
 				}
 			],
@@ -3926,13 +4936,22 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "@Average Skill@",
+					"name": {
+						"compare": "is",
+						"qualifier": "@Average Skill@"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Combat Sport",
-					"specialization": "@Average Skill@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Combat Sport"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Average Skill@"
+					},
 					"modifier": -3
 				},
 				{
@@ -3954,13 +4973,22 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "@Easy Skill@",
+					"name": {
+						"compare": "is",
+						"qualifier": "@Easy Skill@"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Combat Sport",
-					"specialization": "@Easy Skill@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Combat Sport"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Easy Skill@"
+					},
 					"modifier": -3
 				},
 				{
@@ -3982,13 +5010,22 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "@Hard Skill@",
+					"name": {
+						"compare": "is",
+						"qualifier": "@Hard Skill@"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Combat Sport",
-					"specialization": "@Hard Skill@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Combat Sport"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Hard Skill@"
+					},
 					"modifier": -3
 				},
 				{
@@ -4010,13 +5047,22 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "@Average Skill@",
+					"name": {
+						"compare": "is",
+						"qualifier": "@Average Skill@"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Combat Art",
-					"specialization": "@Average Skill@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Combat Art"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Average Skill@"
+					},
 					"modifier": -3
 				},
 				{
@@ -4038,13 +5084,22 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "@Easy Skill@",
+					"name": {
+						"compare": "is",
+						"qualifier": "@Easy Skill@"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Combat Art",
-					"specialization": "@Easy Skill@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Combat Art"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Easy Skill@"
+					},
 					"modifier": -3
 				},
 				{
@@ -4066,13 +5121,22 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "@Hard Skill@",
+					"name": {
+						"compare": "is",
+						"qualifier": "@Hard Skill@"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Combat Art",
-					"specialization": "@Hard Skill@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Combat Art"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Hard Skill@"
+					},
 					"modifier": -3
 				},
 				{
@@ -4208,17 +5272,26 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Literature",
+					"name": {
+						"compare": "is",
+						"qualifier": "Literature"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Poetry",
+					"name": {
+						"compare": "is",
+						"qualifier": "Poetry"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Writing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Writing"
+					},
 					"modifier": -3
 				},
 				{
@@ -4243,18 +5316,30 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Group Performance",
-					"specialization": "Conducting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Group Performance"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Conducting"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Musical Composition",
+					"name": {
+						"compare": "is",
+						"qualifier": "Musical Composition"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Musical Instrument",
+					"name": {
+						"compare": "is",
+						"qualifier": "Musical Instrument"
+					},
 					"modifier": -3
 				},
 				{
@@ -4315,7 +5400,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Cooking",
+					"name": {
+						"compare": "is",
+						"qualifier": "Cooking"
+					},
 					"modifier": -2
 				},
 				{
@@ -4324,7 +5412,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Housekeeping",
+					"name": {
+						"compare": "is",
+						"qualifier": "Housekeeping"
+					},
 					"modifier": -5
 				}
 			],
@@ -4337,8 +5428,8 @@
 			"tags": [
 				"Everyman"
 			],
-			"specialization": "@Optional Specialty@",
-			"difficulty": "iq/e",
+			"optional_specialization": "@Optional Specialty@",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -4346,7 +5437,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Housekeeping",
+					"name": {
+						"compare": "is",
+						"qualifier": "Housekeeping"
+					},
 					"modifier": -5
 				}
 			],
@@ -4359,8 +5453,8 @@
 			"tags": [
 				"Everyman"
 			],
-			"specialization": "Baking",
-			"difficulty": "iq/e",
+			"optional_specialization": "Baking",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -4368,7 +5462,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Housekeeping",
+					"name": {
+						"compare": "is",
+						"qualifier": "Housekeeping"
+					},
 					"modifier": -5
 				}
 			],
@@ -4381,8 +5478,8 @@
 			"tags": [
 				"Everyman"
 			],
-			"specialization": "Beverage Making",
-			"difficulty": "iq/e",
+			"optional_specialization": "Beverage Making",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -4390,7 +5487,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Housekeeping",
+					"name": {
+						"compare": "is",
+						"qualifier": "Housekeeping"
+					},
 					"modifier": -5
 				}
 			],
@@ -4412,7 +5512,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Forgery",
+					"name": {
+						"compare": "is",
+						"qualifier": "Forgery"
+					},
 					"modifier": -2
 				}
 			],
@@ -4436,7 +5539,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Psychology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Psychology"
+					},
 					"modifier": -4
 				}
 			],
@@ -4473,8 +5579,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Mathematics",
-					"specialization": "Cryptology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mathematics"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Cryptology"
+					},
 					"modifier": -5
 				}
 			],
@@ -4489,13 +5601,19 @@
 				"Military",
 				"Spy"
 			],
-			"specialization": "Code Design",
-			"difficulty": "iq/a",
+			"optional_specialization": "Code Design",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Mathematics",
-					"specialization": "Cryptology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mathematics"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Cryptology"
+					},
 					"modifier": -5
 				}
 			],
@@ -4510,13 +5628,19 @@
 				"Military",
 				"Spy"
 			],
-			"specialization": "Cryptanalysis",
-			"difficulty": "iq/a",
+			"optional_specialization": "Cryptanalysis",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Mathematics",
-					"specialization": "Cryptology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mathematics"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Cryptology"
+					},
 					"modifier": -5
 				}
 			],
@@ -4542,12 +5666,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Research",
+					"name": {
+						"compare": "is",
+						"qualifier": "Research"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Current Affairs",
+					"name": {
+						"compare": "is",
+						"qualifier": "Current Affairs"
+					},
 					"modifier": -4
 				}
 			],
@@ -4573,12 +5703,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Research",
+					"name": {
+						"compare": "is",
+						"qualifier": "Research"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Current Affairs",
+					"name": {
+						"compare": "is",
+						"qualifier": "Current Affairs"
+					},
 					"modifier": -4
 				}
 			],
@@ -4603,12 +5739,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Research",
+					"name": {
+						"compare": "is",
+						"qualifier": "Research"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Current Affairs",
+					"name": {
+						"compare": "is",
+						"qualifier": "Current Affairs"
+					},
 					"modifier": -4
 				}
 			],
@@ -4635,12 +5777,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Research",
+					"name": {
+						"compare": "is",
+						"qualifier": "Research"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Current Affairs",
+					"name": {
+						"compare": "is",
+						"qualifier": "Current Affairs"
+					},
 					"modifier": -4
 				}
 			],
@@ -4665,12 +5813,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Research",
+					"name": {
+						"compare": "is",
+						"qualifier": "Research"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Current Affairs",
+					"name": {
+						"compare": "is",
+						"qualifier": "Current Affairs"
+					},
 					"modifier": -4
 				}
 			],
@@ -4695,12 +5849,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Research",
+					"name": {
+						"compare": "is",
+						"qualifier": "Research"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Current Affairs",
+					"name": {
+						"compare": "is",
+						"qualifier": "Current Affairs"
+					},
 					"modifier": -4
 				}
 			],
@@ -4727,12 +5887,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Research",
+					"name": {
+						"compare": "is",
+						"qualifier": "Research"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Current Affairs",
+					"name": {
+						"compare": "is",
+						"qualifier": "Current Affairs"
+					},
 					"modifier": -4
 				}
 			],
@@ -4757,12 +5923,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Research",
+					"name": {
+						"compare": "is",
+						"qualifier": "Research"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Current Affairs",
+					"name": {
+						"compare": "is",
+						"qualifier": "Current Affairs"
+					},
 					"modifier": -4
 				}
 			],
@@ -4778,7 +5950,7 @@
 				"Knowledge",
 				"Social"
 			],
-			"specialization": "Science \u0026 Technology",
+			"specialization": "Science & Technology",
 			"difficulty": "iq/e",
 			"defaults": [
 				{
@@ -4787,12 +5959,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Research",
+					"name": {
+						"compare": "is",
+						"qualifier": "Research"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Current Affairs",
+					"name": {
+						"compare": "is",
+						"qualifier": "Current Affairs"
+					},
 					"modifier": -4
 				}
 			],
@@ -4817,12 +5995,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Research",
+					"name": {
+						"compare": "is",
+						"qualifier": "Research"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Current Affairs",
+					"name": {
+						"compare": "is",
+						"qualifier": "Current Affairs"
+					},
 					"modifier": -4
 				}
 			],
@@ -4847,12 +6031,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Research",
+					"name": {
+						"compare": "is",
+						"qualifier": "Research"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Current Affairs",
+					"name": {
+						"compare": "is",
+						"qualifier": "Current Affairs"
+					},
 					"modifier": -4
 				}
 			],
@@ -4893,12 +6083,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Body Language",
+					"name": {
+						"compare": "is",
+						"qualifier": "Body Language"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Psychology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Psychology"
+					},
 					"modifier": -4
 				}
 			],
@@ -4919,17 +6115,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "First Aid",
+					"name": {
+						"compare": "is",
+						"qualifier": "First Aid"
+					},
 					"modifier": -8
 				},
 				{
 					"type": "skill",
-					"name": "Physician",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Veterinary",
+					"name": {
+						"compare": "is",
+						"qualifier": "Veterinary"
+					},
 					"modifier": -5
 				}
 			],
@@ -4953,7 +6158,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Politics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Politics"
+					},
 					"modifier": -6
 				}
 			],
@@ -4972,7 +6180,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "@Unarmed or Melee Weapon Skill@"
+				"name": {
+					"compare": "is",
+					"qualifier": "@Unarmed or Melee Weapon Skill@"
+				}
 			},
 			"limit": 5,
 			"prereqs": {
@@ -5004,7 +6215,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Brawling"
+				"name": {
+					"compare": "is",
+					"qualifier": "Brawling"
+				}
 			},
 			"limit": 5,
 			"points": 2
@@ -5022,7 +6236,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Broadsword"
+				"name": {
+					"compare": "is",
+					"qualifier": "Broadsword"
+				}
 			},
 			"limit": 5,
 			"points": 2
@@ -5040,7 +6257,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Karate"
+				"name": {
+					"compare": "is",
+					"qualifier": "Karate"
+				}
 			},
 			"limit": 5,
 			"points": 2
@@ -5058,7 +6278,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Knife"
+				"name": {
+					"compare": "is",
+					"qualifier": "Knife"
+				}
 			},
 			"limit": 5,
 			"points": 2
@@ -5076,7 +6299,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Shortsword"
+				"name": {
+					"compare": "is",
+					"qualifier": "Shortsword"
+				}
 			},
 			"limit": 5,
 			"points": 2
@@ -5099,7 +6325,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Makeup",
+					"name": {
+						"compare": "is",
+						"qualifier": "Makeup"
+					},
 					"modifier": -3
 				}
 			],
@@ -5121,22 +6350,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Scuba",
+					"name": {
+						"compare": "is",
+						"qualifier": "Scuba"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Battlesuit",
+					"name": {
+						"compare": "is",
+						"qualifier": "Battlesuit"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "NBC Suit",
+					"name": {
+						"compare": "is",
+						"qualifier": "NBC Suit"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Vacc Suit",
+					"name": {
+						"compare": "is",
+						"qualifier": "Vacc Suit"
+					},
 					"modifier": -4
 				}
 			],
@@ -5179,13 +6420,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
-					"specialization": "Heavy Wheeled",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Heavy Wheeled"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
 					"modifier": -4
 				}
 			],
@@ -5212,13 +6462,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
-					"specialization": "Heavy Wheeled",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Heavy Wheeled"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
 					"modifier": -4
 				}
 			],
@@ -5245,7 +6504,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
 					"modifier": -5
 				}
 			],
@@ -5272,13 +6534,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
-					"specialization": "Tracked",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Tracked"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
 					"modifier": -4
 				}
 			],
@@ -5305,13 +6576,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
-					"specialization": "Automobile",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Automobile"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
 					"modifier": -4
 				}
 			],
@@ -5338,7 +6618,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
 					"modifier": -5
 				}
 			],
@@ -5365,7 +6648,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
 					"modifier": -5
 				}
 			],
@@ -5392,12 +6678,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Battlesuit",
+					"name": {
+						"compare": "is",
+						"qualifier": "Battlesuit"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
 					"modifier": -5
 				}
 			],
@@ -5424,7 +6716,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Bicycling",
+					"name": {
+						"compare": "is",
+						"qualifier": "Bicycling"
+					},
 					"modifier": -4
 				}
 			],
@@ -5451,13 +6746,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
-					"specialization": "Halftrack",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Halftrack"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Driving",
+					"name": {
+						"compare": "is",
+						"qualifier": "Driving"
+					},
 					"modifier": -4
 				}
 			],
@@ -5481,7 +6785,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Throwing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Throwing"
+					},
 					"modifier": -4
 				}
 			],
@@ -5500,7 +6807,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Broadsword",
+				"name": {
+					"compare": "is",
+					"qualifier": "Broadsword"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -5519,8 +6829,14 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "Pistol",
+				"name": {
+					"compare": "is",
+					"qualifier": "Guns"
+				},
+				"specialization": {
+					"compare": "is",
+					"qualifier": "Pistol"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -5539,7 +6855,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Knife",
+				"name": {
+					"compare": "is",
+					"qualifier": "Knife"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -5558,7 +6877,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Shortsword",
+				"name": {
+					"compare": "is",
+					"qualifier": "Shortsword"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -5581,17 +6903,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Finance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Finance"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Market Analysis",
+					"name": {
+						"compare": "is",
+						"qualifier": "Market Analysis"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Merchant",
+					"name": {
+						"compare": "is",
+						"qualifier": "Merchant"
+					},
 					"modifier": -6
 				}
 			],
@@ -5610,7 +6941,10 @@
 			"difficulty": "a",
 			"default": {
 				"type": "skill",
-				"name": "Brawling",
+				"name": {
+					"compare": "is",
+					"qualifier": "Brawling"
+				},
 				"modifier": -2
 			},
 			"limit": 0,
@@ -5643,7 +6977,10 @@
 			"difficulty": "a",
 			"default": {
 				"type": "skill",
-				"name": "Karate",
+				"name": {
+					"compare": "is",
+					"qualifier": "Karate"
+				},
 				"modifier": -2
 			},
 			"limit": 0,
@@ -5679,8 +7016,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electrical",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electrical"
+					},
 					"modifier": -3
 				}
 			],
@@ -5703,19 +7046,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
-					"specialization": "@Electronics type@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Electronics type@"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				}
 			],
@@ -5738,19 +7096,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
-					"specialization": "Communications",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Communications"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				}
 			],
@@ -5775,19 +7148,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
-					"specialization": "Electronic Warfare",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronic Warfare"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				}
 			],
@@ -5810,19 +7198,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
-					"specialization": "Force Shields",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Force Shields"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				}
 			],
@@ -5845,19 +7248,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
-					"specialization": "Matter Transmitters",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Matter Transmitters"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				}
 			],
@@ -5882,19 +7300,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
-					"specialization": "Media",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Media"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				}
 			],
@@ -5918,19 +7351,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
-					"specialization": "Medical",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Medical"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				}
 			],
@@ -5953,19 +7401,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
-					"specialization": "Parachronic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Parachronic"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				}
 			],
@@ -5988,19 +7451,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
-					"specialization": "Psychotronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Psychotronics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				}
 			],
@@ -6023,19 +7501,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
-					"specialization": "Scientific",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Scientific"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				}
 			],
@@ -6061,19 +7554,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Security",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Security"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				}
 			],
@@ -6096,19 +7604,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
-					"specialization": "Sensors",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Sensors"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				}
 			],
@@ -6131,19 +7654,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
-					"specialization": "Sonar",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Sonar"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				}
 			],
@@ -6168,19 +7706,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
-					"specialization": "Surveillance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Surveillance"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				}
 			],
@@ -6203,19 +7756,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
-					"specialization": "Temporal",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Temporal"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
 					"modifier": -4
 				}
 			],
@@ -6239,19 +7807,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "@Electronics type@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Electronics type@"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6275,19 +7858,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Communications",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Communications"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6311,18 +7909,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Computer Operation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Computer Operation"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6347,19 +7957,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Electronic Warfare",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronic Warfare"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6383,19 +8008,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Force Shields",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Force Shields"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6419,19 +8059,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Matter Transmitters",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Matter Transmitters"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6455,19 +8110,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Media",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Media"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6491,19 +8161,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Medical",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Medical"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6527,19 +8212,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Parachronic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Parachronic"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6563,19 +8263,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Psychotronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Psychotronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6599,19 +8314,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Scientific",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Scientific"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6635,19 +8365,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Security",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Security"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6671,19 +8416,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Sensors",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Sensors"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6707,19 +8467,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Sonar",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Sonar"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6743,19 +8518,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Surveillance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Surveillance"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6779,19 +8569,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Temporal",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Temporal"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Electronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Electronics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -4
 				}
 			],
@@ -6812,8 +8617,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Armoury",
-					"specialization": "Heavy Weapons",
+					"name": {
+						"compare": "is",
+						"qualifier": "Armoury"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Heavy Weapons"
+					},
 					"modifier": -6
 				}
 			],
@@ -6856,8 +8667,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Armoury",
-					"specialization": "Heavy Weapons",
+					"name": {
+						"compare": "is",
+						"qualifier": "Armoury"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Heavy Weapons"
+					},
 					"modifier": -6
 				}
 			],
@@ -6900,8 +8717,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Mechanic",
-					"specialization": "Automobile",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Automobile"
+					},
 					"modifier": -6
 				}
 			],
@@ -6944,7 +8767,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Architecture",
+					"name": {
+						"compare": "is",
+						"qualifier": "Architecture"
+					},
 					"modifier": -6
 				}
 			],
@@ -6987,8 +8813,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Mechanic",
-					"specialization": "Clockwork",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Clockwork"
+					},
 					"modifier": -6
 				}
 			],
@@ -7031,8 +8863,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Explosives",
-					"specialization": "Demolition",
+					"name": {
+						"compare": "is",
+						"qualifier": "Explosives"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Demolition"
+					},
 					"modifier": -6
 				}
 			],
@@ -7075,7 +8913,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Electrician",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electrician"
+					},
 					"modifier": -6
 				}
 			],
@@ -7118,7 +8959,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Electronics Repair",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Repair"
+					},
 					"modifier": -6
 				}
 			],
@@ -7161,12 +9005,18 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Chemistry",
+					"name": {
+						"compare": "is",
+						"qualifier": "Chemistry"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Metallurgy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Metallurgy"
+					},
 					"modifier": -6
 				}
 			],
@@ -7237,8 +9087,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Mechanic",
-					"specialization": "Micromachines",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Micromachines"
+					},
 					"modifier": -6
 				}
 			],
@@ -7281,13 +9137,22 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Explosives",
-					"specialization": "Demolition",
+					"name": {
+						"compare": "is",
+						"qualifier": "Explosives"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Demolition"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Geology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geology"
+					},
 					"modifier": -6
 				}
 			],
@@ -7330,8 +9195,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Mechanic",
-					"specialization": "Nanomachines",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Nanomachines"
+					},
 					"modifier": -6
 				}
 			],
@@ -7374,8 +9245,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Parachronic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Parachronic"
+					},
 					"modifier": -6
 				}
 			],
@@ -7432,8 +9309,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Psychotronics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Psychotronics"
+					},
 					"modifier": -6
 				}
 			],
@@ -7476,8 +9359,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Mechanic",
-					"specialization": "Robotics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Robotics"
+					},
 					"modifier": -6
 				}
 			],
@@ -7520,8 +9409,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Mechanic",
-					"specialization": "Ships",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Ships"
+					},
 					"modifier": -6
 				}
 			],
@@ -7564,8 +9459,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Armoury",
-					"specialization": "Small Arms",
+					"name": {
+						"compare": "is",
+						"qualifier": "Armoury"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Small Arms"
+					},
 					"modifier": -6
 				}
 			],
@@ -7608,8 +9509,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Mechanic",
-					"specialization": "Starships",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Starships"
+					},
 					"modifier": -6
 				}
 			],
@@ -7652,8 +9559,14 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Temporal",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Temporal"
+					},
 					"modifier": -6
 				}
 			],
@@ -7768,7 +9681,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acrobatics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acrobatics"
+					},
 					"modifier": -5
 				}
 			],
@@ -7824,17 +9740,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Religious Ritual",
+					"name": {
+						"compare": "is",
+						"qualifier": "Religious Ritual"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Ritual Magic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Ritual Magic"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Theology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Theology"
+					},
 					"modifier": -3
 				}
 			],
@@ -8005,25 +9930,46 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Combat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Combat"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Mining",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Mining"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Explosives",
-					"specialization": "Underwater Demolition",
+					"name": {
+						"compare": "is",
+						"qualifier": "Explosives"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Underwater Demolition"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Explosives",
+					"name": {
+						"compare": "is",
+						"qualifier": "Explosives"
+					},
 					"modifier": -4
 				}
 			],
@@ -8049,25 +9995,46 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Combat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Combat"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Mining",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Mining"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Explosives",
-					"specialization": "Underwater Demolition",
+					"name": {
+						"compare": "is",
+						"qualifier": "Explosives"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Underwater Demolition"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Explosives",
+					"name": {
+						"compare": "is",
+						"qualifier": "Explosives"
+					},
 					"modifier": -4
 				}
 			],
@@ -8092,13 +10059,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Explosives",
-					"specialization": "Nuclear Ordnance Disposal",
+					"name": {
+						"compare": "is",
+						"qualifier": "Explosives"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Nuclear Ordnance Disposal"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Explosives",
+					"name": {
+						"compare": "is",
+						"qualifier": "Explosives"
+					},
 					"modifier": -4
 				}
 			],
@@ -8137,12 +10113,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Chemistry",
+					"name": {
+						"compare": "is",
+						"qualifier": "Chemistry"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Explosives",
+					"name": {
+						"compare": "is",
+						"qualifier": "Explosives"
+					},
 					"modifier": -4
 				}
 			],
@@ -8166,13 +10148,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Explosives",
-					"specialization": "Explosive Ordnance Disposal",
+					"name": {
+						"compare": "is",
+						"qualifier": "Explosives"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Explosive Ordnance Disposal"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Explosives",
+					"name": {
+						"compare": "is",
+						"qualifier": "Explosives"
+					},
 					"modifier": -4
 				}
 			],
@@ -8196,13 +10187,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Explosives",
-					"specialization": "Demolition",
+					"name": {
+						"compare": "is",
+						"qualifier": "Explosives"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Demolition"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Explosives",
+					"name": {
+						"compare": "is",
+						"qualifier": "Explosives"
+					},
 					"modifier": -4
 				}
 			],
@@ -8224,8 +10224,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Animal Handling",
-					"specialization": "Raptors",
+					"name": {
+						"compare": "is",
+						"qualifier": "Animal Handling"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Raptors"
+					},
 					"modifier": -3
 				}
 			],
@@ -8246,12 +10252,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Gardening",
+					"name": {
+						"compare": "is",
+						"qualifier": "Gardening"
+					},
 					"modifier": -3
 				}
 			],
@@ -8394,7 +10406,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acting"
+					},
 					"modifier": -5
 				}
 			],
@@ -8413,7 +10428,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "@Unarmed or Melee Weapon Skill@"
+				"name": {
+					"compare": "is",
+					"qualifier": "@Unarmed or Melee Weapon Skill@"
+				}
 			},
 			"limit": 4,
 			"prereqs": {
@@ -8445,7 +10463,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Brawling"
+				"name": {
+					"compare": "is",
+					"qualifier": "Brawling"
+				}
 			},
 			"limit": 4,
 			"points": 2
@@ -8463,7 +10484,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Broadsword"
+				"name": {
+					"compare": "is",
+					"qualifier": "Broadsword"
+				}
 			},
 			"limit": 4,
 			"points": 2
@@ -8481,7 +10505,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Force Sword"
+				"name": {
+					"compare": "is",
+					"qualifier": "Force Sword"
+				}
 			},
 			"limit": 4,
 			"points": 2
@@ -8499,7 +10526,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Karate"
+				"name": {
+					"compare": "is",
+					"qualifier": "Karate"
+				}
 			},
 			"limit": 4,
 			"points": 2
@@ -8517,7 +10547,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Knife"
+				"name": {
+					"compare": "is",
+					"qualifier": "Knife"
+				}
 			},
 			"limit": 4,
 			"points": 2
@@ -8535,7 +10568,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Shortsword"
+				"name": {
+					"compare": "is",
+					"qualifier": "Shortsword"
+				}
 			},
 			"limit": 4,
 			"points": 2
@@ -8557,12 +10593,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Pickpocket",
+					"name": {
+						"compare": "is",
+						"qualifier": "Pickpocket"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Sleight of Hand",
+					"name": {
+						"compare": "is",
+						"qualifier": "Sleight of Hand"
+					},
 					"modifier": -4
 				}
 			],
@@ -8579,17 +10621,26 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Accounting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Accounting"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Economics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Economics"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Merchant",
+					"name": {
+						"compare": "is",
+						"qualifier": "Merchant"
+					},
 					"modifier": -6
 				}
 			],
@@ -8608,7 +10659,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Arm Lock",
+				"name": {
+					"compare": "is",
+					"qualifier": "Arm Lock"
+				},
 				"modifier": -3
 			},
 			"limit": 0,
@@ -8641,15 +10695,24 @@
 				},
 				{
 					"type": "skill",
-					"name": "Esoteric Medicine"
+					"name": {
+						"compare": "is",
+						"qualifier": "Esoteric Medicine"
+					}
 				},
 				{
 					"type": "skill",
-					"name": "Physician"
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					}
 				},
 				{
 					"type": "skill",
-					"name": "Veterinary",
+					"name": {
+						"compare": "is",
+						"qualifier": "Veterinary"
+					},
 					"modifier": -4
 				}
 			],
@@ -8690,12 +10753,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Axe/Mace",
+					"name": {
+						"compare": "is",
+						"qualifier": "Axe/Mace"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Two-Handed Flail",
+					"name": {
+						"compare": "is",
+						"qualifier": "Two-Handed Flail"
+					},
 					"modifier": -3
 				}
 			],
@@ -8798,27 +10867,42 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Broadsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Broadsword"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Shortsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Shortsword"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Two-Handed Sword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Two-Handed Sword"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Jitte/Sai",
+					"name": {
+						"compare": "is",
+						"qualifier": "Jitte/Sai"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Knife",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knife"
+					},
 					"modifier": -3
 				},
 				{
@@ -8845,17 +10929,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Kusari",
+					"name": {
+						"compare": "is",
+						"qualifier": "Kusari"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Monowire Whip",
+					"name": {
+						"compare": "is",
+						"qualifier": "Monowire Whip"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Whip",
+					"name": {
+						"compare": "is",
+						"qualifier": "Whip"
+					},
 					"modifier": -3
 				}
 			],
@@ -8889,7 +10982,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Criminology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Criminology"
+					},
 					"modifier": -4
 				}
 			],
@@ -8913,7 +11009,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Counterfeiting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Counterfeiting"
+					},
 					"modifier": -2
 				}
 			],
@@ -8936,12 +11035,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Fast-Talk",
+					"name": {
+						"compare": "is",
+						"qualifier": "Fast-Talk"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Occultism",
+					"name": {
+						"compare": "is",
+						"qualifier": "Occultism"
+					},
 					"modifier": -3
 				}
 			],
@@ -8963,12 +11068,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Fast-Talk",
+					"name": {
+						"compare": "is",
+						"qualifier": "Fast-Talk"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Occultism",
+					"name": {
+						"compare": "is",
+						"qualifier": "Occultism"
+					},
 					"modifier": -3
 				}
 			],
@@ -8990,12 +11101,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Fast-Talk",
+					"name": {
+						"compare": "is",
+						"qualifier": "Fast-Talk"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Occultism",
+					"name": {
+						"compare": "is",
+						"qualifier": "Occultism"
+					},
 					"modifier": -3
 				}
 			],
@@ -9017,12 +11134,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Fast-Talk",
+					"name": {
+						"compare": "is",
+						"qualifier": "Fast-Talk"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Occultism",
+					"name": {
+						"compare": "is",
+						"qualifier": "Occultism"
+					},
 					"modifier": -3
 				}
 			],
@@ -9044,12 +11167,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Fast-Talk",
+					"name": {
+						"compare": "is",
+						"qualifier": "Fast-Talk"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Occultism",
+					"name": {
+						"compare": "is",
+						"qualifier": "Occultism"
+					},
 					"modifier": -3
 				}
 			],
@@ -9071,12 +11200,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Fast-Talk",
+					"name": {
+						"compare": "is",
+						"qualifier": "Fast-Talk"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Occultism",
+					"name": {
+						"compare": "is",
+						"qualifier": "Occultism"
+					},
 					"modifier": -3
 				}
 			],
@@ -9098,12 +11233,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Fast-Talk",
+					"name": {
+						"compare": "is",
+						"qualifier": "Fast-Talk"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Occultism",
+					"name": {
+						"compare": "is",
+						"qualifier": "Occultism"
+					},
 					"modifier": -3
 				}
 			],
@@ -9124,7 +11265,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Artillery",
+					"name": {
+						"compare": "is",
+						"qualifier": "Artillery"
+					},
 					"modifier": -5
 				}
 			],
@@ -9186,8 +11330,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Mathematics",
-					"specialization": "Statistics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mathematics"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Statistics"
+					},
 					"modifier": -5
 				}
 			],
@@ -9225,7 +11375,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Farming",
+					"name": {
+						"compare": "is",
+						"qualifier": "Farming"
+					},
 					"modifier": -3
 				}
 			],
@@ -9266,19 +11419,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geology",
-					"specialization": "Earthlike",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Earthlike"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Meteorology",
-					"specialization": "Earthlike",
+					"name": {
+						"compare": "is",
+						"qualifier": "Meteorology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Earthlike"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
 					"modifier": -5
 				}
 			],
@@ -9302,19 +11470,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geology",
-					"specialization": "Earthlike",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Earthlike"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Meteorology",
-					"specialization": "Earthlike",
+					"name": {
+						"compare": "is",
+						"qualifier": "Meteorology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Earthlike"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
 					"modifier": -5
 				}
 			],
@@ -9338,19 +11521,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geology",
-					"specialization": "Gas Giants",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Gas Giants"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Meteorology",
-					"specialization": "Gas Giants",
+					"name": {
+						"compare": "is",
+						"qualifier": "Meteorology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Gas Giants"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
 					"modifier": -5
 				}
 			],
@@ -9374,19 +11572,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geology",
-					"specialization": "Hostile Terrestrial",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Hostile Terrestrial"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Meteorology",
-					"specialization": "Hostile Terrestrial",
+					"name": {
+						"compare": "is",
+						"qualifier": "Meteorology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Hostile Terrestrial"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
 					"modifier": -5
 				}
 			],
@@ -9410,19 +11623,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geology",
-					"specialization": "Ice Dwarfs",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Ice Dwarfs"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Meteorology",
-					"specialization": "Ice Dwarfs",
+					"name": {
+						"compare": "is",
+						"qualifier": "Meteorology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Ice Dwarfs"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
 					"modifier": -5
 				}
 			],
@@ -9446,19 +11674,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geology",
-					"specialization": "Ice Worlds",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Ice Worlds"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Meteorology",
-					"specialization": "Ice Worlds",
+					"name": {
+						"compare": "is",
+						"qualifier": "Meteorology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Ice Worlds"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
 					"modifier": -5
 				}
 			],
@@ -9482,19 +11725,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geology",
-					"specialization": "Rock Worlds",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Rock Worlds"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Meteorology",
-					"specialization": "Rock Worlds",
+					"name": {
+						"compare": "is",
+						"qualifier": "Meteorology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Rock Worlds"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
 					"modifier": -5
 				}
 			],
@@ -9518,12 +11776,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Economics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Economics"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
 					"modifier": -5
 				}
 			],
@@ -9547,12 +11811,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Area Knowledge",
+					"name": {
+						"compare": "is",
+						"qualifier": "Area Knowledge"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
 					"modifier": -5
 				}
 			],
@@ -9575,13 +11845,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "Physical, Earthlike",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Physical, Earthlike"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Prospecting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Prospecting"
+					},
 					"modifier": -5
 				}
 			],
@@ -9604,13 +11883,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "Physical, Earthlike",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Physical, Earthlike"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Prospecting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Prospecting"
+					},
 					"modifier": -5
 				}
 			],
@@ -9633,13 +11921,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "Physical, Gas Giants",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Physical, Gas Giants"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Prospecting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Prospecting"
+					},
 					"modifier": -5
 				}
 			],
@@ -9662,13 +11959,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "Physical, Hostile Terrestrial",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Physical, Hostile Terrestrial"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Prospecting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Prospecting"
+					},
 					"modifier": -5
 				}
 			],
@@ -9691,13 +11997,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "Physical, Ice Dwarfs",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Physical, Ice Dwarfs"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Prospecting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Prospecting"
+					},
 					"modifier": -5
 				}
 			],
@@ -9720,13 +12035,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "Physical, Ice Worlds",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Physical, Ice Worlds"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Prospecting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Prospecting"
+					},
 					"modifier": -5
 				}
 			],
@@ -9749,13 +12073,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geography",
-					"specialization": "Physical, Rock Worlds",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geography"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Physical, Rock Worlds"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Prospecting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Prospecting"
+					},
 					"modifier": -5
 				}
 			],
@@ -9791,7 +12124,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "@Combat Skill@",
+				"name": {
+					"compare": "is",
+					"qualifier": "@Combat Skill@"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -9824,7 +12160,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Brawling",
+				"name": {
+					"compare": "is",
+					"qualifier": "Brawling"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -9843,7 +12182,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Broadsword",
+				"name": {
+					"compare": "is",
+					"qualifier": "Broadsword"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -9862,7 +12204,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Karate",
+				"name": {
+					"compare": "is",
+					"qualifier": "Karate"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -9881,7 +12226,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Knife",
+				"name": {
+					"compare": "is",
+					"qualifier": "Knife"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -9900,7 +12248,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Shortsword",
+				"name": {
+					"compare": "is",
+					"qualifier": "Shortsword"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -9923,7 +12274,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Dancing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Dancing"
+					},
 					"modifier": -2
 				}
 			],
@@ -9982,7 +12336,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Dancing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Dancing"
+					},
 					"modifier": -2
 				}
 			],
@@ -10049,12 +12406,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Musical Instrument",
+					"name": {
+						"compare": "is",
+						"qualifier": "Musical Instrument"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Singing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Singing"
+					},
 					"modifier": -3
 				}
 			],
@@ -10163,7 +12526,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Performance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Performance"
+					},
 					"modifier": -5
 				}
 			],
@@ -10230,7 +12596,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Stage Combat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Stage Combat"
+					},
 					"modifier": -2
 				}
 			],
@@ -10298,7 +12667,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Gunner",
+					"name": {
+						"compare": "is",
+						"qualifier": "Gunner"
+					},
 					"modifier": -4
 				}
 			],
@@ -10323,7 +12695,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Gunner",
+					"name": {
+						"compare": "is",
+						"qualifier": "Gunner"
+					},
 					"modifier": -4
 				}
 			],
@@ -10348,7 +12723,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Gunner",
+					"name": {
+						"compare": "is",
+						"qualifier": "Gunner"
+					},
 					"modifier": -4
 				}
 			],
@@ -10373,7 +12751,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Gunner",
+					"name": {
+						"compare": "is",
+						"qualifier": "Gunner"
+					},
 					"modifier": -4
 				}
 			],
@@ -10398,7 +12779,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Gunner",
+					"name": {
+						"compare": "is",
+						"qualifier": "Gunner"
+					},
 					"modifier": -4
 				}
 			],
@@ -10423,7 +12807,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Gunner",
+					"name": {
+						"compare": "is",
+						"qualifier": "Gunner"
+					},
 					"modifier": -4
 				}
 			],
@@ -10448,7 +12835,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
 					"modifier": -4
 				}
 			],
@@ -10473,7 +12863,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
 					"modifier": -4
 				}
 			],
@@ -10498,7 +12891,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
 					"modifier": -4
 				}
 			],
@@ -10523,7 +12919,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
 					"modifier": -4
 				}
 			],
@@ -10548,50 +12947,98 @@
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Grenade Launcher",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Grenade Launcher"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Gyroc",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Gyroc"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Anti-Armor Weapon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Anti-Armor Weapon"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Musket",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Musket"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Pistol",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Pistol"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Rifle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Rifle"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Shotgun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Shotgun"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Submachine Gun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Submachine Gun"
+					},
 					"modifier": -2
 				}
 			],
@@ -10616,50 +13063,98 @@
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Grenade Launcher",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Grenade Launcher"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Gyroc",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Gyroc"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Anti-Armor Weapon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Anti-Armor Weapon"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Machine Gun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Machine Gun"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Pistol",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Pistol"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Rifle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Rifle"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Shotgun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Shotgun"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Submachine Gun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Submachine Gun"
+					},
 					"modifier": -2
 				}
 			],
@@ -10684,56 +13179,110 @@
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Grenade Launcher",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Grenade Launcher"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Gyroc",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Gyroc"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Anti-Armor Weapon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Anti-Armor Weapon"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Machine Gun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Machine Gun"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Musket",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Musket"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Beam Weapons",
-					"specialization": "Pistol",
+					"name": {
+						"compare": "is",
+						"qualifier": "Beam Weapons"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Pistol"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Rifle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Rifle"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Shotgun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Shotgun"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Submachine Gun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Submachine Gun"
+					},
 					"modifier": -2
 				}
 			],
@@ -10758,56 +13307,110 @@
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Grenade Launcher",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Grenade Launcher"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Gyroc",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Gyroc"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Anti-Armor Weapon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Anti-Armor Weapon"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Machine Gun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Machine Gun"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Musket",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Musket"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Pistol",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Pistol"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Beam Weapons",
-					"specialization": "Rifle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Beam Weapons"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Rifle"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Shotgun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Shotgun"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Submachine Gun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Submachine Gun"
+					},
 					"modifier": -2
 				}
 			],
@@ -10832,50 +13435,98 @@
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Grenade Launcher",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Grenade Launcher"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Gyroc",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Gyroc"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Anti-Armor Weapon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Anti-Armor Weapon"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Machine Gun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Machine Gun"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Musket",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Musket"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Pistol",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Pistol"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Rifle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Rifle"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Submachine Gun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Submachine Gun"
+					},
 					"modifier": -2
 				}
 			],
@@ -10900,50 +13551,98 @@
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Grenade Launcher",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Grenade Launcher"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Gyroc",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Gyroc"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Anti-Armor Weapon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Anti-Armor Weapon"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Light Machine Gun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Machine Gun"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Musket",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Musket"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Pistol",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Pistol"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Rifle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Rifle"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Guns",
-					"specialization": "Shotgun",
+					"name": {
+						"compare": "is",
+						"qualifier": "Guns"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Shotgun"
+					},
 					"modifier": -2
 				}
 			],
@@ -11074,8 +13773,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Savoir-Faire",
-					"specialization": "High Society",
+					"name": {
+						"compare": "is",
+						"qualifier": "Savoir-Faire"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "High Society"
+					},
 					"modifier": -3
 				}
 			],
@@ -11265,7 +13970,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Sleight of Hand",
+					"name": {
+						"compare": "is",
+						"qualifier": "Sleight of Hand"
+					},
 					"modifier": -3
 				}
 			],
@@ -11285,7 +13993,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Bow",
+				"name": {
+					"compare": "is",
+					"qualifier": "Bow"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -11367,8 +14078,14 @@
 			"difficulty": "a",
 			"default": {
 				"type": "skill",
-				"name": "Mimicry",
-				"specialization": "Speech",
+				"name": {
+					"compare": "is",
+					"qualifier": "Mimicry"
+				},
+				"specialization": {
+					"compare": "is",
+					"qualifier": "Speech"
+				},
 				"modifier": -3
 			},
 			"limit": 0,
@@ -11392,7 +14109,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Innate Attack",
+					"name": {
+						"compare": "is",
+						"qualifier": "Innate Attack"
+					},
 					"modifier": -2
 				}
 			],
@@ -11416,7 +14136,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Innate Attack",
+					"name": {
+						"compare": "is",
+						"qualifier": "Innate Attack"
+					},
 					"modifier": -2
 				}
 			],
@@ -11440,7 +14163,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Innate Attack",
+					"name": {
+						"compare": "is",
+						"qualifier": "Innate Attack"
+					},
 					"modifier": -2
 				}
 			],
@@ -11464,7 +14190,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Innate Attack",
+					"name": {
+						"compare": "is",
+						"qualifier": "Innate Attack"
+					},
 					"modifier": -2
 				}
 			],
@@ -11483,7 +14212,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Intelligence Analysis",
+					"name": {
+						"compare": "is",
+						"qualifier": "Intelligence Analysis"
+					},
 					"modifier": -2
 				},
 				{
@@ -11492,7 +14224,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Strategy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Strategy"
+					},
 					"modifier": -6
 				}
 			],
@@ -11508,8 +14243,8 @@
 				"Police",
 				"Spy"
 			],
-			"specialization": "@Optional Specialty@",
-			"difficulty": "iq/a",
+			"optional_specialization": "@Optional Specialty@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -11517,7 +14252,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Strategy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Strategy"
+					},
 					"modifier": -6
 				}
 			],
@@ -11533,8 +14271,8 @@
 				"Police",
 				"Spy"
 			],
-			"specialization": "Traffic Analysis",
-			"difficulty": "iq/a",
+			"optional_specialization": "Traffic Analysis",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -11542,7 +14280,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Strategy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Strategy"
+					},
 					"modifier": -6
 				}
 			],
@@ -11566,12 +14307,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Intimidation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Intimidation"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Psychology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Psychology"
+					},
 					"modifier": -4
 				}
 			],
@@ -11595,7 +14342,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acting"
+					},
 					"modifier": -3
 				}
 			],
@@ -11664,14 +14414,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Smith",
-					"specialization": "Copper",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smith"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Copper"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Smith",
-					"specialization": "Lead \u0026 Tin",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smith"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Lead & Tin"
+					},
 					"modifier": -4
 				}
 			],
@@ -11691,17 +14453,26 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Force Sword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Force Sword"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Main-Gauche",
+					"name": {
+						"compare": "is",
+						"qualifier": "Main-Gauche"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Shortsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Shortsword"
+					},
 					"modifier": -3
 				},
 				{
@@ -11738,7 +14509,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Judo"
+							"name": {
+								"compare": "is",
+								"qualifier": "Judo"
+							}
 						}
 					],
 					"calc": {
@@ -11761,7 +14535,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Karate",
+				"name": {
+					"compare": "is",
+					"qualifier": "Karate"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -11864,7 +14641,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Brawling",
+				"name": {
+					"compare": "is",
+					"qualifier": "Brawling"
+				},
 				"modifier": -2
 			},
 			"limit": 0,
@@ -11883,7 +14663,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Karate",
+				"name": {
+					"compare": "is",
+					"qualifier": "Karate"
+				},
 				"modifier": -2
 			},
 			"limit": 0,
@@ -11902,7 +14685,10 @@
 			"difficulty": "a",
 			"default": {
 				"type": "skill",
-				"name": "Brawling",
+				"name": {
+					"compare": "is",
+					"qualifier": "Brawling"
+				},
 				"modifier": -1
 			},
 			"limit": 0,
@@ -11921,7 +14707,10 @@
 			"difficulty": "a",
 			"default": {
 				"type": "skill",
-				"name": "Karate",
+				"name": {
+					"compare": "is",
+					"qualifier": "Karate"
+				},
 				"modifier": -1
 			},
 			"limit": 0,
@@ -11940,17 +14729,26 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Force Sword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Force Sword"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Main-Gauche",
+					"name": {
+						"compare": "is",
+						"qualifier": "Main-Gauche"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Shortsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Shortsword"
+					},
 					"modifier": -3
 				},
 				{
@@ -11975,12 +14773,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Climbing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Climbing"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Seamanship",
+					"name": {
+						"compare": "is",
+						"qualifier": "Seamanship"
+					},
 					"modifier": -4
 				}
 			],
@@ -12003,22 +14807,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Force Whip",
+					"name": {
+						"compare": "is",
+						"qualifier": "Force Whip"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Monowire Whip",
+					"name": {
+						"compare": "is",
+						"qualifier": "Monowire Whip"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Whip",
+					"name": {
+						"compare": "is",
+						"qualifier": "Whip"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Two-Handed Flail",
+					"name": {
+						"compare": "is",
+						"qualifier": "Two-Handed Flail"
+					},
 					"modifier": -4
 				}
 			],
@@ -12041,7 +14857,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Spear",
+					"name": {
+						"compare": "is",
+						"qualifier": "Spear"
+					},
 					"modifier": -3
 				}
 			],
@@ -12139,7 +14958,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Swimming",
+				"name": {
+					"compare": "is",
+					"qualifier": "Swimming"
+				},
 				"modifier": -5
 			},
 			"limit": 0,
@@ -12248,7 +15070,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Liquid Projector",
+					"name": {
+						"compare": "is",
+						"qualifier": "Liquid Projector"
+					},
 					"modifier": -4
 				}
 			],
@@ -12273,7 +15098,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Liquid Projector",
+					"name": {
+						"compare": "is",
+						"qualifier": "Liquid Projector"
+					},
 					"modifier": -4
 				}
 			],
@@ -12298,7 +15126,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Liquid Projector",
+					"name": {
+						"compare": "is",
+						"qualifier": "Liquid Projector"
+					},
 					"modifier": -4
 				}
 			],
@@ -12323,7 +15154,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Liquid Projector",
+					"name": {
+						"compare": "is",
+						"qualifier": "Liquid Projector"
+					},
 					"modifier": -4
 				}
 			],
@@ -12348,7 +15182,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Liquid Projector",
+					"name": {
+						"compare": "is",
+						"qualifier": "Liquid Projector"
+					},
 					"modifier": -4
 				}
 			],
@@ -12368,7 +15205,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Literature",
+					"name": {
+						"compare": "is",
+						"qualifier": "Literature"
+					},
 					"modifier": -2
 				},
 				{
@@ -12387,8 +15227,8 @@
 				"Scholarly",
 				"Social Sciences"
 			],
-			"specialization": "@Optional Specialty@",
-			"difficulty": "iq/a",
+			"optional_specialization": "@Optional Specialty@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -12434,7 +15274,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -5
 				}
 			],
@@ -12458,27 +15301,42 @@
 				},
 				{
 					"type": "skill",
-					"name": "Jitte/Sai",
+					"name": {
+						"compare": "is",
+						"qualifier": "Jitte/Sai"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Knife",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knife"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Rapier",
+					"name": {
+						"compare": "is",
+						"qualifier": "Rapier"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Saber",
+					"name": {
+						"compare": "is",
+						"qualifier": "Saber"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Smallsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smallsword"
+					},
 					"modifier": -3
 				}
 			],
@@ -12500,7 +15358,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Disguise",
+					"name": {
+						"compare": "is",
+						"qualifier": "Disguise"
+					},
 					"modifier": -2
 				}
 			],
@@ -12522,12 +15383,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Economics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Economics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Merchant",
+					"name": {
+						"compare": "is",
+						"qualifier": "Merchant"
+					},
 					"modifier": -4
 				}
 			],
@@ -12565,12 +15432,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Physics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
 					"modifier": -5
 				}
 			],
@@ -12593,12 +15466,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Physics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physics"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
 					"modifier": -5
 				}
 			],
@@ -12621,7 +15500,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Computer Programming",
+					"name": {
+						"compare": "is",
+						"qualifier": "Computer Programming"
+					},
 					"modifier": -5
 				}
 			],
@@ -12644,7 +15526,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Cryptography",
+					"name": {
+						"compare": "is",
+						"qualifier": "Cryptography"
+					},
 					"modifier": -5
 				}
 			],
@@ -12676,8 +15561,8 @@
 			"tags": [
 				"Natural Science"
 			],
-			"specialization": "Pure: @Optional specialty@",
-			"difficulty": "iq/a",
+			"optional_specialization": "Pure: @Optional specialty@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "iq",
@@ -12722,12 +15607,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Cartography",
+					"name": {
+						"compare": "is",
+						"qualifier": "Cartography"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Navigation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Navigation"
+					},
 					"modifier": -4
 				}
 			],
@@ -12751,18 +15642,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "@Machine class@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Machine class@"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -12786,18 +15689,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Aerospace",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Aerospace"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -12821,18 +15736,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Antimatter Reactor",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Antimatter Reactor"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -12856,18 +15783,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Autogyro",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Autogyro"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -12891,18 +15830,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Automobile",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Automobile"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -12926,18 +15877,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Clockwork",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Clockwork"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -12961,18 +15924,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Construction Equipment",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Construction Equipment"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -12996,18 +15971,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Contragravity",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Contragravity"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13031,18 +16018,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Diesel Engine",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Diesel Engine"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13066,18 +16065,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Fission Reactor",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Fission Reactor"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13101,18 +16112,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Flight Pack",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Flight Pack"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13136,18 +16159,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Free-Flooding Sub",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Free-Flooding Sub"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13171,18 +16206,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Fuel Cell",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Fuel Cell"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13206,18 +16253,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Fusion Reactor",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Fusion Reactor"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13241,18 +16300,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Gas Turbine",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Gas Turbine"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13276,18 +16347,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Gasoline Engine",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Gasoline Engine"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13311,18 +16394,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Glider",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Glider"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13346,18 +16441,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Halftrack",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Halftrack"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13381,18 +16488,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Heavy Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Heavy Airplane"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13416,18 +16535,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Heavy Wheeled",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Heavy Wheeled"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13451,18 +16582,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Helicopter",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Helicopter"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13486,18 +16629,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "High-Performance Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "High-Performance Airplane"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13521,18 +16676,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "High-Performance Spacecraft",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "High-Performance Spacecraft"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13556,18 +16723,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Hovercraft",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Hovercraft"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13591,18 +16770,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Large Sub",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Large Sub"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13626,18 +16817,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Legged Drive",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Legged Drive"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13661,18 +16864,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Light Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Airplane"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13696,18 +16911,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Lighter-Than-Air",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Lighter-Than-Air"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13731,18 +16958,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Lightsail",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Lightsail"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13766,18 +17005,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Low-G Wings",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Low-G Wings"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13801,18 +17052,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Low-Performance Spacecraft",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Low-Performance Spacecraft"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13836,18 +17099,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Mecha",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Mecha"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13871,18 +17146,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Micromachines",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Micromachines"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13906,18 +17193,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Mini-Sub",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Mini-Sub"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13941,18 +17240,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Motorcycle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Motorcycle"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -13976,18 +17287,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Nanomachines",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Nanomachines"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -14011,18 +17334,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Reactionless Thrusters",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Reactionless Thrusters"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -14046,18 +17381,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Robotics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Robotics"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -14081,18 +17428,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Rockets",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Rockets"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic"
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					}
 				}
 			],
 			"tech_level": "",
@@ -14115,18 +17474,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Steam Engine",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Steam Engine"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -14150,18 +17521,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Tracked Drive",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Tracked Drive"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -14185,18 +17568,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Tracked Vehicle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Tracked Vehicle"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -14220,18 +17615,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Ultralight",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Ultralight"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -14255,18 +17662,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Vertol",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Vertol"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -14290,18 +17709,30 @@
 				},
 				{
 					"type": "skill",
-					"name": "Engineer",
-					"specialization": "Wheeled Drive",
+					"name": {
+						"compare": "is",
+						"qualifier": "Engineer"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Wheeled Drive"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Machinist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Machinist"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Mechanic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mechanic"
+					},
 					"modifier": -4
 				}
 			],
@@ -14323,7 +17754,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Autohypnosis",
+					"name": {
+						"compare": "is",
+						"qualifier": "Autohypnosis"
+					},
 					"modifier": -4
 				}
 			],
@@ -14377,17 +17811,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Merchant",
+					"name": {
+						"compare": "is",
+						"qualifier": "Merchant"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Finance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Finance"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Market Analysis",
+					"name": {
+						"compare": "is",
+						"qualifier": "Market Analysis"
+					},
 					"modifier": -4
 				}
 			],
@@ -14401,8 +17844,8 @@
 				"Business",
 				"Social"
 			],
-			"specialization": "@Class of Goods@",
-			"difficulty": "iq/e",
+			"optional_specialization": "@Class of Goods@",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -14410,12 +17853,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Finance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Finance"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Market Analysis",
+					"name": {
+						"compare": "is",
+						"qualifier": "Market Analysis"
+					},
 					"modifier": -4
 				}
 			],
@@ -14432,17 +17881,26 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Chemistry",
+					"name": {
+						"compare": "is",
+						"qualifier": "Chemistry"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Jeweler",
+					"name": {
+						"compare": "is",
+						"qualifier": "Jeweler"
+					},
 					"modifier": -8
 				},
 				{
 					"type": "skill",
-					"name": "Smith",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smith"
+					},
 					"modifier": -8
 				}
 			],
@@ -14595,13 +18053,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Mimicry",
-					"specialization": "Bird Calls",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mimicry"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Bird Calls"
+					},
 					"modifier": -6
 				}
 			],
@@ -14627,13 +18094,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Mimicry",
-					"specialization": "Animal Sounds",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mimicry"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Animal Sounds"
+					},
 					"modifier": -6
 				}
 			],
@@ -14656,12 +18132,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acting"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Linguistics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Linguistics"
+					},
 					"modifier": -4
 				}
 			],
@@ -14682,7 +18164,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Meditation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Meditation"
+					},
 					"modifier": -5
 				}
 			],
@@ -14705,17 +18190,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Force Whip",
+					"name": {
+						"compare": "is",
+						"qualifier": "Force Whip"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Kusari",
+					"name": {
+						"compare": "is",
+						"qualifier": "Kusari"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Whip",
+					"name": {
+						"compare": "is",
+						"qualifier": "Whip"
+					},
 					"modifier": -3
 				}
 			],
@@ -14735,7 +18229,10 @@
 			"difficulty": "a",
 			"default": {
 				"type": "skill",
-				"name": "Photography",
+				"name": {
+					"compare": "is",
+					"qualifier": "Photography"
+				},
 				"modifier": -3
 			},
 			"points": 1
@@ -14769,12 +18266,18 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Musical Instrument",
+					"name": {
+						"compare": "is",
+						"qualifier": "Musical Instrument"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Poetry",
+					"name": {
+						"compare": "is",
+						"qualifier": "Poetry"
+					},
 					"modifier": -2
 				}
 			],
@@ -14870,7 +18373,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -3
 				}
 			],
@@ -14896,7 +18402,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -3
 				}
 			],
@@ -14922,7 +18431,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -3
 				}
 			],
@@ -14948,7 +18460,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -3
 				}
 			],
@@ -14974,7 +18489,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -3
 				}
 			],
@@ -15000,7 +18518,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -3
 				}
 			],
@@ -15026,7 +18547,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -3
 				}
 			],
@@ -15047,19 +18571,34 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Astronomy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Astronomy"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Navigation",
-					"specialization": "Land",
+					"name": {
+						"compare": "is",
+						"qualifier": "Navigation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Land"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Navigation",
-					"specialization": "Sea",
+					"name": {
+						"compare": "is",
+						"qualifier": "Navigation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Sea"
+					},
 					"modifier": -2
 				}
 			],
@@ -15081,19 +18620,34 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Astronomy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Astronomy"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Navigation",
-					"specialization": "Land",
+					"name": {
+						"compare": "is",
+						"qualifier": "Navigation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Land"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Navigation",
-					"specialization": "Sea",
+					"name": {
+						"compare": "is",
+						"qualifier": "Navigation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Sea"
+					},
 					"modifier": -2
 				}
 			],
@@ -15115,19 +18669,34 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Astronomy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Astronomy"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Mathematics",
-					"specialization": "Applied",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mathematics"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Applied"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Navigation",
-					"specialization": "Space",
+					"name": {
+						"compare": "is",
+						"qualifier": "Navigation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Space"
+					},
 					"modifier": -5
 				}
 			],
@@ -15153,31 +18722,58 @@
 				},
 				{
 					"type": "skill",
-					"name": "Cartography",
+					"name": {
+						"compare": "is",
+						"qualifier": "Cartography"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Mathematics",
-					"specialization": "Surveying",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mathematics"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Surveying"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Navigation",
-					"specialization": "Air",
+					"name": {
+						"compare": "is",
+						"qualifier": "Navigation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Air"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Navigation",
-					"specialization": "Sea",
+					"name": {
+						"compare": "is",
+						"qualifier": "Navigation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Sea"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Navigation",
-					"specialization": "Underground",
+					"name": {
+						"compare": "is",
+						"qualifier": "Navigation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Underground"
+					},
 					"modifier": -2
 				}
 			],
@@ -15199,24 +18795,42 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Astronomy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Astronomy"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Seamanship",
+					"name": {
+						"compare": "is",
+						"qualifier": "Seamanship"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Navigation",
-					"specialization": "Air",
+					"name": {
+						"compare": "is",
+						"qualifier": "Navigation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Air"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Navigation",
-					"specialization": "Land",
+					"name": {
+						"compare": "is",
+						"qualifier": "Navigation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Land"
+					},
 					"modifier": -2
 				}
 			],
@@ -15238,19 +18852,34 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Astronomy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Astronomy"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Mathematics",
-					"specialization": "Applied",
+					"name": {
+						"compare": "is",
+						"qualifier": "Mathematics"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Applied"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Navigation",
-					"specialization": "Hyperspace",
+					"name": {
+						"compare": "is",
+						"qualifier": "Navigation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Hyperspace"
+					},
 					"modifier": -5
 				}
 			],
@@ -15273,17 +18902,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Battlesuit",
+					"name": {
+						"compare": "is",
+						"qualifier": "Battlesuit"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Diving Suit",
+					"name": {
+						"compare": "is",
+						"qualifier": "Diving Suit"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Vacc Suit",
+					"name": {
+						"compare": "is",
+						"qualifier": "Vacc Suit"
+					},
 					"modifier": -2
 				}
 			],
@@ -15303,6 +18941,9 @@
 			"difficulty": "h",
 			"default": {
 				"type": "st",
+				"name": {
+					"compare": "is"
+				},
 				"modifier": -4
 			},
 			"limit": 3,
@@ -15321,7 +18962,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Cloak",
+					"name": {
+						"compare": "is",
+						"qualifier": "Cloak"
+					},
 					"modifier": -5
 				}
 			],
@@ -15338,7 +18982,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Piloting",
+				"name": {
+					"compare": "is",
+					"qualifier": "Piloting"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -15363,7 +19010,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Shadowing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Shadowing"
+					},
 					"modifier": -5
 				}
 			],
@@ -15399,7 +19049,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Broadsword",
+				"name": {
+					"compare": "is",
+					"qualifier": "Broadsword"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -15418,8 +19071,14 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Guns",
-				"specialization": "Pistol",
+				"name": {
+					"compare": "is",
+					"qualifier": "Guns"
+				},
+				"specialization": {
+					"compare": "is",
+					"qualifier": "Pistol"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -15438,7 +19097,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Knife",
+				"name": {
+					"compare": "is",
+					"qualifier": "Knife"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -15457,7 +19119,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Shortsword",
+				"name": {
+					"compare": "is",
+					"qualifier": "Shortsword"
+				},
 				"modifier": -4
 			},
 			"limit": 0,
@@ -15478,8 +19143,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Animal Handling",
-					"specialization": "Equines",
+					"name": {
+						"compare": "is",
+						"qualifier": "Animal Handling"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Equines"
+					},
 					"modifier": -5
 				}
 			],
@@ -15499,12 +19170,18 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Paleontology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Paleontology"
+					},
 					"modifier": -2
 				}
 			],
@@ -15525,12 +19202,18 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Paleontology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Paleontology"
+					},
 					"modifier": -2
 				}
 			],
@@ -15551,17 +19234,26 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Paleontology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Paleontology"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Anthropology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Anthropology"
+					},
 					"modifier": -2
 				}
 			],
@@ -15583,12 +19275,18 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Paleontology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Paleontology"
+					},
 					"modifier": -2
 				}
 			],
@@ -15609,12 +19307,18 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Paleontology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Paleontology"
+					},
 					"modifier": -2
 				}
 			],
@@ -15638,12 +19342,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Fast-Talk",
+					"name": {
+						"compare": "is",
+						"qualifier": "Fast-Talk"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Public Speaking",
+					"name": {
+						"compare": "is",
+						"qualifier": "Public Speaking"
+					},
 					"modifier": -3
 				}
 			],
@@ -15696,12 +19406,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acting"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Public Speaking",
+					"name": {
+						"compare": "is",
+						"qualifier": "Public Speaking"
+					},
 					"modifier": -2
 				}
 			],
@@ -15766,17 +19482,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Biology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Biology"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Herb Lore",
+					"name": {
+						"compare": "is",
+						"qualifier": "Herb Lore"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -5
 				}
 			],
@@ -15815,12 +19540,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Chemistry",
+					"name": {
+						"compare": "is",
+						"qualifier": "Chemistry"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Physician",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					},
 					"modifier": -5
 				}
 			],
@@ -15863,8 +19594,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Electronics Operation",
-					"specialization": "Media",
+					"name": {
+						"compare": "is",
+						"qualifier": "Electronics Operation"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Media"
+					},
 					"modifier": -5
 				}
 			],
@@ -15886,12 +19623,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "First Aid",
+					"name": {
+						"compare": "is",
+						"qualifier": "First Aid"
+					},
 					"modifier": -11
 				},
 				{
 					"type": "skill",
-					"name": "Veterinary",
+					"name": {
+						"compare": "is",
+						"qualifier": "Veterinary"
+					},
 					"modifier": -5
 				}
 			],
@@ -15909,7 +19652,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Physics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physics"
+					},
 					"modifier": -2,
 					"when_tl": {
 						"compare": "at_least",
@@ -15953,8 +19699,8 @@
 			"tags": [
 				"Natural Science"
 			],
-			"specialization": "@TL 6+ Optional Specialty@",
-			"difficulty": "iq/h",
+			"optional_specialization": "@TL 6+ Optional Specialty@",
+			"difficulty": "iq/vh",
 			"defaults": [
 				{
 					"type": "iq",
@@ -15999,17 +19745,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Diagnosis",
+					"name": {
+						"compare": "is",
+						"qualifier": "Diagnosis"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Physician",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Surgery",
+					"name": {
+						"compare": "is",
+						"qualifier": "Surgery"
+					},
 					"modifier": -5
 				}
 			],
@@ -16032,12 +19787,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Filch",
+					"name": {
+						"compare": "is",
+						"qualifier": "Filch"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Sleight of Hand",
+					"name": {
+						"compare": "is",
+						"qualifier": "Sleight of Hand"
+					},
 					"modifier": -4
 				}
 			],
@@ -16059,13 +19820,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "High-Performance Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "High-Performance Airplane"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
 					"modifier": -4
 				}
 			],
@@ -16088,13 +19858,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "High-Performance Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "High-Performance Airplane"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
 					"modifier": -4
 				}
 			],
@@ -16113,19 +19892,34 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Helicopter",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Helicopter"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Heavy Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Heavy Airplane"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
 					"modifier": -5
 				},
 				{
@@ -16134,14 +19928,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Light Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Airplane"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "High-Performance Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "High-Performance Airplane"
+					},
 					"modifier": -4
 				}
 			],
@@ -16164,13 +19970,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Vertol",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Vertol"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
 					"modifier": -5
 				}
 			],
@@ -16193,13 +20008,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Vertol",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Vertol"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
 					"modifier": -5
 				}
 			],
@@ -16222,19 +20046,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Light Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Airplane"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Ultralight",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Ultralight"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
 					"modifier": -4
 				}
 			],
@@ -16257,19 +20096,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "High-Performance Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "High-Performance Airplane"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Light Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Airplane"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
 					"modifier": -4
 				}
 			],
@@ -16292,19 +20146,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Autogyro",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Autogyro"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Vertol",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Vertol"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
 					"modifier": -5
 				}
 			],
@@ -16327,25 +20196,46 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Aerospace",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Aerospace"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Heavy Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Heavy Airplane"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Light Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Airplane"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
 					"modifier": -5
 				}
 			],
@@ -16368,14 +20258,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Aerospace",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Aerospace"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Low-Performance Spacecraft",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Low-Performance Spacecraft"
+					},
 					"modifier": -2
 				}
 			],
@@ -16398,31 +20300,58 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Glider",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Glider"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Heavy Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Heavy Airplane"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "High-Performance Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "High-Performance Airplane"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Ultralight",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Ultralight"
+					},
 					"modifier": -2
 				}
 			],
@@ -16445,7 +20374,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
 					"modifier": -5
 				}
 			],
@@ -16468,8 +20400,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Low-Performance Spacecraft",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Low-Performance Spacecraft"
+					},
 					"modifier": -4
 				}
 			],
@@ -16492,8 +20430,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Glider",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Glider"
+					},
 					"modifier": -4
 				}
 			],
@@ -16516,14 +20460,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Aerospace",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Aerospace"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "High-Performance Spacecraft",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "High-Performance Spacecraft"
+					},
 					"modifier": -2
 				}
 			],
@@ -16546,31 +20502,58 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Gilder",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Gilder"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Light Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Light Airplane"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Heavy Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Heavy Airplane"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "High-Performance Airplane",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "High-Performance Airplane"
+					},
 					"modifier": -4
 				}
 			],
@@ -16593,19 +20576,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Contragravity",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Contragravity"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Helicopter",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Helicopter"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
 					"modifier": -5
 				}
 			],
@@ -16628,7 +20626,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Writing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Writing"
+					},
 					"modifier": -5
 				}
 			],
@@ -16652,17 +20653,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Chemistry",
+					"name": {
+						"compare": "is",
+						"qualifier": "Chemistry"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Pharmacy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Pharmacy"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Physician",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					},
 					"modifier": -3
 				}
 			],
@@ -16686,17 +20696,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Spear",
+					"name": {
+						"compare": "is",
+						"qualifier": "Spear"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Staff",
+					"name": {
+						"compare": "is",
+						"qualifier": "Staff"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Two-Handed Axe/Mace",
+					"name": {
+						"compare": "is",
+						"qualifier": "Two-Handed Axe/Mace"
+					},
 					"modifier": -4
 				}
 			],
@@ -16718,7 +20737,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Diplomacy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Diplomacy"
+					},
 					"modifier": -5
 				}
 			],
@@ -16876,12 +20898,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Merchant",
+					"name": {
+						"compare": "is",
+						"qualifier": "Merchant"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Psychology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Psychology"
+					},
 					"modifier": -4
 				}
 			],
@@ -16904,7 +20932,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Geology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Geology"
+					},
 					"modifier": -4
 				}
 			],
@@ -16927,7 +20958,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Sociology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Sociology"
+					},
 					"modifier": -4
 				}
 			],
@@ -16946,7 +20980,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Public Speaking",
+					"name": {
+						"compare": "is",
+						"qualifier": "Public Speaking"
+					},
 					"modifier": -2
 				},
 				{
@@ -16955,17 +20992,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acting"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Performance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Performance"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Politics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Politics"
+					},
 					"modifier": -5
 				}
 			],
@@ -16980,8 +21026,8 @@
 				"Scholarly",
 				"Social"
 			],
-			"specialization": "@Optional Specialty@",
-			"difficulty": "iq/e",
+			"optional_specialization": "@Optional Specialty@",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -16989,17 +21035,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acting"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Performance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Performance"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Politics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Politics"
+					},
 					"modifier": -5
 				}
 			],
@@ -17014,8 +21069,8 @@
 				"Scholarly",
 				"Social"
 			],
-			"specialization": "Debate",
-			"difficulty": "iq/e",
+			"optional_specialization": "Debate",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -17023,17 +21078,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acting"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Performance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Performance"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Politics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Politics"
+					},
 					"modifier": -5
 				}
 			],
@@ -17048,8 +21112,8 @@
 				"Scholarly",
 				"Social"
 			],
-			"specialization": "Oratory",
-			"difficulty": "iq/e",
+			"optional_specialization": "Oratory",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -17057,17 +21121,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acting"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Performance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Performance"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Politics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Politics"
+					},
 					"modifier": -5
 				}
 			],
@@ -17082,8 +21155,8 @@
 				"Scholarly",
 				"Social"
 			],
-			"specialization": "Rhetoric",
-			"difficulty": "iq/e",
+			"optional_specialization": "Rhetoric",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -17091,17 +21164,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acting"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Performance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Performance"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Politics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Politics"
+					},
 					"modifier": -5
 				}
 			],
@@ -17116,8 +21198,8 @@
 				"Scholarly",
 				"Social"
 			],
-			"specialization": "Punning",
-			"difficulty": "iq/e",
+			"optional_specialization": "Punning",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -17125,17 +21207,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acting"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Performance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Performance"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Politics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Politics"
+					},
 					"modifier": -5
 				}
 			],
@@ -17150,8 +21241,8 @@
 				"Scholarly",
 				"Social"
 			],
-			"specialization": "Storytelling",
-			"difficulty": "iq/e",
+			"optional_specialization": "Storytelling",
+			"difficulty": "iq/a",
 			"defaults": [
 				{
 					"type": "iq",
@@ -17159,17 +21250,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Acting",
+					"name": {
+						"compare": "is",
+						"qualifier": "Acting"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Performance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Performance"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Politics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Politics"
+					},
 					"modifier": -5
 				}
 			],
@@ -17216,22 +21316,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Broadsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Broadsword"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Main-Gauche",
+					"name": {
+						"compare": "is",
+						"qualifier": "Main-Gauche"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Saber",
+					"name": {
+						"compare": "is",
+						"qualifier": "Saber"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Smallsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smallsword"
+					},
 					"modifier": -3
 				}
 			],
@@ -17250,14 +21362,26 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Ritual Magic",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Ritual Magic"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Theology",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Theology"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -4
 				}
 			],
@@ -17279,7 +21403,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Writing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Writing"
+					},
 					"modifier": -3
 				}
 			],
@@ -17369,7 +21496,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "@Melee Weapon Skill@"
+				"name": {
+					"compare": "is",
+					"qualifier": "@Melee Weapon Skill@"
+				}
 			},
 			"limit": 5,
 			"points": 2
@@ -17386,7 +21516,10 @@
 			],
 			"difficulty": "h",
 			"default": {
-				"type": "dx"
+				"type": "dx",
+				"name": {
+					"compare": "is"
+				}
 			},
 			"limit": 5,
 			"points": 2
@@ -17404,7 +21537,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Broadsword"
+				"name": {
+					"compare": "is",
+					"qualifier": "Broadsword"
+				}
 			},
 			"limit": 5,
 			"points": 2
@@ -17422,7 +21558,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Knife"
+				"name": {
+					"compare": "is",
+					"qualifier": "Knife"
+				}
 			},
 			"limit": 5,
 			"points": 2
@@ -17440,7 +21579,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Shortsword"
+				"name": {
+					"compare": "is",
+					"qualifier": "Shortsword"
+				}
 			},
 			"limit": 5,
 			"points": 2
@@ -17461,8 +21603,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Animal Handling",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Animal Handling"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -3
 				}
 			],
@@ -17484,8 +21632,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Animal Handling",
-					"specialization": "Camel",
+					"name": {
+						"compare": "is",
+						"qualifier": "Animal Handling"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Camel"
+					},
 					"modifier": -3
 				}
 			],
@@ -17507,8 +21661,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Animal Handling",
-					"specialization": "Dolphin",
+					"name": {
+						"compare": "is",
+						"qualifier": "Animal Handling"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Dolphin"
+					},
 					"modifier": -3
 				}
 			],
@@ -17530,8 +21690,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Animal Handling",
-					"specialization": "Dragon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Animal Handling"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Dragon"
+					},
 					"modifier": -3
 				}
 			],
@@ -17553,8 +21719,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Animal Handling",
-					"specialization": "Equines",
+					"name": {
+						"compare": "is",
+						"qualifier": "Animal Handling"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Equines"
+					},
 					"modifier": -3
 				}
 			],
@@ -17573,7 +21745,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Ritual Magic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Ritual Magic"
+					},
 					"modifier": -6
 				}
 			],
@@ -17594,7 +21769,10 @@
 			"difficulty": "a",
 			"default": {
 				"type": "skill",
-				"name": "Climbing",
+				"name": {
+					"compare": "is",
+					"qualifier": "Climbing"
+				},
 				"modifier": -2
 			},
 			"limit": 0,
@@ -17633,27 +21811,42 @@
 				},
 				{
 					"type": "skill",
-					"name": "Broadsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Broadsword"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Shortsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Shortsword"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Main-Gauche",
+					"name": {
+						"compare": "is",
+						"qualifier": "Main-Gauche"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Rapier",
+					"name": {
+						"compare": "is",
+						"qualifier": "Rapier"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Smallsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smallsword"
+					},
 					"modifier": -3
 				}
 			],
@@ -17676,7 +21869,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Games",
+					"name": {
+						"compare": "is",
+						"qualifier": "Games"
+					},
 					"modifier": -3
 				}
 			],
@@ -17699,7 +21895,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Games",
+					"name": {
+						"compare": "is",
+						"qualifier": "Games"
+					},
 					"modifier": -3
 				}
 			],
@@ -17723,8 +21922,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Savoir-Faire",
-					"specialization": "Servant",
+					"name": {
+						"compare": "is",
+						"qualifier": "Savoir-Faire"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Servant"
+					},
 					"modifier": -2
 				}
 			],
@@ -17749,7 +21954,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Streetwise",
+					"name": {
+						"compare": "is",
+						"qualifier": "Streetwise"
+					},
 					"modifier": -3
 				}
 			],
@@ -17811,8 +22019,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Savoir-Faire",
-					"specialization": "High Society",
+					"name": {
+						"compare": "is",
+						"qualifier": "Savoir-Faire"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "High Society"
+					},
 					"modifier": -2
 				}
 			],
@@ -17833,7 +22047,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Climbing",
+				"name": {
+					"compare": "is",
+					"qualifier": "Climbing"
+				},
 				"modifier": -3
 			},
 			"limit": 0,
@@ -17875,7 +22092,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Diving Suit",
+					"name": {
+						"compare": "is",
+						"qualifier": "Diving Suit"
+					},
 					"modifier": -2
 				}
 			],
@@ -17929,7 +22149,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Criminology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Criminology"
+					},
 					"modifier": -5
 				}
 			],
@@ -17948,8 +22171,14 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Explosives",
-				"specialization": "Demolition",
+				"name": {
+					"compare": "is",
+					"qualifier": "Explosives"
+				},
+				"specialization": {
+					"compare": "is",
+					"qualifier": "Demolition"
+				},
 				"modifier": -2
 			},
 			"limit": 0,
@@ -18007,12 +22236,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Observation",
+					"name": {
+						"compare": "is",
+						"qualifier": "Observation"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Stealth",
+					"name": {
+						"compare": "is",
+						"qualifier": "Stealth"
+					},
 					"modifier": -4
 				}
 			],
@@ -18036,8 +22271,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Shield",
-					"specialization": "Force",
+					"name": {
+						"compare": "is",
+						"qualifier": "Shield"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Force"
+					},
 					"modifier": -2
 				}
 			],
@@ -18061,8 +22302,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Shield",
-					"specialization": "Buckler",
+					"name": {
+						"compare": "is",
+						"qualifier": "Shield"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Buckler"
+					},
 					"modifier": -2
 				}
 			],
@@ -18103,13 +22350,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Airshipman",
+					"name": {
+						"compare": "is",
+						"qualifier": "Airshipman"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Lighter-Than-Air",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Lighter-Than-Air"
+					},
 					"modifier": -5
 				}
 			],
@@ -18166,13 +22422,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Airshipman",
+					"name": {
+						"compare": "is",
+						"qualifier": "Airshipman"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Lighter-Than-Air",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Lighter-Than-Air"
+					},
 					"modifier": -5
 				}
 			],
@@ -18229,19 +22494,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Seamanship",
+					"name": {
+						"compare": "is",
+						"qualifier": "Seamanship"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Large Powerboat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Large Powerboat"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Boating",
-					"specialization": "Sailboat",
+					"name": {
+						"compare": "is",
+						"qualifier": "Boating"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Sailboat"
+					},
 					"modifier": -5
 				}
 			],
@@ -18298,19 +22578,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Spacer",
+					"name": {
+						"compare": "is",
+						"qualifier": "Spacer"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Low-Performance Spacecraft",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Low-Performance Spacecraft"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "High-Performance Spacecraft",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "High-Performance Spacecraft"
+					},
 					"modifier": -5
 				}
 			],
@@ -18367,19 +22662,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Spacer",
+					"name": {
+						"compare": "is",
+						"qualifier": "Spacer"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "Low-Performance Spacecraft",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Low-Performance Spacecraft"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Piloting",
-					"specialization": "High-Performance Spacecraft",
+					"name": {
+						"compare": "is",
+						"qualifier": "Piloting"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "High-Performance Spacecraft"
+					},
 					"modifier": -5
 				}
 			],
@@ -18436,13 +22746,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Submariner",
+					"name": {
+						"compare": "is",
+						"qualifier": "Submariner"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Submarine",
-					"specialization": "Large Sub",
+					"name": {
+						"compare": "is",
+						"qualifier": "Submarine"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Large Sub"
+					},
 					"modifier": -5
 				}
 			],
@@ -18496,37 +22815,58 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Broadsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Broadsword"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Force Sword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Force Sword"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Jitte/Sai",
+					"name": {
+						"compare": "is",
+						"qualifier": "Jitte/Sai"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Knife",
+					"name": {
+						"compare": "is",
+						"qualifier": "Knife"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Saber",
+					"name": {
+						"compare": "is",
+						"qualifier": "Saber"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Smallsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smallsword"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Tonfa",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tonfa"
+					},
 					"modifier": -3
 				},
 				{
@@ -18602,7 +22942,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Filch",
+					"name": {
+						"compare": "is",
+						"qualifier": "Filch"
+					},
 					"modifier": -5
 				}
 			],
@@ -18638,7 +22981,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Escape",
+				"name": {
+					"compare": "is",
+					"qualifier": "Escape"
+				},
 				"modifier": -5
 			},
 			"limit": 0,
@@ -18661,22 +23007,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Shortsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Shortsword"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Main-Gauche",
+					"name": {
+						"compare": "is",
+						"qualifier": "Main-Gauche"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Rapier",
+					"name": {
+						"compare": "is",
+						"qualifier": "Rapier"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Saber",
+					"name": {
+						"compare": "is",
+						"qualifier": "Saber"
+					},
 					"modifier": -3
 				}
 			],
@@ -18698,12 +23056,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Jeweler",
+					"name": {
+						"compare": "is",
+						"qualifier": "Jeweler"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Smith",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smith"
+					},
 					"modifier": -4
 				}
 			],
@@ -18726,7 +23090,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Smith",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smith"
+					},
 					"modifier": -4
 				}
 			],
@@ -18740,7 +23107,7 @@
 			"tags": [
 				"Craft"
 			],
-			"specialization": "Lead \u0026 Tin",
+			"specialization": "Lead & Tin",
 			"difficulty": "iq/a",
 			"defaults": [
 				{
@@ -18749,12 +23116,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Jeweler",
+					"name": {
+						"compare": "is",
+						"qualifier": "Jeweler"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Smith",
+					"name": {
+						"compare": "is",
+						"qualifier": "Smith"
+					},
 					"modifier": -4
 				}
 			],
@@ -18795,12 +23168,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Anthropology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Anthropology"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Psychology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Psychology"
+					},
 					"modifier": -4
 				}
 			],
@@ -18857,12 +23236,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Polearm",
+					"name": {
+						"compare": "is",
+						"qualifier": "Polearm"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Staff",
+					"name": {
+						"compare": "is",
+						"qualifier": "Staff"
+					},
 					"modifier": -2
 				}
 			],
@@ -18885,8 +23270,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Thrown Weapon",
-					"specialization": "Spear",
+					"name": {
+						"compare": "is",
+						"qualifier": "Thrown Weapon"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Spear"
+					},
 					"modifier": -4
 				}
 			],
@@ -18936,12 +23327,18 @@
 				},
 				{
 					"type": "skill",
-					"name": "Polearm",
+					"name": {
+						"compare": "is",
+						"qualifier": "Polearm"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Spear",
+					"name": {
+						"compare": "is",
+						"qualifier": "Spear"
+					},
 					"modifier": -2
 				}
 			],
@@ -18959,7 +23356,10 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Performance",
+					"name": {
+						"compare": "is",
+						"qualifier": "Performance"
+					},
 					"modifier": -3
 				}
 			],
@@ -19005,17 +23405,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Intelligence Analysis",
+					"name": {
+						"compare": "is",
+						"qualifier": "Intelligence Analysis"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Tactics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tactics"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Strategy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Strategy"
+					},
 					"modifier": -4
 				}
 			],
@@ -19037,17 +23446,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Intelligence Analysis",
+					"name": {
+						"compare": "is",
+						"qualifier": "Intelligence Analysis"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Tactics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tactics"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Strategy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Strategy"
+					},
 					"modifier": -4
 				}
 			],
@@ -19069,17 +23487,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Intelligence Analysis",
+					"name": {
+						"compare": "is",
+						"qualifier": "Intelligence Analysis"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Tactics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tactics"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Strategy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Strategy"
+					},
 					"modifier": -4
 				}
 			],
@@ -19101,17 +23528,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Intelligence Analysis",
+					"name": {
+						"compare": "is",
+						"qualifier": "Intelligence Analysis"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Tactics",
+					"name": {
+						"compare": "is",
+						"qualifier": "Tactics"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Strategy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Strategy"
+					},
 					"modifier": -4
 				}
 			],
@@ -19152,14 +23588,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Submarine",
-					"specialization": "Large Sub",
+					"name": {
+						"compare": "is",
+						"qualifier": "Submarine"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Large Sub"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Submarine",
-					"specialization": "Mini-Sub",
+					"name": {
+						"compare": "is",
+						"qualifier": "Submarine"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Mini-Sub"
+					},
 					"modifier": -4
 				}
 			],
@@ -19204,14 +23652,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Submarine",
-					"specialization": "Free-Flooding Sub",
+					"name": {
+						"compare": "is",
+						"qualifier": "Submarine"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Free-Flooding Sub"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Submarine",
-					"specialization": "Mini-Sub",
+					"name": {
+						"compare": "is",
+						"qualifier": "Submarine"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Mini-Sub"
+					},
 					"modifier": -4
 				}
 			],
@@ -19234,7 +23694,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Submarine",
+					"name": {
+						"compare": "is",
+						"qualifier": "Submarine"
+					},
 					"modifier": -4
 				}
 			],
@@ -19333,22 +23796,34 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "First Aid",
+					"name": {
+						"compare": "is",
+						"qualifier": "First Aid"
+					},
 					"modifier": -12
 				},
 				{
 					"type": "skill",
-					"name": "Physician",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Physiology",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physiology"
+					},
 					"modifier": -8
 				},
 				{
 					"type": "skill",
-					"name": "Veterinary",
+					"name": {
+						"compare": "is",
+						"qualifier": "Veterinary"
+					},
 					"modifier": -5
 				}
 			],
@@ -19394,55 +23869,106 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Bank",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Bank"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Deep Ocean Vent",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Deep Ocean Vent"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Fresh-Water Lake",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Fresh-Water Lake"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Open Ocean",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Open Ocean"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Reef",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Reef"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "River/Stream",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "River/Stream"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Salt-Water Sea",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Salt-Water Sea"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Tropical Lagoon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Tropical Lagoon"
+					},
 					"modifier": -4
 				}
 			],
@@ -19465,7 +23991,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				}
 			],
@@ -19488,55 +24017,106 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Arctic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Arctic"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Desert",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Desert"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Island/Beach",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Island/Beach"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Jungle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Jungle"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Mountain",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Mountain"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Plains",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Plains"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Swamplands",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Swamplands"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Woodlands",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Woodlands"
+					},
 					"modifier": -3
 				}
 			],
@@ -19559,49 +24139,94 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Desert",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Desert"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Island/Beach",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Island/Beach"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Jungle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Jungle"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Mountain",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Mountain"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Plains",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Plains"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Swamplands",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Swamplands"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Woodlands",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Woodlands"
+					},
 					"modifier": -3
 				}
 			],
@@ -19624,49 +24249,94 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Deep Ocean Vent",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Deep Ocean Vent"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Fresh-Water Lake",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Fresh-Water Lake"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Open Ocean",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Open Ocean"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Reef",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Reef"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "River/Stream",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "River/Stream"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Salt-Water Sea",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Salt-Water Sea"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Tropical Lagoon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Tropical Lagoon"
+					},
 					"modifier": -4
 				}
 			],
@@ -19689,49 +24359,94 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Bank",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Bank"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Fresh-Water Lake",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Fresh-Water Lake"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Open Ocean",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Open Ocean"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Reef",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Reef"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "River/Stream",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "River/Stream"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Salt-Water Sea",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Salt-Water Sea"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Tropical Lagoon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Tropical Lagoon"
+					},
 					"modifier": -4
 				}
 			],
@@ -19754,49 +24469,94 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Arctic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Arctic"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Island/Beach",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Island/Beach"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Jungle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Jungle"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Mountain",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Mountain"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Plains",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Plains"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Swampland",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Swampland"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Woodlands",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Woodlands"
+					},
 					"modifier": -3
 				}
 			],
@@ -19819,49 +24579,94 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Bank",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Bank"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Deep Ocean Vent",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Deep Ocean Vent"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Open Ocean",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Open Ocean"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Reef",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Reef"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "River/Stream",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "River/Stream"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Salt-Water Sea",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Salt-Water Sea"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Tropical Lagoon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Tropical Lagoon"
+					},
 					"modifier": -4
 				}
 			],
@@ -19884,55 +24689,106 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Tropical Lagoon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Tropical Lagoon"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Arctic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Arctic"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Desert",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Desert"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Jungle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Jungle"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Mountain",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Mountain"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Plains",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Plains"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Swampland",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Swampland"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Woodlands",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Woodlands"
+					},
 					"modifier": -3
 				}
 			],
@@ -19955,49 +24811,94 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Arctic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Arctic"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Desert",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Desert"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Mountain",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Mountain"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Plains",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Plains"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Swampland",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Swampland"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Island/Beach",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Island/Beach"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Woodlands",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Woodlands"
+					},
 					"modifier": -3
 				}
 			],
@@ -20020,49 +24921,94 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Arctic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Arctic"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Desert",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Desert"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Island/Beach",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Island/Beach"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Jungle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Jungle"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Plains",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Plains"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Swampland",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Swampland"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Woodlands",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Woodlands"
+					},
 					"modifier": -3
 				}
 			],
@@ -20085,49 +25031,94 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Bank",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Bank"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Deep Ocean Vent",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Deep Ocean Vent"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Fresh-Water Lake",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Fresh-Water Lake"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Reef",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Reef"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "River/Stream",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "River/Stream"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Salt-Water Sea",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Salt-Water Sea"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Tropical Lagoon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Tropical Lagoon"
+					},
 					"modifier": -4
 				}
 			],
@@ -20150,49 +25141,94 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Arctic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Arctic"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Desert",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Desert"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Island/Beach",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Island/Beach"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Jungle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Jungle"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Mountain",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Mountain"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Swampland",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Swampland"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Woodlands",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Woodlands"
+					},
 					"modifier": -3
 				}
 			],
@@ -20215,49 +25251,94 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Bank",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Bank"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Deep Ocean Vent",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Deep Ocean Vent"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Fresh-Water Lake",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Fresh-Water Lake"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Open Ocean",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Open Ocean"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "River/Stream",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "River/Stream"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Salt-Water Sea",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Salt-Water Sea"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Tropical Lagoon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Tropical Lagoon"
+					},
 					"modifier": -4
 				}
 			],
@@ -20280,55 +25361,106 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Swampland",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Swampland"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Bank",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Bank"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Deep Ocean Vent",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Deep Ocean Vent"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Fresh-Water Lake",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Fresh-Water Lake"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Open Ocean",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Open Ocean"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Reef",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Reef"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Salt-Water Sea",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Salt-Water Sea"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Tropical Lagoon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Tropical Lagoon"
+					},
 					"modifier": -4
 				}
 			],
@@ -20351,49 +25483,94 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Bank",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Bank"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Deep Ocean Vent",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Deep Ocean Vent"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Fresh-Water Lake",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Fresh-Water Lake"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Open Ocean",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Open Ocean"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Reef",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Reef"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "River/Stream",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "River/Stream"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Tropical Lagoon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Tropical Lagoon"
+					},
 					"modifier": -4
 				}
 			],
@@ -20416,55 +25593,106 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "River/Stream",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "River/Stream"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Arctic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Arctic"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Desert",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Desert"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Jungle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Jungle"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Mountain",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Mountain"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Plains",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Plains"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Island/Beach",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Island/Beach"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Woodlands",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Woodlands"
+					},
 					"modifier": -3
 				}
 			],
@@ -20487,55 +25715,106 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Island/Beach",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Island/Beach"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Bank",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Bank"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Deep Ocean Vent",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Deep Ocean Vent"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Fresh-Water Lake",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Fresh-Water Lake"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Open Ocean",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Open Ocean"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Reef",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Reef"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Salt-Water Sea",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Salt-Water Sea"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "River/Stream",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "River/Stream"
+					},
 					"modifier": -4
 				}
 			],
@@ -20558,49 +25837,94 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Arctic",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Arctic"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Desert",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Desert"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Island/Beach",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Island/Beach"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Jungle",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Jungle"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Mountain",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Mountain"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Plains",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Plains"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Survival",
-					"specialization": "Swampland",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Swampland"
+					},
 					"modifier": -3
 				}
 			],
@@ -20629,7 +25953,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "@Two-Handed Weapon Skill@",
+				"name": {
+					"compare": "is",
+					"qualifier": "@Two-Handed Weapon Skill@"
+				},
 				"modifier": -3
 			},
 			"limit": 0,
@@ -20648,7 +25975,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Polearm",
+				"name": {
+					"compare": "is",
+					"qualifier": "Polearm"
+				},
 				"modifier": -3
 			},
 			"limit": 0,
@@ -20667,7 +25997,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Spear",
+				"name": {
+					"compare": "is",
+					"qualifier": "Spear"
+				},
 				"modifier": -3
 			},
 			"limit": 0,
@@ -20686,7 +26019,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Staff",
+				"name": {
+					"compare": "is",
+					"qualifier": "Staff"
+				},
 				"modifier": -3
 			},
 			"limit": 0,
@@ -20705,7 +26041,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "@Unarmed Combat Skill@",
+				"name": {
+					"compare": "is",
+					"qualifier": "@Unarmed Combat Skill@"
+				},
 				"modifier": -3
 			},
 			"limit": 0,
@@ -20724,7 +26063,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Judo",
+				"name": {
+					"compare": "is",
+					"qualifier": "Judo"
+				},
 				"modifier": -3
 			},
 			"limit": 0,
@@ -20743,7 +26085,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Karate",
+				"name": {
+					"compare": "is",
+					"qualifier": "Karate"
+				},
 				"modifier": -3
 			},
 			"limit": 0,
@@ -20762,7 +26107,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Sumo Wrestling",
+				"name": {
+					"compare": "is",
+					"qualifier": "Sumo Wrestling"
+				},
 				"modifier": -3
 			},
 			"limit": 0,
@@ -20815,7 +26163,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Strategy",
+					"name": {
+						"compare": "is",
+						"qualifier": "Strategy"
+					},
 					"modifier": -6
 				}
 			],
@@ -20855,19 +26206,34 @@
 				},
 				{
 					"type": "skill",
-					"name": "Animal Handling",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Animal Handling"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Riding",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Riding"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Teamster",
+					"name": {
+						"compare": "is",
+						"qualifier": "Teamster"
+					},
 					"modifier": -3
 				}
 			],
@@ -20890,14 +26256,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Animal Handling",
-					"specialization": "Equines",
+					"name": {
+						"compare": "is",
+						"qualifier": "Animal Handling"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Equines"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Riding",
-					"specialization": "Equines",
+					"name": {
+						"compare": "is",
+						"qualifier": "Riding"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Equines"
+					},
 					"modifier": -2
 				}
 			],
@@ -20937,8 +26315,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Religious Ritual",
-					"specialization": "@Specialty@",
+					"name": {
+						"compare": "is",
+						"qualifier": "Religious Ritual"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "@Specialty@"
+					},
 					"modifier": -4
 				}
 			],
@@ -20962,7 +26346,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Dropping",
+					"name": {
+						"compare": "is",
+						"qualifier": "Dropping"
+					},
 					"modifier": -4
 				}
 			],
@@ -21056,7 +26443,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Throwing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Throwing"
+					},
 					"modifier": -2
 				}
 			],
@@ -21080,8 +26470,14 @@
 				},
 				{
 					"type": "skill",
-					"name": "Thrown Weapon",
-					"specialization": "Spear",
+					"name": {
+						"compare": "is",
+						"qualifier": "Thrown Weapon"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Spear"
+					},
 					"modifier": -2
 				}
 			],
@@ -21124,7 +26520,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Throwing",
+					"name": {
+						"compare": "is",
+						"qualifier": "Throwing"
+					},
 					"modifier": -2
 				}
 			],
@@ -21148,13 +26547,22 @@
 				},
 				{
 					"type": "skill",
-					"name": "Spear Thrower",
+					"name": {
+						"compare": "is",
+						"qualifier": "Spear Thrower"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Thrown Weapon",
-					"specialization": "Harpoon",
+					"name": {
+						"compare": "is",
+						"qualifier": "Thrown Weapon"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Harpoon"
+					},
 					"modifier": -2
 				}
 			],
@@ -21196,7 +26604,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Shortsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Shortsword"
+					},
 					"modifier": -3
 				}
 			],
@@ -21218,7 +26629,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Naturalist",
+					"name": {
+						"compare": "is",
+						"qualifier": "Naturalist"
+					},
 					"modifier": -5
 				}
 			],
@@ -21241,7 +26655,10 @@
 				},
 				{
 					"type": "skill",
-					"name": "Lockpicking",
+					"name": {
+						"compare": "is",
+						"qualifier": "Lockpicking"
+					},
 					"modifier": -3
 				}
 			],
@@ -21265,17 +26682,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Axe/Mace",
+					"name": {
+						"compare": "is",
+						"qualifier": "Axe/Mace"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Polearm",
+					"name": {
+						"compare": "is",
+						"qualifier": "Polearm"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Two-Handed Flail",
+					"name": {
+						"compare": "is",
+						"qualifier": "Two-Handed Flail"
+					},
 					"modifier": -4
 				}
 			],
@@ -21298,17 +26724,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Flail",
+					"name": {
+						"compare": "is",
+						"qualifier": "Flail"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Kusari",
+					"name": {
+						"compare": "is",
+						"qualifier": "Kusari"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Two-Handed Axe/Mace",
+					"name": {
+						"compare": "is",
+						"qualifier": "Two-Handed Axe/Mace"
+					},
 					"modifier": -4
 				}
 			],
@@ -21327,12 +26762,18 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Broadsword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Broadsword"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "Force Sword",
+					"name": {
+						"compare": "is",
+						"qualifier": "Force Sword"
+					},
 					"modifier": -4
 				},
 				{
@@ -21393,17 +26834,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Diving Suit",
+					"name": {
+						"compare": "is",
+						"qualifier": "Diving Suit"
+					},
 					"modifier": -4
 				},
 				{
 					"type": "skill",
-					"name": "NBC Suit",
+					"name": {
+						"compare": "is",
+						"qualifier": "NBC Suit"
+					},
 					"modifier": -2
 				},
 				{
 					"type": "skill",
-					"name": "Battlesuit",
+					"name": {
+						"compare": "is",
+						"qualifier": "Battlesuit"
+					},
 					"modifier": -2
 				}
 			],
@@ -21433,17 +26883,26 @@
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Animal Handling",
+					"name": {
+						"compare": "is",
+						"qualifier": "Animal Handling"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Physician",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Surgery",
+					"name": {
+						"compare": "is",
+						"qualifier": "Surgery"
+					},
 					"modifier": -5
 				}
 			],
@@ -21458,22 +26917,31 @@
 				"Animal",
 				"Medical"
 			],
-			"specialization": "@Optional Specialty@",
-			"difficulty": "iq/a",
+			"optional_specialization": "@Optional Specialty@",
+			"difficulty": "iq/h",
 			"defaults": [
 				{
 					"type": "skill",
-					"name": "Animal Handling",
+					"name": {
+						"compare": "is",
+						"qualifier": "Animal Handling"
+					},
 					"modifier": -6
 				},
 				{
 					"type": "skill",
-					"name": "Physician",
+					"name": {
+						"compare": "is",
+						"qualifier": "Physician"
+					},
 					"modifier": -5
 				},
 				{
 					"type": "skill",
-					"name": "Surgery",
+					"name": {
+						"compare": "is",
+						"qualifier": "Surgery"
+					},
 					"modifier": -5
 				}
 			],
@@ -21527,17 +26995,26 @@
 				},
 				{
 					"type": "skill",
-					"name": "Force Whip",
+					"name": {
+						"compare": "is",
+						"qualifier": "Force Whip"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Kusari",
+					"name": {
+						"compare": "is",
+						"qualifier": "Kusari"
+					},
 					"modifier": -3
 				},
 				{
 					"type": "skill",
-					"name": "Monowire Whip",
+					"name": {
+						"compare": "is",
+						"qualifier": "Monowire Whip"
+					},
 					"modifier": -3
 				}
 			],
@@ -21556,7 +27033,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "@Melee Weapon Skill@",
+				"name": {
+					"compare": "is",
+					"qualifier": "@Melee Weapon Skill@"
+				},
 				"modifier": -5
 			},
 			"limit": 0,
@@ -21575,7 +27055,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Boxing",
+				"name": {
+					"compare": "is",
+					"qualifier": "Boxing"
+				},
 				"modifier": -5
 			},
 			"limit": 0,
@@ -21594,7 +27077,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Broadsword",
+				"name": {
+					"compare": "is",
+					"qualifier": "Broadsword"
+				},
 				"modifier": -5
 			},
 			"limit": 0,
@@ -21613,7 +27099,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Karate",
+				"name": {
+					"compare": "is",
+					"qualifier": "Karate"
+				},
 				"modifier": -5
 			},
 			"limit": 0,
@@ -21632,7 +27121,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Staff",
+				"name": {
+					"compare": "is",
+					"qualifier": "Staff"
+				},
 				"modifier": -5
 			},
 			"limit": 0,
@@ -21651,7 +27143,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Two-Handed Sword",
+				"name": {
+					"compare": "is",
+					"qualifier": "Two-Handed Sword"
+				},
 				"modifier": -5
 			},
 			"limit": 0,
@@ -21669,7 +27164,10 @@
 			"difficulty": "h",
 			"default": {
 				"type": "skill",
-				"name": "Lockpicking",
+				"name": {
+					"compare": "is",
+					"qualifier": "Lockpicking"
+				},
 				"modifier": -5
 			},
 			"limit": 0,


### PR DESCRIPTION
This makes sure that every skill listed in Basic Set that calls out that it may have optional specialties has their optional specialties set up using the new Optional Specialization field.

Unfortunately, due to my lack of foresight the diff is a mess, as I haven't split the automatic file format changes to Basic Set Skills from the deliberate changes.

For completeness, the full list of skills affected is:
* Artist
* Astronomy
* Biology
* Cryptography
* Chemistry (no explicit optional specialty in the list, but it's the example for optional specialties)
* Intelligence Analysis
* Merchant
* Physics
* Veterinary