### PR TITLE
Fix point costs for traits in the Inhuman Vampire template

### DIFF
--- a/Library/Monster Hunters/Classes/Champions/Inhuman Vampire.gct
+++ b/Library/Monster Hunters/Classes/Champions/Inhuman Vampire.gct
@@ -12,7 +12,7 @@
 					"children": [
 						{
 							"id": "tsWvCW1Guqeebb4FS",
-							"name": "Acute Taste \u0026 Smell",
+							"name": "Acute Taste & Smell",
 							"reference": "B35",
 							"tags": [
 								"Advantage",
@@ -278,13 +278,14 @@
 									"tags": [
 										"Physical"
 									],
+									"base_points": 1,
 									"calc": {
-										"points": 0
+										"points": 1
 									}
 								}
 							],
 							"calc": {
-								"points": 0
+								"points": 1
 							}
 						},
 						{
@@ -464,7 +465,7 @@
 						}
 					],
 					"calc": {
-						"points": 181
+						"points": 182
 					}
 				},
 				{
@@ -631,32 +632,31 @@
 							],
 							"modifiers": [
 								{
-									"id": "m76jSCdisBgrYKFxx",
+									"id": "meG26rMbYViA1ejk3",
 									"name": "Common",
 									"cost_adj": "-5"
 								},
 								{
-									"id": "m3czOCuguMTmlsnlM",
+									"id": "m0k_agyIH6mi3yXoa",
 									"name": "Occasional",
 									"cost_adj": "-10",
 									"disabled": true
 								},
 								{
-									"id": "mW4C6HjNybuLFOyLr",
+									"id": "mgnOEnsuqwi7OkPs0",
 									"name": "Rare",
 									"cost_adj": "-15",
 									"disabled": true
 								},
 								{
-									"id": "mGciYOxOYTIajAbnr",
+									"id": "m-uyR_UKJBneuut9W",
 									"name": "Illegal",
 									"cost_adj": "-5",
 									"disabled": true
 								}
 							],
-							"base_points": -5,
 							"calc": {
-								"points": -10
+								"points": -5
 							}
 						},
 						{
@@ -937,7 +937,7 @@
 						}
 					],
 					"calc": {
-						"points": -127
+						"points": -122
 					}
 				},
 				{
@@ -1013,7 +1013,7 @@
 				}
 			],
 			"calc": {
-				"points": 194
+				"points": 200
 			}
 		}
 	]


### PR DESCRIPTION
I noticed that the Inhuman Vampire template was showing as a 194 point template even though it had no choices, but Monster Hunter expects the Inhuman racial templates to be 200 points each. Comparing the point costs of the traits against the list on MH1-51 I noticed "Can burn HP for extra effort" was 0 points on the template vs. 1 point in the book, and Draining (blood) was -10 points on the template vs. -5 points in the book. I've fixed both of these issues, bringing the template costs up to the correct 200 points.

I made the changes in GCS itself. It looks like GCS also decided to update some IDs and switch away from a Unicode escape for the ampersand in "Acute Taste & Smell"