### PR TITLE
Update the Dungeon Fantasy Mentalist template and add the Mentalist lens

### DIFF
--- a/Library/Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Trait Modifiers.adm
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Trait Modifiers.adm
@@ -1,0 +1,12 @@
+{
+	"version": 5,
+	"rows": [
+		{
+			"id": "mrvjsoNmm32aFWqsK",
+			"name": "Psionic",
+			"reference": "DF14:5",
+			"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+			"cost_adj": "-10%"
+		}
+	]
+}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq
@@ -2,6 +2,60 @@
 	"version": 5,
 	"rows": [
 		{
+			"id": "twYbceNKP5XRucfbL",
+			"name": "Psi Talent",
+			"reference": "DF14:4",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Mental",
+				"Psionics"
+			],
+			"points_per_level": 5,
+			"max_levels": "6",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to ALL rolls involving Psionic Abilities",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"levels": 1,
+			"calc": {
+				"points": 5,
+				"current_level": 1
+			}
+		},
+		{
+			"id": "tfHo4a0U7i7qDw6K7",
+			"name": "Resistant to Psionics",
+			"reference": "DF14:14, B81",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Mental",
+				"Physical"
+			],
+			"points_per_level": 2,
+			"max_levels": "6",
+			"features": [
+				{
+					"type": "conditional_modifier",
+					"situation": "to all resistance rolls against psi",
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"levels": 1,
+			"calc": {
+				"points": 2,
+				"current_level": 1
+			}
+		},
+		{
 			"id": "t-wyLZnOXVarj_V7i",
 			"name": "Talent (Psientist)",
 			"reference": "DF14:21,PU3:15",
@@ -13,18 +67,18 @@
 			],
 			"modifiers": [
 				{
-					"id": "mRefdRpmnwm2AZHqR",
+					"id": "mJvMvWGy3xOS7fOxG",
 					"name": "Reaction Bonus",
 					"local_notes": "Psis"
 				},
 				{
-					"id": "mzS32G6q5IjhER5hg",
+					"id": "mO8ASUeFlflVayvjM",
 					"name": "Alternate Benefit",
 					"local_notes": "Bonus to self control rolls after a successful Meditation, Mental Strength, or Mind Block",
 					"disabled": true
 				},
 				{
-					"id": "mq5Ey3Ur3KsP52GD2",
+					"id": "m7kN4sJS-pod20noc",
 					"name": "Alternative Cost",
 					"cost_adj": "1",
 					"affects": "levels_only",
@@ -32,6 +86,7 @@
 				}
 			],
 			"points_per_level": 5,
+			"max_levels": "4",
 			"features": [
 				{
 					"type": "skill_bonus",
@@ -117,6 +172,5048 @@
 			"calc": {
 				"points": 5,
 				"current_level": 1
+			}
+		},
+		{
+			"id": "tDw_0VbKuFabwn_Jd",
+			"name": "Unusual Background (Psionic)",
+			"reference": "DF14:14",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Mental",
+				"Psionics"
+			],
+			"base_points": 10,
+			"calc": {
+				"points": 10
+			}
+		},
+		{
+			"id": "TOPmoEpxNVOENhuke",
+			"name": "Psionic Abilities",
+			"reference": "DF14:5",
+			"children": [
+				{
+					"id": "TyOFku13Cni2U2XKj",
+					"name": "Alternate Psionic Abilities",
+					"reference": "DF14:5",
+					"reference_highlight": "Alternate Abilities",
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Unusual Background (Psionic)"
+								}
+							},
+							{
+								"type": "script_prereq",
+								"script": "const msgtxt = []\nif (self.children.some(child => child.findActiveModifier(\"Psionic\") === null)) msgtxt.push(\"You have a Non-Psionic Trait\");\nmsgtxt.join(\"\\n* \")"
+							}
+						]
+					},
+					"container_type": "alternative_abilities",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "TlriqjaC9ObjC3vmw",
+					"name": "Anti-Psi",
+					"children": [
+						{
+							"id": "T-FL0lMLmezBuBTk_",
+							"name": "Dispel Psi",
+							"reference": "DF14:5",
+							"tags": [
+								"Advantage",
+								"Psionics"
+							],
+							"children": [
+								{
+									"id": "twZLjdPOHrISMMWMr",
+									"name": "Dispel Psi 1",
+									"reference": "DF14:5",
+									"local_notes": "Neutralize",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "m3_KgddpkJ2zf3RBT",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mGw78DaTuwoIKNdbM",
+											"name": "Interruption",
+											"reference": "PSI16",
+											"cost_adj": "-50%"
+										}
+									],
+									"base_points": 50,
+									"calc": {
+										"points": 20
+									}
+								},
+								{
+									"id": "tDpufqECai5-mcF06",
+									"name": "Dispel Psi 2",
+									"reference": "DF14:5",
+									"local_notes": "Neutralize",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 4
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mtKIASvrbdgH6dmzE",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mTwe7dc3GkvfPsyxZ",
+											"name": "Interruption",
+											"reference": "PSI16",
+											"cost_adj": "-50%"
+										},
+										{
+											"id": "mGXf7eOQxaUzz3TeD",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mlMYKfQnlVJoEWb5w"
+											},
+											"name": "Ranged",
+											"reference": "B107,P105",
+											"cost_adj": "40%"
+										}
+									],
+									"base_points": 50,
+									"calc": {
+										"points": 40
+									}
+								}
+							],
+							"calc": {
+								"points": 60
+							}
+						},
+						{
+							"id": "t-N0coAK8BBi9cv-P",
+							"name": "Mind Shield",
+							"reference": "DF14:8",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Psionics"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "script_prereq",
+										"script": "(self.level > Math.max(0,entity.traitLevel('Psi Talent')) + 6) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unusual Background (Psionic)"
+										}
+									}
+								]
+							},
+							"replacements": {
+								"Condition": "Psionic Only"
+							},
+							"modifiers": [
+								{
+									"id": "mcduQMqfd-FMj5Bhv",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								},
+								{
+									"id": "mLcRXxiA6naqrMJy0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+										"id": "m2IwCpU9KwYmjiSSA"
+									},
+									"name": "Accessibility (@Condition@)",
+									"reference": "B110,P99",
+									"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+									"cost_adj": "-1%",
+									"levels": 50,
+									"calc": {}
+								}
+							],
+							"points_per_level": 4,
+							"max_levels": "12",
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Resisting Psionic abilities",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 2,
+								"current_level": 1
+							}
+						},
+						{
+							"id": "t41dc1qjJpsTwmo9d",
+							"name": "Psychic Armor",
+							"reference": "DF14:9",
+							"local_notes": "Damage Resistance",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Psionics"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "script_prereq",
+										"script": "(self.level > Math.max(0,entity.traitLevel('Psi Talent')) + 6) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unusual Background (Psionic)"
+										}
+									}
+								]
+							},
+							"replacements": {
+								"Very Common Attack Form": "Psionic"
+							},
+							"modifiers": [
+								{
+									"id": "mprDW7qVflzJgU3sC",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								},
+								{
+									"id": "mlE7r_Gk52IYGt7fb",
+									"name": "Limited",
+									"reference": "B46",
+									"local_notes": "@Very Common Attack Form@",
+									"cost_adj": "-20%",
+									"calc": {
+										"resolved_notes": "Psionic"
+									}
+								}
+							],
+							"points_per_level": 5,
+							"max_levels": "12",
+							"features": [
+								{
+									"type": "dr_bonus",
+									"locations": [
+										"all"
+									],
+									"specialization": "Psionic",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 4,
+								"current_level": 1
+							}
+						}
+					],
+					"calc": {
+						"points": 66
+					}
+				},
+				{
+					"id": "Tyvd1CFrO8eJUnPo2",
+					"name": "ESP",
+					"children": [
+						{
+							"id": "tAIl6UZXIwIKyejVd",
+							"name": "Psight",
+							"reference": "DF14:9",
+							"local_notes": "Scanning Sense (Para-Radar)",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Psionics"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unusual Background (Psionic)"
+										}
+									}
+								]
+							},
+							"modifiers": [
+								{
+									"id": "mIhAOq537j0VhdVf3",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								}
+							],
+							"base_points": 40,
+							"calc": {
+								"points": 36
+							}
+						},
+						{
+							"id": "TtkLgm-_FUKjSB5MM",
+							"name": "Psychic Sensitivity",
+							"reference": "DF14:9",
+							"tags": [
+								"Advantage",
+								"Psionics"
+							],
+							"children": [
+								{
+									"id": "t_csCNxhoc0R3rvRV",
+									"name": "Psychic Sensitivity 1",
+									"reference": "DF14:9",
+									"local_notes": "Detect (Psionic Abilities)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mNgMigqsCXM5jOg8g",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										}
+									],
+									"base_points": 10,
+									"calc": {
+										"points": 9
+									}
+								},
+								{
+									"id": "tkBFqf6kj84xQjvHe",
+									"name": "Psychic Sensitivity 2",
+									"reference": "DF14:9",
+									"local_notes": "Detect (Psionics Abilities and Beings)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mvHBrajj5C_J5URxJ",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										}
+									],
+									"base_points": 20,
+									"calc": {
+										"points": 18
+									}
+								},
+								{
+									"id": "t1rPlPMEFO-M8KRuy",
+									"name": "Psychic Sensitivity 3",
+									"reference": "DF14:9",
+									"local_notes": "Detect (All Psi related phenomena)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 4
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mnI8YeldiEuVcBczs",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										}
+									],
+									"base_points": 30,
+									"calc": {
+										"points": 27
+									}
+								}
+							],
+							"calc": {
+								"points": 54
+							}
+						},
+						{
+							"id": "TXjINaGQQRyibII2n",
+							"name": "Psychometry",
+							"reference": "DF14:10",
+							"tags": [
+								"Advantage",
+								"Psionics"
+							],
+							"children": [
+								{
+									"id": "toxav4n5IJrsq39nB",
+									"name": "Psychometry 1",
+									"reference": "DF14:10",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mTpk_iWRALc78UzL-",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										}
+									],
+									"base_points": 20,
+									"calc": {
+										"points": 18
+									}
+								},
+								{
+									"id": "tugXU5K_ir3eOXLRk",
+									"name": "Psychometry 2",
+									"reference": "DF14:10",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mCT1RnpZGpelVBdrL",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mZCyjLt6Xjttg5lY1",
+											"name": "Visions",
+											"reference": "PSI17",
+											"cost_adj": "50%"
+										}
+									],
+									"base_points": 20,
+									"calc": {
+										"points": 28
+									}
+								},
+								{
+									"id": "tdmgzderARDkvroCE",
+									"name": "Psychometry 3",
+									"reference": "DF14:10",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 4
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "m1iDdpUti-RaWzeks",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mkypbD7xIfX9fLNgR",
+											"name": "Immersive",
+											"reference": "P69",
+											"cost_adj": "100%"
+										}
+									],
+									"base_points": 20,
+									"calc": {
+										"points": 38
+									}
+								}
+							],
+							"calc": {
+								"points": 84
+							}
+						},
+						{
+							"id": "TpcfzVnz3ITGKt5xv",
+							"name": "Remote Viewing",
+							"reference": "DF14:10",
+							"tags": [
+								"Advantage",
+								"Psionics"
+							],
+							"children": [
+								{
+									"id": "twBbzT_AzQLGjA4Za",
+									"name": "Remote Viewing 1",
+									"reference": "DF14:10",
+									"local_notes": "Clairsentance",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "moWb-1q6CGgvQKLdk",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mu4Xt13D4as1oii8b",
+											"name": "Clairvoyance",
+											"cost_adj": "-10%"
+										}
+									],
+									"base_points": 50,
+									"calc": {
+										"points": 40
+									}
+								},
+								{
+									"id": "t7hTC8Ps78kc_MsJO",
+									"name": "Remote Viewing 2",
+									"reference": "DF14:10",
+									"local_notes": "Clairsentance",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "m7Gtkt1rLBo3HVV-V",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										}
+									],
+									"base_points": 50,
+									"calc": {
+										"points": 45
+									}
+								},
+								{
+									"id": "tIXRibv7FHGkf-2qh",
+									"name": "Remote Viewing 3",
+									"reference": "DF14:10",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "prereq_list",
+												"all": false,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "psi talent"
+														},
+														"level": {
+															"compare": "at_least",
+															"qualifier": 1
+														}
+													},
+													{
+														"type": "trait_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "psight"
+														}
+													}
+												]
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mqFnGlb6rWVnOgfwr",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mPqhZ_3vt340zhHlR",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mIgewYjuzmPvs7Jx9"
+											},
+											"name": "2x Increased Range",
+											"reference": "B106",
+											"cost_adj": "10%"
+										}
+									],
+									"base_points": 50,
+									"calc": {
+										"points": 50
+									}
+								}
+							],
+							"calc": {
+								"points": 135
+							}
+						},
+						{
+							"id": "t-Oo-7smxxcl8lLTF",
+							"name": "Transdimensional Sight",
+							"reference": "DF14:11",
+							"local_notes": "See Invisible (Extradimensional)",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Psionics"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unusual Background (Psionic)"
+										}
+									}
+								]
+							},
+							"modifiers": [
+								{
+									"id": "mZx8p6hrXbkOG6JoL",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								},
+								{
+									"id": "mwO6D1GjpFkYYjDzy",
+									"name": "Nuisance Effect (Eyes can be eaten)",
+									"reference": "B112,P104",
+									"cost_adj": "-5%"
+								}
+							],
+							"base_points": 15,
+							"calc": {
+								"points": 13
+							}
+						}
+					],
+					"calc": {
+						"points": 322
+					}
+				},
+				{
+					"id": "TWHvefnnTO1syG-4A",
+					"name": "Psychokinesis",
+					"children": [
+						{
+							"id": "tCCpZB2-HnrIJ6RWS",
+							"name": "Ergokinetic Shield",
+							"reference": "DF14:6",
+							"local_notes": "Damage Resistance",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Psionics"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "script_prereq",
+										"script": "(self.level > Math.max(0,entity.traitLevel('Psi Talent')) + 6) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+									}
+								]
+							},
+							"replacements": {
+								"Very Common Attack Form": "Energy"
+							},
+							"modifiers": [
+								{
+									"id": "mQ8sEJ4kV_VYvIaKH",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								},
+								{
+									"id": "mI0AdLwNnUZXvOwMl",
+									"name": "Limited",
+									"reference": "B46",
+									"local_notes": "@Very Common Attack Form@",
+									"cost_adj": "-20%",
+									"calc": {
+										"resolved_notes": "Energy"
+									}
+								}
+							],
+							"points_per_level": 5,
+							"max_levels": "12",
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 4,
+								"current_level": 1
+							}
+						},
+						{
+							"id": "TmZJd5sZeVYMZohCC",
+							"name": "Levitation",
+							"reference": "DF14:6",
+							"tags": [
+								"Advantage",
+								"Psionics"
+							],
+							"children": [
+								{
+									"id": "tGOGdAac3YsZzxbJ_",
+									"name": "Levitation 1",
+									"reference": "DF14:6",
+									"local_notes": "Flight",
+									"tags": [
+										"Exotic",
+										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mB83CDFafslZW45fe",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "m-aAVJPzXMaRyzXKi",
+											"name": "Low Ceiling",
+											"reference": "B56",
+											"local_notes": "5'",
+											"cost_adj": "-25%"
+										},
+										{
+											"id": "mFWrhoQ-kEwKVxc5t",
+											"name": "Slow, Move 1",
+											"reference": "PSI14",
+											"cost_adj": "-45%"
+										}
+									],
+									"base_points": 40,
+									"calc": {
+										"points": 8
+									}
+								},
+								{
+									"id": "tLR4TUVDYR8lgFYex",
+									"name": "Levitation 2",
+									"reference": "DF14:6",
+									"local_notes": "Flight",
+									"tags": [
+										"Exotic",
+										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mPd7nDWz_7OIvFt1r",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "m1HVYKjeDp9nVTSiF",
+											"name": "Low Ceiling",
+											"reference": "B56",
+											"local_notes": "10'",
+											"cost_adj": "-20%"
+										},
+										{
+											"id": "mJY2U07l7VrHKP-PS",
+											"name": "Slow",
+											"reference": "PSI14",
+											"local_notes": "Basic Speed",
+											"cost_adj": "-25%"
+										}
+									],
+									"base_points": 40,
+									"calc": {
+										"points": 18
+									}
+								},
+								{
+									"id": "tWAfvBp6H_TonJeOS",
+									"name": "Levitation 3",
+									"reference": "DF14:6",
+									"local_notes": "Flight",
+									"tags": [
+										"Exotic",
+										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 4
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mcoZSQhfYrP6AFXuP",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mgfcMlfjlxJ0uLpZX",
+											"name": "Low Ceiling",
+											"reference": "B56",
+											"local_notes": "10'",
+											"cost_adj": "-20%"
+										}
+									],
+									"base_points": 40,
+									"calc": {
+										"points": 28
+									}
+								}
+							],
+							"calc": {
+								"points": 54
+							}
+						},
+						{
+							"id": "tcWKoSMXzAFvYXAYU",
+							"name": "Psychokinetic Lash",
+							"reference": "DF14:10",
+							"local_notes": "Innate Attack (Crush)",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Psionics"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "script_prereq",
+										"script": "(self.level > entity.traitLevel('Psi Talent')) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unusual Background (Psionic)"
+										}
+									}
+								]
+							},
+							"modifiers": [
+								{
+									"id": "mu0y6-2z0QdI59jX9",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								},
+								{
+									"id": "mu_sCfbgwZ1fTL6A9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+										"id": "mBUqeaOCkjZbdZXTV"
+									},
+									"name": "Variable",
+									"reference": "B109,P107",
+									"cost_adj": "5%"
+								}
+							],
+							"points_per_level": 5,
+							"max_levels": "6",
+							"weapons": [
+								{
+									"id": "wT1AAnrvv-jZf9gX5",
+									"sv": 1,
+									"damage": {
+										"type": "",
+										"base_leveled": "1d"
+									},
+									"usage": "Parry",
+									"parry": "0",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Innate Attack"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Gaze"
+											}
+										}
+									],
+									"calc": {
+										"damage": "1d per level"
+									}
+								},
+								{
+									"id": "Wkc2QTulLI4Axlt53",
+									"sv": 1,
+									"damage": {
+										"type": "cr",
+										"base_leveled": "1d"
+									},
+									"usage": "Lash",
+									"accuracy": "3",
+									"range": "10/100",
+									"rate_of_fire": "1",
+									"recoil": "1",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Innate Attack"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Gaze"
+											}
+										}
+									],
+									"calc": {
+										"damage": "1d per level  cr"
+									}
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 5,
+								"current_level": 1
+							}
+						},
+						{
+							"id": "tUg36TbXQg2z4--p4",
+							"name": "Pyrokinetic Bolt",
+							"reference": "DF14:10",
+							"local_notes": "Innate Attack (Burn)",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Psionics"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "script_prereq",
+										"script": "(self.level > entity.traitLevel('Psi Talent')) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unusual Background (Psionic)"
+										}
+									}
+								]
+							},
+							"modifiers": [
+								{
+									"id": "mtDijltqGUebKxZXB",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								},
+								{
+									"id": "mhgubpT5UdDELhPh0",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+										"id": "mBUqeaOCkjZbdZXTV"
+									},
+									"name": "Variable",
+									"reference": "B109,P107",
+									"cost_adj": "5%"
+								}
+							],
+							"points_per_level": 5,
+							"max_levels": "6",
+							"weapons": [
+								{
+									"id": "wBo29yDX9O6YTOxgf",
+									"sv": 1,
+									"damage": {
+										"type": "",
+										"base_leveled": "1d"
+									},
+									"usage": "Parry",
+									"parry": "0",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Innate Attack"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Gaze"
+											}
+										}
+									],
+									"calc": {
+										"damage": "1d per level"
+									}
+								},
+								{
+									"id": "WYg9WIeYbU_iwr4Ik",
+									"sv": 1,
+									"damage": {
+										"type": "burn",
+										"base_leveled": "1d"
+									},
+									"usage": "Bolt",
+									"accuracy": "3",
+									"range": "10/100",
+									"rate_of_fire": "1",
+									"recoil": "1",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Innate Attack"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Gaze"
+											}
+										}
+									],
+									"calc": {
+										"damage": "1d per level  burn"
+									}
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 5,
+								"current_level": 1
+							}
+						},
+						{
+							"id": "td7oozECEczwnPR-C",
+							"name": "Telekinesis",
+							"reference": "B92,P82,PSI17",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Force",
+								"Mental",
+								"Physical"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "script_prereq",
+										"script": "(self.level > Math.max(0,entity.traitLevel('Psi Talent')) + 10) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unusual Background (Psionic)"
+										},
+										"level": {
+											"compare": "at_least"
+										}
+									}
+								]
+							},
+							"replacements": {
+								"Disciplines of Faith or Major Vow": "Disciplines of Faith or Major Vow"
+							},
+							"modifiers": [
+								{
+									"id": "m4AsgG54_xeSNMw0o",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								},
+								{
+									"id": "mDtAdl0liDLCAK97r",
+									"name": "Cannot Affect Self",
+									"reference": "PSI17",
+									"cost_adj": "-20%"
+								}
+							],
+							"points_per_level": 5,
+							"max_levels": "16",
+							"weapons": [
+								{
+									"id": "weVXCwszze9s5oSql",
+									"sv": 1,
+									"damage": {
+										"type": "cr",
+										"st": "tk_thr"
+									},
+									"usage": "Grab",
+									"reach": "C,1-10",
+									"defaults": [
+										{
+											"type": "dx"
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Judo"
+											}
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Sumo Wrestling"
+											}
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Wrestling"
+											}
+										}
+									],
+									"calc": {
+										"damage": "telekinetic thr cr"
+									}
+								},
+								{
+									"id": "wR0gcBjtyT7PQoUkk",
+									"sv": 1,
+									"damage": {
+										"type": "cr",
+										"st": "tk_thr"
+									},
+									"usage": "Shove",
+									"usage_notes": "No Damage, Double Knockback",
+									"reach": "C,1-10",
+									"defaults": [
+										{
+											"type": "dx"
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Sumo Wrestling"
+											}
+										}
+									],
+									"calc": {
+										"damage": "telekinetic thr cr"
+									}
+								},
+								{
+									"id": "wqu3h26L1j-PFD0eW",
+									"sv": 1,
+									"damage": {
+										"type": "cr",
+										"st": "tk_thr"
+									},
+									"usage": "Strike",
+									"reach": "C,1-10",
+									"parry": "0",
+									"defaults": [
+										{
+											"type": "dx"
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Boxing"
+											}
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Karate"
+											}
+										}
+									],
+									"calc": {
+										"damage": "telekinetic thr cr"
+									}
+								}
+							],
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Skill use of High Manual Dexterity as per B92+",
+									"amount": 4
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 4,
+								"current_level": 1
+							}
+						}
+					],
+					"calc": {
+						"points": 72
+					}
+				},
+				{
+					"id": "TLqsbmbz-2jgmCeAB",
+					"name": "Telepathy",
+					"children": [
+						{
+							"id": "t-LpbpjqQoNZb1DAA",
+							"name": "Battlesense",
+							"reference": "DF14:5",
+							"local_notes": "Enhanced (Block, Dodge, Parry)",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Psionics"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "script_prereq",
+										"script": "((self.level*2) > entity.traitLevel('Psi Talent')) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Mind Reading"
+										}
+									}
+								]
+							},
+							"replacements": {
+								"Condition": "Not against the Mindless"
+							},
+							"modifiers": [
+								{
+									"id": "mKCBCRwn61yiLr-Vv",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								},
+								{
+									"id": "mqPHoy2avwOUr6P-f",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+										"id": "m2IwCpU9KwYmjiSSA"
+									},
+									"name": "Accessibility (@Condition@)",
+									"reference": "B110,P99",
+									"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+									"cost_adj": "-1%",
+									"levels": 10,
+									"calc": {}
+								}
+							],
+							"points_per_level": 30,
+							"max_levels": "3",
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "dodge",
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "parry",
+									"amount": 1,
+									"per_level": true
+								},
+								{
+									"type": "attribute_bonus",
+									"attribute": "block",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 24,
+								"current_level": 1
+							}
+						},
+						{
+							"id": "tZkafJWp7VeDD-Szf",
+							"name": "Empathy",
+							"reference": "DF14:6",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Psionics"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unusual Background (Psionic)"
+										}
+									}
+								]
+							},
+							"replacements": {
+								"Condition": "Not on Elder Things"
+							},
+							"modifiers": [
+								{
+									"id": "myYQOWe9FOFFsIZOi",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								},
+								{
+									"id": "m34vs0FGOufemdJEo",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+										"id": "m2IwCpU9KwYmjiSSA"
+									},
+									"name": "Accessibility (@Condition@)",
+									"reference": "B110,P99",
+									"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+									"cost_adj": "-1%",
+									"levels": 5,
+									"calc": {}
+								}
+							],
+							"base_points": 15,
+							"calc": {
+								"points": 13
+							}
+						},
+						{
+							"id": "tFovAJ3h8q_yyIrOW",
+							"name": "Fear",
+							"reference": "DF14:6",
+							"local_notes": "Terror",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Psionics"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Telesend"
+										}
+									}
+								]
+							},
+							"modifiers": [
+								{
+									"id": "mw_ZKYi8wDjkP-fj1",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								},
+								{
+									"id": "m8OZeN59Q_rfZMXdK",
+									"name": "Active",
+									"reference": "P84"
+								}
+							],
+							"base_points": 30,
+							"calc": {
+								"points": 27
+							}
+						},
+						{
+							"id": "tePelkGSO0FP9l3Bz",
+							"name": "Intuition",
+							"reference": "DF14:6",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Psionics"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unusual Background (Psionic)"
+										}
+									}
+								]
+							},
+							"replacements": {
+								"Condition": "Not places that have never had sentient visitors or a past"
+							},
+							"modifiers": [
+								{
+									"id": "mNNtrrIjjIpriVJfJ",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								},
+								{
+									"id": "mAC9xJYw7AcBEHwK4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+										"id": "m2IwCpU9KwYmjiSSA"
+									},
+									"name": "Accessibility (@Condition@)",
+									"reference": "B110,P99",
+									"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+									"cost_adj": "-1%",
+									"levels": 5,
+									"calc": {}
+								}
+							],
+							"base_points": 15,
+							"calc": {
+								"points": 13
+							}
+						},
+						{
+							"id": "TzDmTA3w76H7Dn65y",
+							"name": "Madness",
+							"reference": "DF14:7",
+							"tags": [
+								"Advantage",
+								"Psionics"
+							],
+							"children": [
+								{
+									"id": "tWa7S7frYk5HwZF5e",
+									"name": "Madness 1",
+									"reference": "DF14:7",
+									"local_notes": "Affliction (Hallucinating)",
+									"tags": [
+										"Advantage",
+										"Physical",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Different Attribute": "Will"
+									},
+									"modifiers": [
+										{
+											"id": "m1X4vbes-JQSwG7zX",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "miFz-DIqxFJ0jfGlY",
+											"name": "Hallucination",
+											"reference": "B429",
+											"cost_adj": "50%"
+										},
+										{
+											"id": "mtxJghZMTAX7OJCmT",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mwYBuNRe3OO7f3KNJ"
+											},
+											"name": "Malediction",
+											"reference": "B106,P103",
+											"local_notes": "-1 per yard of range",
+											"cost_adj": "100%"
+										},
+										{
+											"id": "mibQMQVQ2gTePGmGO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mlMAMv0A4zOUT52xH"
+											},
+											"name": "No Signature",
+											"reference": "B106,P103",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "mcIOQ9XbgsBYNXZoP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm",
+												"id": "mJ4fxQ_hJHsqPgccX"
+											},
+											"name": "Based on @Different Attribute@, Own Roll",
+											"reference": "PU4:12",
+											"cost_adj": "20%"
+										}
+									],
+									"base_points": 10,
+									"calc": {
+										"points": 28
+									}
+								},
+								{
+									"id": "tWjV7-qGxOzaLtKsW",
+									"name": "Madness 2",
+									"reference": "DF14:7",
+									"local_notes": "Affliction (Hallucinating)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Different Attribute": "Will"
+									},
+									"modifiers": [
+										{
+											"id": "mK7G27OWh8Ycia1EO",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mupIQ_UcW8j_UMA8U",
+											"name": "Hallucination",
+											"reference": "B429",
+											"cost_adj": "50%"
+										},
+										{
+											"id": "m-qiCqvyUXM0GlC4V",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mgoMzmGtd5meGGC3u"
+											},
+											"name": "Malediction",
+											"reference": "B106,P103",
+											"local_notes": "Use SSRT range penalties",
+											"cost_adj": "150%"
+										},
+										{
+											"id": "mcSICq0biSzfC0UTW",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mlMAMv0A4zOUT52xH"
+											},
+											"name": "No Signature",
+											"reference": "B106,P103",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "mtq8b6qFUD_ia5PPX",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm",
+												"id": "mJ4fxQ_hJHsqPgccX"
+											},
+											"name": "Based on @Different Attribute@, Own Roll",
+											"reference": "PU4:12",
+											"cost_adj": "20%"
+										}
+									],
+									"base_points": 10,
+									"calc": {
+										"points": 33
+									}
+								},
+								{
+									"id": "tMFO-pHZCnrweNQgO",
+									"name": "Madness 3",
+									"reference": "DF14:7",
+									"local_notes": "Affliction (Hallucinating)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 4
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Different Attribute": "Will"
+									},
+									"modifiers": [
+										{
+											"id": "mI_nPAo3mM-E3MigF",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "m0d9iCpQoi4Lb9pT0",
+											"name": "Hallucination",
+											"reference": "B429",
+											"cost_adj": "50%"
+										},
+										{
+											"id": "mGrHYYTrqeVGlOdle",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mrQbJZqh8LqLTSlSm"
+											},
+											"name": "Malediction",
+											"reference": "B106,P103",
+											"local_notes": "Uses Long-Distance Modifiers",
+											"cost_adj": "200%"
+										},
+										{
+											"id": "mgqNRUj-DiLA5SNZ6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mlMAMv0A4zOUT52xH"
+											},
+											"name": "No Signature",
+											"reference": "B106,P103",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "ma-RET7RiwWpN3xy5",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm",
+												"id": "mJ4fxQ_hJHsqPgccX"
+											},
+											"name": "Based on @Different Attribute@, Own Roll",
+											"reference": "PU4:12",
+											"cost_adj": "20%"
+										}
+									],
+									"base_points": 10,
+									"calc": {
+										"points": 38
+									}
+								}
+							],
+							"calc": {
+								"points": 99
+							}
+						},
+						{
+							"id": "T8sVjMvLzDutBao_0",
+							"name": "Mind Blast",
+							"reference": "DF14:7",
+							"tags": [
+								"Advantage",
+								"Psionics"
+							],
+							"children": [
+								{
+									"id": "tgRTvaXLKKq1SGf22",
+									"name": "Mind Blast 1",
+									"reference": "DF14:7",
+									"local_notes": "Affliction 1 (Stun)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Different Attribute": "Will"
+									},
+									"modifiers": [
+										{
+											"id": "mpRBfWO0vN2F6xgBv",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mCenuCIl3BNg-xvV3",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm",
+												"id": "mJ4fxQ_hJHsqPgccX"
+											},
+											"name": "Based on @Different Attribute@, Own Roll",
+											"reference": "PU4:12",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "mYjvLsKiaofu04siP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mibbcaZA6iq5s3ETp"
+											},
+											"name": "3x Duration",
+											"reference": "B105",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "mXtSWLVkQKgcoN4hj",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mwYBuNRe3OO7f3KNJ"
+											},
+											"name": "Malediction",
+											"reference": "B106,P103",
+											"local_notes": "-1 per yard of range",
+											"cost_adj": "100%"
+										},
+										{
+											"id": "m8iMx07hTJmHFEF7P",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mlMAMv0A4zOUT52xH"
+											},
+											"name": "No Signature",
+											"reference": "B106,P103",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "m1pj29gBiDdlZOiUQ",
+											"name": "Secondary Unconsciousness",
+											"reference": "B429",
+											"cost_adj": "40%"
+										}
+									],
+									"base_points": 10,
+									"calc": {
+										"points": 29
+									}
+								},
+								{
+									"id": "t8z7PHdzPL43IUN8h",
+									"name": "Mind Blast 2",
+									"reference": "DF14:7",
+									"local_notes": "Affliction 1 (Stun)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Different Attribute": "Will"
+									},
+									"modifiers": [
+										{
+											"id": "m2HsAwzN2mNYe8oyL",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mPP2i3_v0XRa60vfx",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm",
+												"id": "mJ4fxQ_hJHsqPgccX"
+											},
+											"name": "Based on @Different Attribute@, Own Roll",
+											"reference": "PU4:12",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "muGZNG83kRoWb4RAx",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mibbcaZA6iq5s3ETp"
+											},
+											"name": "3x Duration",
+											"reference": "B105",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "m9Epmm7qNm8Bmtf4B",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mgoMzmGtd5meGGC3u"
+											},
+											"name": "Malediction",
+											"reference": "B106,P103",
+											"local_notes": "Use SSRT range penalties",
+											"cost_adj": "150%"
+										},
+										{
+											"id": "mp8c6NJO2Vb9j4jed",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mlMAMv0A4zOUT52xH"
+											},
+											"name": "No Signature",
+											"reference": "B106,P103",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "mQcjtTgAsrP_nJuCi",
+											"name": "Secondary Unconsciousness",
+											"reference": "B429",
+											"cost_adj": "40%"
+										}
+									],
+									"base_points": 10,
+									"calc": {
+										"points": 34
+									}
+								},
+								{
+									"id": "tuFejhdLoZpFC8Vz8",
+									"name": "Mind Blast 3",
+									"reference": "DF14:7",
+									"local_notes": "Affliction 1 (Stun)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 4
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Different Attribute": "Will"
+									},
+									"modifiers": [
+										{
+											"id": "mNLJofNEt0fmFu7kT",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "me9OITQYnEUF_VFDF",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm",
+												"id": "mJ4fxQ_hJHsqPgccX"
+											},
+											"name": "Based on @Different Attribute@, Own Roll",
+											"reference": "PU4:12",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "mlvawqFltZCT8jzn9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mibbcaZA6iq5s3ETp"
+											},
+											"name": "3x Duration",
+											"reference": "B105",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "m5q4VhAnj-PBIKn4z",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mrQbJZqh8LqLTSlSm"
+											},
+											"name": "Malediction",
+											"reference": "B106,P103",
+											"local_notes": "Uses Long-Distance Modifiers",
+											"cost_adj": "200%"
+										},
+										{
+											"id": "mI7PYRxz1N_9futqf",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mlMAMv0A4zOUT52xH"
+											},
+											"name": "No Signature",
+											"reference": "B106,P103",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "mTvyqZQwJjWVmIn52",
+											"name": "Secondary Unconsciousness",
+											"reference": "B429",
+											"cost_adj": "40%"
+										}
+									],
+									"base_points": 10,
+									"calc": {
+										"points": 39
+									}
+								}
+							],
+							"calc": {
+								"points": 102
+							}
+						},
+						{
+							"id": "Txm9zbmWD0B19TwvP",
+							"name": "Mind Control",
+							"reference": "DF14:7",
+							"tags": [
+								"Advantage",
+								"Psionics"
+							],
+							"children": [
+								{
+									"id": "tGU3dd0dmu76Tt9KW",
+									"name": "Mind Control 1",
+									"reference": "DF14:7",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Telesend"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mS_Jn3HY2RqdiDj96",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mh8qVtTl9ZRYgF7DX",
+											"name": "Mind Tricks",
+											"reference": "PSI15",
+											"cost_adj": "-30%"
+										}
+									],
+									"base_points": 50,
+									"calc": {
+										"points": 30
+									}
+								},
+								{
+									"id": "t6wg73HkodIKMT7Om",
+									"name": "Mind Control 2",
+									"reference": "DF14:7",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 4
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Telesend"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mqcc3yEzGFcfniBoZ",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										}
+									],
+									"base_points": 50,
+									"calc": {
+										"points": 45
+									}
+								}
+							],
+							"calc": {
+								"points": 75
+							}
+						},
+						{
+							"id": "tNjl44OWEq8f7_z6X",
+							"name": "Mind Meld",
+							"reference": "DF14:8",
+							"local_notes": "**Mind Probe** , Feature: Can compel speech, but risk giving up secrets.",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Psionics"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unusual Background (Psionic)"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Psi Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									}
+								]
+							},
+							"modifiers": [
+								{
+									"id": "mnG6JvTcNKWwLP1IP",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								},
+								{
+									"id": "mG983WiEqvUhBamCO",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Power Ups/Power Ups 8 Limitations Limitation Modifiers.adm",
+										"id": "mnXv6kra7QDSGy2f5"
+									},
+									"name": "Immediate Preparation Required",
+									"reference": "PU8:14",
+									"local_notes": "1 minute",
+									"cost_adj": "-30%"
+								}
+							],
+							"base_points": 20,
+							"calc": {
+								"points": 12
+							}
+						},
+						{
+							"id": "tSwvnXANtzmf-moeF",
+							"name": "Mind Reading",
+							"reference": "DF14:8",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Psionics"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unusual Background (Psionic)"
+										}
+									}
+								]
+							},
+							"modifiers": [
+								{
+									"id": "mRC1611osFQfNQOgf",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								}
+							],
+							"base_points": 30,
+							"calc": {
+								"points": 27
+							}
+						},
+						{
+							"id": "TvV3pDjC7pVG9V-St",
+							"name": "Mind Stab",
+							"reference": "DF14:9",
+							"tags": [
+								"Advantage",
+								"Psionics"
+							],
+							"children": [
+								{
+									"id": "tB0jeNW169PovpPXy",
+									"name": "Mind Stab 1",
+									"reference": "DF14:9",
+									"local_notes": "Innate Attack (Fatigue/Toxic)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Telesend"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Condition": "No effect on Brainless; Damage cannot exceed margin of victory; Psychic Armor protects normally"
+									},
+									"modifiers": [
+										{
+											"id": "mtl5-teVXTMphAW_t",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "md1ZmzpkexhSUcdie",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+												"id": "m2IwCpU9KwYmjiSSA"
+											},
+											"name": "Accessibility (@Condition@)",
+											"reference": "B110,P99",
+											"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+											"cost_adj": "-1%",
+											"levels": 70,
+											"calc": {}
+										},
+										{
+											"id": "mCjEVZ7Nj_CQddQE9",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mlMAMv0A4zOUT52xH"
+											},
+											"name": "No Signature",
+											"reference": "B106,P103",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "mqilF0KMCjjBFc-OP",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mwYBuNRe3OO7f3KNJ"
+											},
+											"name": "Malediction",
+											"reference": "B106,P103",
+											"local_notes": "-1 per yard of range",
+											"cost_adj": "100%"
+										}
+									],
+									"base_points": 32.5,
+									"calc": {
+										"points": 46
+									}
+								},
+								{
+									"id": "tyYA39PgVuzKONhgz",
+									"name": "Mind Stab 2",
+									"reference": "DF14:9",
+									"local_notes": "Innate Attack (Fatigue/Toxic)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 4
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Telesend"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Condition": "No effect on Brainless; Damage cannot exceed margin of victory; Psychic Armor protects normally"
+									},
+									"modifiers": [
+										{
+											"id": "m3jE4NtFelLqnlMLU",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "m1xu-7jTfUTVhKssg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+												"id": "m2IwCpU9KwYmjiSSA"
+											},
+											"name": "Accessibility (@Condition@)",
+											"reference": "B110,P99",
+											"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+											"cost_adj": "-1%",
+											"levels": 70,
+											"calc": {}
+										},
+										{
+											"id": "m-VX8U7giehgUYCTg",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mlMAMv0A4zOUT52xH"
+											},
+											"name": "No Signature",
+											"reference": "B106,P103",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "mtziKdDsdxVQSRofr",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mgoMzmGtd5meGGC3u"
+											},
+											"name": "Malediction",
+											"reference": "B106,P103",
+											"local_notes": "Use SSRT range penalties",
+											"cost_adj": "150%"
+										}
+									],
+									"base_points": 32.5,
+									"calc": {
+										"points": 62
+									}
+								},
+								{
+									"id": "tky1yaFu610_AMAQ1",
+									"name": "Mind Stab 3",
+									"reference": "DF14:9",
+									"local_notes": "Innate Attack (Fatigue/Toxic)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 6
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Telesend"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Condition": "No effect on Brainless; Damage cannot exceed margin of victory; Psychic Armor protects normally"
+									},
+									"modifiers": [
+										{
+											"id": "mP_miCDdGpFoSqHb9",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mg7zOUfvfUDoP-9Su",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+												"id": "m2IwCpU9KwYmjiSSA"
+											},
+											"name": "Accessibility (@Condition@)",
+											"reference": "B110,P99",
+											"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+											"cost_adj": "-1%",
+											"levels": 70,
+											"calc": {}
+										},
+										{
+											"id": "mDiN_3GkYbNH8mXoJ",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mlMAMv0A4zOUT52xH"
+											},
+											"name": "No Signature",
+											"reference": "B106,P103",
+											"cost_adj": "20%"
+										},
+										{
+											"id": "mzpSZfy3fcZSanx7P",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mrQbJZqh8LqLTSlSm"
+											},
+											"name": "Malediction",
+											"reference": "B106,P103",
+											"local_notes": "Uses Long-Distance Modifiers",
+											"cost_adj": "200%"
+										}
+									],
+									"base_points": 32.5,
+									"calc": {
+										"points": 78
+									}
+								}
+							],
+							"calc": {
+								"points": 186
+							}
+						},
+						{
+							"id": "tgFRGx8DCKK9Lxgjl",
+							"name": "Telesend",
+							"reference": "DF14:11",
+							"local_notes": "Telecommunication (Telesend)",
+							"tags": [
+								"Advantage",
+								"Exotic",
+								"Mental",
+								"Psionics"
+							],
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unusual Background (Psionic)"
+										}
+									}
+								]
+							},
+							"modifiers": [
+								{
+									"id": "mKDqLhEYuwkDvgN5i",
+									"name": "Psionic",
+									"reference": "DF14:5",
+									"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+									"cost_adj": "-10%"
+								}
+							],
+							"base_points": 30,
+							"calc": {
+								"points": 27
+							}
+						}
+					],
+					"calc": {
+						"points": 605
+					}
+				}
+			],
+			"calc": {
+				"points": 1065
+			}
+		},
+		{
+			"id": "T9sbajfExnpml3GMl",
+			"name": "Psi Perks",
+			"reference": "DF14:14",
+			"reference_highlight": "Psi Perks",
+			"local_notes": "to a maximum of one perk per 10 full points total in Psi Talent, Psionics abilities, and psi-related skills. For dedicated mentalists, this limit will rarely matter!",
+			"children": [
+				{
+					"id": "tcuO-BLXXd_imjqq1",
+					"name": "Perk (Focused Resistance)",
+					"reference": "DF14:14",
+					"reference_highlight": "Focused Resistance",
+					"local_notes": "**@resist one specific Psionics ability,spell, Enthrallment skill, or monster attack that targets IQ or Will@**<br>This is cumulative with other bonuses to resist.",
+					"tags": [
+						"Mental",
+						"Perk"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Unusual Background (Psionic)"
+								}
+							}
+						]
+					},
+					"base_points": 1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to resist @resist one specific Psionics ability,spell, Enthrallment skill, or monster attack that targets IQ or Will@",
+							"amount": 3
+						}
+					],
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tfpbL_5feCpNHXVyg",
+					"name": "Perk (Gazer)",
+					"reference": "DF14:14",
+					"reference_highlight": "Gazer",
+					"local_notes": "Replace regular Innate Attack (Gaze) with a Per-based one",
+					"tags": [
+						"Mental",
+						"Perk"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Unusual Background (Psionic)"
+								}
+							}
+						]
+					},
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tyoMXlZdGiHssPk9a",
+					"name": "Perk (Hilfe!)",
+					"reference": "DF14:14",
+					"reference_highlight": "Hilfe!",
+					"local_notes": "When you're in danger you can send out a call for help detectable by any party member who's been on at least 2 adventures with you and passes a Perception +Psi Talent roll. But only to know that you're in trouble.",
+					"tags": [
+						"Mental",
+						"Perk"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Unusual Background (Psionic)"
+								}
+							}
+						]
+					},
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tPTedUv0DDrSy0ayj",
+					"name": "Perk (Psharp)",
+					"reference": "DF14:14",
+					"reference_highlight": "Psharp",
+					"local_notes": "Use Psight to cheat at [Gambling](DF2:4). Claim a +1 to +3 bonus to the skill roll but make a reaction roll at -1 to -3 respectively. On a [Bad](BX560) reaction you're caught cheating.",
+					"tags": [
+						"Mental",
+						"Perk"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Unusual Background (Psionic)"
+								}
+							}
+						]
+					},
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tmrQgcoQi8yFJ_I5m",
+					"name": "Perk (Psychic Replica @Signature Gear@)",
+					"reference": "DF14:14",
+					"reference_highlight": "Psychic Replica",
+					"local_notes": "A designated piece of Signature Gear weighing up to BL appears with you when you project into another plane.",
+					"tags": [
+						"Equipment",
+						"Perk"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Unusual Background (Psionic)"
+								}
+							}
+						]
+					},
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "tE8FlntN5oDKW_d7k",
+					"name": "Perk (Psychic Terror)",
+					"reference": "DF14:14",
+					"reference_highlight": "Psychic Terror",
+					"local_notes": "If you do not have any form of Terror, failing to read your mind causes a Fright Check the first time it happens. If you _do_ have a form of Terror (including [Fear](DF14:6)), it instead activates for free even on a successful mind read.",
+					"tags": [
+						"Mental",
+						"Perk"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Unusual Background (Psionic)"
+								}
+							}
+						]
+					},
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "t-5KfznFRvunEzZTM",
+					"name": "Perk (Telekinetic Tether @Signature Gear@)",
+					"reference": "DF14:14",
+					"reference_highlight": "Telekinetic Tether",
+					"local_notes": "A designated piece of Signature Gear weighing up to BL can be summoed to your hand from up to 2yds away if not restrained. If already in reach it's easier to fast-draw.",
+					"tags": [
+						"Equipment",
+						"Perk"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Unusual Background (Psionic)"
+								}
+							}
+						]
+					},
+					"base_points": 1,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to fast-draw @Signature Gear@",
+							"amount": 4
+						}
+					],
+					"calc": {
+						"points": 1
+					}
+				},
+				{
+					"id": "t9YufpTv3AxsWnWvx",
+					"name": "Perk (Weird Dreams CR@Self-control roll@)",
+					"reference": "DF14:14",
+					"reference_highlight": "Weird Dreams",
+					"local_notes": "Like [Nightmares](B144) you have unsettling dreams on a failed roll against @Self-control roll@, but they also include useful clues about today's activities. Lost FP can be paid from Energy Reserve (Psionic) or a psionic power item but won't recover without rest.",
+					"tags": [
+						"Mental",
+						"Perk"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Nightmares"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Unusual Background (Psionic)"
+								}
+							}
+						]
+					},
+					"base_points": 1,
+					"calc": {
+						"points": 1
+					}
+				}
+			],
+			"calc": {
+				"points": 8
+			}
+		},
+		{
+			"id": "TGseI9IykAzbtB-fp",
+			"name": "Mentalist Power-Ups",
+			"reference": "DF14:19",
+			"children": [
+				{
+					"id": "tqpmMxemwbsfvbFXN",
+					"name": "Acute ESP",
+					"reference": "DF14:19",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Psionics"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "script_prereq",
+								"script": "(self.level > Math.max(0,entity.traitLevel('Psi Talent'))) ? \"You do NOT have enough Psi Talent\" : \"\""
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Transdimensional Sight"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Remote Viewing"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Psychic Sensitivity"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Psight"
+								}
+							}
+						]
+					},
+					"points_per_level": 2,
+					"max_levels": "6",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "Perception rolled for information from (Psight, Psychic Sensitivity, or Transdimensional Sight) and Sense rolls during Remote Viewing.",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 2,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "tBvXhgZfCtT0jghfW",
+					"name": "Blind Viewing",
+					"reference": "DF14:19",
+					"local_notes": "Technique",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Psionics"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Remote Viewing"
+								}
+							}
+						]
+					},
+					"base_points": 6,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to counteract the penalty to use Remote Viewing to a place you can't see",
+							"amount": 5
+						}
+					],
+					"calc": {
+						"points": 6
+					}
+				},
+				{
+					"id": "Th2k3oGKa7-UkIe54",
+					"name": "Bonded Creature",
+					"reference": "DF14:20",
+					"reference_highlight": "Bonded Creature",
+					"local_notes": "Like a [familiar](DF5:20) but the link is psionic instead of magical. This still requires obtaining a creature and caring for it for 1d weeks until the bond forms.",
+					"container_type": "meta_trait",
+					"children": [
+						{
+							"id": "ttSv-XI59lXppUlRt",
+							"name": "Ally (@Who@)",
+							"reference": "B36,P41",
+							"local_notes": "<script>entity.exists ? `Ally Point Value: ${Math.floor(entity.points.total*.25)}` : \"\" </script>",
+							"tags": [
+								"Advantage",
+								"Social"
+							],
+							"modifiers": [
+								{
+									"id": "MCCHYNsxZFuMSYqSI",
+									"name": "Point Total",
+									"reference": "B37",
+									"children": [
+										{
+											"id": "mXyeW5BxAnu7_ecOZ",
+											"name": "25% of your starting points",
+											"reference": "B37",
+											"cost_adj": "1"
+										},
+										{
+											"id": "mQS400cerkdopBK9B",
+											"name": "50% of your starting points",
+											"reference": "B37",
+											"cost_adj": "2",
+											"disabled": true
+										},
+										{
+											"id": "me5j-UvffW_LCk0Tc",
+											"name": "75% of your starting points",
+											"reference": "B37",
+											"cost_adj": "3",
+											"disabled": true
+										},
+										{
+											"id": "mP4KyHkTKpP-88-sM",
+											"name": "100% of your starting points",
+											"reference": "B37",
+											"cost_adj": "5",
+											"disabled": true
+										},
+										{
+											"id": "mkOWjRgSdLB5UHS8z",
+											"name": "150% of your starting points",
+											"reference": "B37",
+											"cost_adj": "10",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "M2rQBqSZSjBagfVMh",
+									"name": "Ally Group",
+									"reference": "B37",
+									"children": [
+										{
+											"id": "mg6Q6anWPfao4crAl",
+											"name": "Group of 6-10",
+											"reference": "B37",
+											"cost_adj": "x6",
+											"disabled": true
+										},
+										{
+											"id": "m8koANlzAglK8Hs2c",
+											"name": "Group of 11-20",
+											"reference": "B37",
+											"cost_adj": "x8",
+											"disabled": true
+										},
+										{
+											"id": "mVDsK7f26MVFb0sOM",
+											"name": "Group of 21-50",
+											"reference": "B37",
+											"cost_adj": "x10",
+											"disabled": true
+										},
+										{
+											"id": "mLVaruZegDx4GUgJW",
+											"name": "Group of 51-100",
+											"reference": "B37",
+											"cost_adj": "x12",
+											"disabled": true
+										},
+										{
+											"id": "mYAHsiAW2g1xzIjla",
+											"name": "Group of 101-1000",
+											"reference": "B37",
+											"cost_adj": "x18",
+											"disabled": true
+										},
+										{
+											"id": "mWhJPiUbbfSrFFh50",
+											"name": "Group of 1001-10000",
+											"reference": "B37",
+											"cost_adj": "x24",
+											"disabled": true
+										},
+										{
+											"id": "mEHrgZ6XcdM_W7gMr",
+											"name": "Group of 10001-100000",
+											"reference": "B37",
+											"cost_adj": "x30",
+											"disabled": true
+										},
+										{
+											"id": "mEyj9Pn34fZVm1K0_",
+											"name": "Group of 100001-1000000",
+											"reference": "B37",
+											"cost_adj": "x36",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "M1BLd66AGIFMMmFrU",
+									"name": "Frequency of Appearance",
+									"reference": "B37",
+									"children": [
+										{
+											"id": "m7hu3MxG8Ga73Su9i",
+											"name": "Appears quite rarely (6-)",
+											"reference": "B36",
+											"cost_adj": "x0.5",
+											"disabled": true
+										},
+										{
+											"id": "mQf-fQxRl4czqRUJs",
+											"name": "Appears fairly often (9-)",
+											"reference": "B36",
+											"cost_adj": "x1",
+											"disabled": true
+										},
+										{
+											"id": "mOuLC1M2QbOwSxJs1",
+											"name": "Appears quite often (12-)",
+											"reference": "B36",
+											"cost_adj": "x2",
+											"disabled": true
+										},
+										{
+											"id": "mZyY0AK95ZnbAz18H",
+											"name": "Appears almost all the time (15-)",
+											"reference": "B36",
+											"cost_adj": "x3",
+											"disabled": true
+										},
+										{
+											"id": "mAjbIs3N0Izd_QfJJ",
+											"name": "Appears constantly",
+											"reference": "B36",
+											"cost_adj": "x4"
+										}
+									]
+								},
+								{
+									"id": "mUmDGQai230RF6d7x",
+									"name": "Minion",
+									"reference": "B38",
+									"local_notes": "IQ 0 or Slave Mentality",
+									"disabled": true
+								},
+								{
+									"id": "mRgnBIvZA4XHQdFM8",
+									"name": "Minion",
+									"reference": "B38",
+									"cost_adj": "50%",
+									"disabled": true
+								},
+								{
+									"id": "mG87S6mFjxvJhDYHp",
+									"name": "Special Abilities",
+									"reference": "B38",
+									"local_notes": "@Abilities@",
+									"cost_adj": "50%"
+								},
+								{
+									"id": "MhntRrTPhlQtZvvLA",
+									"name": "Summonable",
+									"children": [
+										{
+											"id": "maTGhp8YAB108TXId",
+											"name": "Summonable",
+											"reference": "B38,P41",
+											"cost_adj": "100%"
+										},
+										{
+											"id": "m0nWlr66n153tfkE5",
+											"name": "Conjured",
+											"reference": "DF9:4,P41",
+											"cost_adj": "100%",
+											"disabled": true
+										},
+										{
+											"id": "mCL0OxkMaqru4fCER",
+											"name": "Harder Summoning 1",
+											"reference": "DF9:4",
+											"cost_adj": "-5%",
+											"disabled": true
+										},
+										{
+											"id": "mAHis1aCB60geaxuX",
+											"name": "Harder Summoning 2",
+											"reference": "DF9:4",
+											"cost_adj": "-10%",
+											"disabled": true
+										},
+										{
+											"id": "mMPX-VCiDT-cIoMPR",
+											"name": "Harder Summoning 3",
+											"reference": "DF9:4",
+											"cost_adj": "-20%",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "MCtyp4BA_lKBaLee0",
+									"name": "Sympathy",
+									"reference": "B38",
+									"children": [
+										{
+											"id": "moYSUiOK1ZqpPcnoC",
+											"name": "Sympathy",
+											"reference": "B38",
+											"local_notes": "Death of one party reduces the other to 0 HP",
+											"cost_adj": "-25%"
+										},
+										{
+											"id": "mPGQGd_TRCkucewqI",
+											"name": "Sympathy",
+											"reference": "B38",
+											"local_notes": "Death of one party reduces the other to 0 HP and wounds affect ally but not you",
+											"cost_adj": "-5%",
+											"disabled": true
+										},
+										{
+											"id": "mpbX8NbQRY-W63QB9",
+											"name": "Sympathy",
+											"reference": "B38",
+											"local_notes": "Death of one party kills the other",
+											"cost_adj": "-50%",
+											"disabled": true
+										},
+										{
+											"id": "mLW0rfbXk6RrXtYpx",
+											"name": "Sympathy",
+											"reference": "B38",
+											"local_notes": "Death of one party kills the other and wounds affect ally but not you",
+											"cost_adj": "-10%",
+											"disabled": true
+										}
+									]
+								},
+								{
+									"id": "mXes291QI4dbdqQdO",
+									"name": "Unwilling",
+									"reference": "B38",
+									"cost_adj": "-50%",
+									"disabled": true
+								},
+								{
+									"id": "mugFur6u5b21nXXhd",
+									"name": "Favor",
+									"reference": "B55",
+									"cost_adj": "x0.2",
+									"disabled": true
+								}
+							],
+							"calc": {
+								"points": 9
+							}
+						},
+						{
+							"id": "t9GvIws-SiZrnGTiZ",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Powers/Powers Traits.adq",
+								"id": "trTYPvJ5UMzNNlDpd"
+							},
+							"name": "Energy Reserve (@Source@)",
+							"reference": "P119",
+							"tags": [
+								"Advantage",
+								"Attribute",
+								"Exotic",
+								"Physical"
+							],
+							"replacements": {
+								"Source": "Psionic"
+							},
+							"modifiers": [
+								{
+									"id": "mDjM0o1-cyrsN5XNC",
+									"name": "Abilities Only",
+									"reference": "P119",
+									"cost_adj": "-10%",
+									"disabled": true
+								},
+								{
+									"id": "mJhycVCGMlAT50HSp",
+									"name": "One Power",
+									"reference": "P119",
+									"cost_adj": "-50%",
+									"disabled": true
+								},
+								{
+									"id": "mD8jHdG667HHTkHSk",
+									"name": "Slow Recharge",
+									"reference": "P119",
+									"local_notes": "1/hour",
+									"cost_adj": "-20%",
+									"disabled": true
+								},
+								{
+									"id": "mfKsR_xLKQHKtzSpb",
+									"name": "Slow Recharge",
+									"reference": "P119",
+									"local_notes": "1/day",
+									"cost_adj": "-60%",
+									"disabled": true
+								},
+								{
+									"id": "mKnGvdCmtZ35ThEkA",
+									"name": "Special Recharge",
+									"reference": "P119",
+									"cost_adj": "-70%",
+									"disabled": true
+								},
+								{
+									"id": "maK-wA9IS-Lr22G70",
+									"name": "Special Recharge",
+									"reference": "P119",
+									"local_notes": "1/s bleed",
+									"cost_adj": "-80%",
+									"disabled": true
+								},
+								{
+									"id": "mdmnWcFiNTdxS2qaX",
+									"name": "Stunts Only",
+									"reference": "P119",
+									"cost_adj": "-10%",
+									"disabled": true
+								},
+								{
+									"id": "mDO-xHWVShB8kuwNc",
+									"name": "Drains Familiar",
+									"cost_adj": "-50%"
+								}
+							],
+							"points_per_level": 3,
+							"can_level": true,
+							"levels": 6,
+							"calc": {
+								"points": 9,
+								"current_level": 6
+							}
+						},
+						{
+							"id": "tLwjBOfehnJ9WCGdE",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy/Dungeon Fantasy 5/Familiars.adq",
+								"id": "t0ZElGf8SsLX7AX24"
+							},
+							"name": "Special Rapport (Familiar)",
+							"reference": "B88",
+							"tags": [
+								"Advantage",
+								"Mental",
+								"Supernatural"
+							],
+							"modifiers": [
+								{
+									"id": "mW4dq2mmFrGn_IDRF",
+									"name": "One Way",
+									"reference": "P77",
+									"cost_adj": "20%",
+									"disabled": true
+								},
+								{
+									"id": "mC5Sps2QSgMEd1RXi",
+									"name": "Transferable",
+									"reference": "P78",
+									"local_notes": "Own Race",
+									"cost_adj": "100%",
+									"disabled": true
+								},
+								{
+									"id": "m7iJcKCJT_eT9CBtV",
+									"name": "Transferable",
+									"reference": "P78",
+									"local_notes": "Living Being",
+									"cost_adj": "150%",
+									"disabled": true
+								},
+								{
+									"id": "mRgKiR8-AZpgOnbYu",
+									"name": "Transferable",
+									"reference": "P78",
+									"local_notes": "Digital Minds",
+									"cost_adj": "150%",
+									"disabled": true
+								},
+								{
+									"id": "mS1whniOibxYavDE7",
+									"name": "Transferable",
+									"reference": "P78",
+									"local_notes": "Any Sapient mind",
+									"cost_adj": "250%",
+									"disabled": true
+								},
+								{
+									"id": "mHv-Ut8IZMgVKs3UD",
+									"name": "Must be Willing or Helpless",
+									"reference": "P78",
+									"cost_adj": "-50%",
+									"disabled": true
+								}
+							],
+							"base_points": 5,
+							"calc": {
+								"points": 5
+							}
+						}
+					],
+					"calc": {
+						"points": 23
+					}
+				},
+				{
+					"id": "tTbrXtmW3JPV_TDeU",
+					"name": "Death Posession",
+					"reference": "DF15:20",
+					"local_notes": "Extra Life (Reincarnation, As defined in [Unkillable](B95), -20%)",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Psionics"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "script_prereq",
+								"script": "const msgtxt = []\nif (self.level > entity.traitLevel('Psi Talent')) { msgtxt.push(\"You do NOT have Enough Psi Talent!\"); } \nmsgtxt.join(\"\\n* \") "
+							}
+						]
+					},
+					"points_per_level": 20,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 20,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "TrQFNeiMv9-j6g4Yq",
+					"name": "Defense Stunts",
+					"reference": "DF14:20",
+					"reference_highlight": "Defense Stunts",
+					"children": [
+						{
+							"id": "tqyZyK5pFfR7kPuU7",
+							"name": "Extended Defense (@Ergokinetic Shield, Mind Shield, or Psychic Armor@)",
+							"reference": "DF14:21",
+							"reference_highlight": "Extended Defense",
+							"local_notes": "Whenever you extend your defense to protect others, ignore the -6 to the Will roll to do so.",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "@Ergokinetic Shield, Mind Shield, or Psychic Armor@"
+										}
+									}
+								]
+							},
+							"base_points": 7,
+							"calc": {
+								"points": 7
+							}
+						},
+						{
+							"id": "t_BH08AicGTlwrSPa",
+							"name": "Sudden Defense (@Ergokinetic Shield, Mind Shield, or Psychic Armor@)",
+							"reference": "DF14:21",
+							"local_notes": "Ignore the -4 penalty to the WIll roll to raise your defense in response to an attack. The defense still can't be used if it's part of an Alternative Abilities set with another ability that's active.",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "@Ergokinetic Shield, Mind Shield, or Psychic Armor@"
+										}
+									}
+								]
+							},
+							"base_points": 5,
+							"calc": {
+								"points": 5
+							}
+						}
+					],
+					"calc": {
+						"points": 12
+					}
+				},
+				{
+					"id": "t9lejxxS0ZhvzT_ea",
+					"name": "Elder Lore",
+					"reference": "DF14:21",
+					"local_notes": "Detect (Elder Artifacts)",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Psionics"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Psi Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
+					"modifiers": [
+						{
+							"id": "m0jBzuMsxHKiosqwE",
+							"name": "Analysis Only",
+							"reference": "PSI14",
+							"cost_adj": "-50%"
+						},
+						{
+							"id": "mKbgPiFNi45n4q3mU",
+							"name": "Analyzing",
+							"reference": "P47",
+							"local_notes": "Immediate Preparation Required, 1hr, -75%  PU8:14",
+							"cost_adj": "+25%"
+						}
+					],
+					"base_points": 10,
+					"calc": {
+						"points": 8
+					}
+				},
+				{
+					"id": "tN10exknYwlScmTNW",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Powers/Powers Traits.adq",
+						"id": "trTYPvJ5UMzNNlDpd"
+					},
+					"name": "Energy Reserve (@Source@)",
+					"reference": "P119",
+					"tags": [
+						"Advantage",
+						"Attribute",
+						"Exotic",
+						"Physical"
+					],
+					"replacements": {
+						"Source": "Psionic"
+					},
+					"modifiers": [
+						{
+							"id": "mR-R9Fw6jq_BAoTpt",
+							"name": "Abilities Only",
+							"reference": "P119",
+							"cost_adj": "-10%",
+							"disabled": true
+						},
+						{
+							"id": "m2iz-wHPNHVc4eYKC",
+							"name": "One Power",
+							"reference": "P119",
+							"cost_adj": "-50%",
+							"disabled": true
+						},
+						{
+							"id": "myOlPsGofZh4nUqY9",
+							"name": "Slow Recharge",
+							"reference": "P119",
+							"local_notes": "1/hour",
+							"cost_adj": "-20%",
+							"disabled": true
+						},
+						{
+							"id": "mO8xddQcF0mcpWLO9",
+							"name": "Slow Recharge",
+							"reference": "P119",
+							"local_notes": "1/day",
+							"cost_adj": "-60%",
+							"disabled": true
+						},
+						{
+							"id": "m-ienAdigos6maG6J",
+							"name": "Special Recharge",
+							"reference": "P119",
+							"cost_adj": "-70%",
+							"disabled": true
+						},
+						{
+							"id": "mXo12ndWCKNAdV-HE",
+							"name": "Special Recharge",
+							"reference": "P119",
+							"local_notes": "1/s bleed",
+							"cost_adj": "-80%",
+							"disabled": true
+						},
+						{
+							"id": "mHw5flG2L4UBXQkeo",
+							"name": "Stunts Only",
+							"reference": "P119",
+							"cost_adj": "-10%",
+							"disabled": true
+						}
+					],
+					"points_per_level": 3,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 3,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "t--FiDUVQ9O4LWLLi",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tpqxCsRu8W1w0NZPS"
+					},
+					"name": "Extraordinary Luck",
+					"reference": "B66",
+					"local_notes": "Usable once per 30 minutes of play",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"modifiers": [
+						{
+							"id": "mW1kllaHy6vWdkWXo",
+							"name": "Active",
+							"reference": "B66",
+							"cost_adj": "-40%",
+							"disabled": true
+						},
+						{
+							"id": "mw7XMl-1JwAtO1hHg",
+							"name": "Aspected",
+							"reference": "B66",
+							"local_notes": "@Aspect@",
+							"cost_adj": "-20%",
+							"disabled": true
+						},
+						{
+							"id": "mrsrl9gcwFjyoUTVp",
+							"name": "Defensive",
+							"reference": "B66",
+							"cost_adj": "-20%",
+							"disabled": true
+						},
+						{
+							"id": "mBR303tsMzxdmRSTw",
+							"name": "Wishing",
+							"reference": "P59",
+							"cost_adj": "100%",
+							"disabled": true
+						},
+						{
+							"id": "mImKdND9UiajfXHUs",
+							"name": "Game Time",
+							"reference": "P108",
+							"local_notes": "Uses per game day equal to its maximum possible uses per real hour",
+							"disabled": true
+						}
+					],
+					"base_points": 30,
+					"calc": {
+						"points": 30
+					}
+				},
+				{
+					"id": "tNHRFdMy-9bwHStcI",
+					"name": "Feature: Will has a cap of 25 before racial modifiers",
+					"reference": "DF14:19",
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tBbMmeSmTJyAfIoSJ",
+					"name": "Mass Chaos (@Fear, Madness, Mind Blast@)",
+					"reference": "DF14:21",
+					"local_notes": "Adds Area of Effect 1 to @Fear, Madness, Mind Blast@ for an extra 2 FP cost",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Psionics"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": false,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "@Fear, Madness, Mind Blast@"
+								}
+							}
+						]
+					},
+					"base_points": 7,
+					"calc": {
+						"points": 7
+					}
+				},
+				{
+					"id": "TMq1FvDBJ_JvGzqrm",
+					"name": "Mind-Reading Stunts",
+					"reference": "DF14:21",
+					"reference_highlight": "Mind-Reading Stunts",
+					"children": [
+						{
+							"id": "tx0nV3F_NtxpkaZzj",
+							"name": "Your Eyes Are My Eyes (Mind Reading)",
+							"reference": "DF14:21",
+							"reference_highlight": "Your Eyes Are My Eyes",
+							"local_notes": "You experience their senses as well as picking up surface thoughts. Costs an extra 2FP/minute to use.",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Mind Reading"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Psi Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
+							},
+							"base_points": 4,
+							"calc": {
+								"points": 4
+							}
+						},
+						{
+							"id": "tmvDFnmx9wPHw2Mv7",
+							"name": "Your Eyes Are My Eyes (Mind Meld)",
+							"reference": "DF14:21",
+							"reference_highlight": "Your Eyes Are My Eyes",
+							"local_notes": "You experience vivid replays of their senses as well as their thoughts. Costs an extra 2FP/minute to use.",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Mind Meld"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Psi Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									}
+								]
+							},
+							"base_points": 4,
+							"calc": {
+								"points": 4
+							}
+						},
+						{
+							"id": "tpbxjClBi6YskLI_5",
+							"name": "Your Tongue Is My Tongue (Mind Reading)",
+							"reference": "DF14:21",
+							"reference_highlight": "Your Tongue Is My Tongue",
+							"local_notes": "You can understand their thoughts without understanding their language. Even for Elder Things! Costs an extra 2FP/minute to use.",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Mind Reading"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Psi Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									}
+								]
+							},
+							"base_points": 7,
+							"calc": {
+								"points": 7
+							}
+						},
+						{
+							"id": "tgw0MCzUXbV_EtQ9s",
+							"name": "Your Tongue Is My Tongue (Mind Meld)",
+							"reference": "DF14:21",
+							"reference_highlight": "Your Tongue Is My Tongue",
+							"local_notes": "You can understand their thoughts without understanding their language. Even for Elder Things! Costs an extra 2FP/minute to use.",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Mind Meld"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Psi Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									}
+								]
+							},
+							"base_points": 7,
+							"calc": {
+								"points": 7
+							}
+						}
+					],
+					"calc": {
+						"points": 22
+					}
+				},
+				{
+					"id": "tuEne7lERZ_MrZz3N",
+					"name": "Psientist",
+					"reference": "DF14:21",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Psionics"
+					],
+					"points_per_level": 5,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Hidden Lore"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Elder Things"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Hidden Lore"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Psi"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Hypnotism"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Meditation"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Mental Strength"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Mind Block"
+							},
+							"amount": 1
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Psychology"
+							},
+							"amount": 1
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 5,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "tT4zYGXDC5Jgz7MiT",
+					"name": "Residue Sense",
+					"reference": "DF14:21",
+					"local_notes": "Psychic Sensitivity can detect psi activity in the past for an extra 2 FP cost",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Psionics"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Psychic Sensitivity"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Psychometry"
+								}
+							}
+						]
+					},
+					"base_points": 7,
+					"calc": {
+						"points": 7
+					}
+				},
+				{
+					"id": "tZUsFHndk_Zwi7vbP",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tzcAVOHp3Wd0BY361"
+					},
+					"name": "Ridiculous Luck",
+					"reference": "B66",
+					"local_notes": "Usable once per 10 minutes of play",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"modifiers": [
+						{
+							"id": "m45SeHmzND0OCulF5",
+							"name": "Active",
+							"reference": "B66",
+							"cost_adj": "-40%",
+							"disabled": true
+						},
+						{
+							"id": "mlf9cK-UZvUe-cyXZ",
+							"name": "Aspected",
+							"reference": "B66",
+							"local_notes": "@Aspect@",
+							"cost_adj": "-20%",
+							"disabled": true
+						},
+						{
+							"id": "mVoh7sjlXMuyh5k1S",
+							"name": "Defensive",
+							"reference": "B66",
+							"cost_adj": "-20%",
+							"disabled": true
+						},
+						{
+							"id": "mcEu4-o-bLQDiKf0u",
+							"name": "Wishing",
+							"reference": "P59",
+							"cost_adj": "100%",
+							"disabled": true
+						},
+						{
+							"id": "mnG8oKdzQShmJjhew",
+							"name": "Game Time",
+							"reference": "P108",
+							"local_notes": "Uses per game day equal to its maximum possible uses per real hour",
+							"disabled": true
+						}
+					],
+					"base_points": 60,
+					"calc": {
+						"points": 60
+					}
+				},
+				{
+					"id": "t0avOzBlHoCiam5X4",
+					"name": "Second Nature",
+					"reference": "DF14:21",
+					"local_notes": "Comparmentalized Mind",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Psionics"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "script_prereq",
+								"script": "const msgtxt = []\nif (self.level > 2) { msgtxt.push(\"Maximum Trait Level is 2!\"); }\nif (self.level > Math.max(0,entity.traitLevel('Psi Talent')) - 4) { msgtxt.push(\"You do NOT have Enough Psi Talent!\"); } \nmsgtxt.join(\"\\n* \") "
+							}
+						]
+					},
+					"modifiers": [
+						{
+							"id": "mLTRZfExAcio5uNli",
+							"name": "Limited (Psi)",
+							"cost_adj": "-10%"
+						}
+					],
+					"points_per_level": 50,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 45,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "tKXjYy0Pf6MuweKDh",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tkiJQ7nfyi9aAdGHK"
+					},
+					"name": "Serendipity",
+					"reference": "B83,P73",
+					"tags": [
+						"Advantage",
+						"Mental"
+					],
+					"modifiers": [
+						{
+							"id": "mKk9uaeO6wZSVHdcg",
+							"name": "Wishing",
+							"reference": "P73",
+							"cost_adj": "100%",
+							"disabled": true
+						},
+						{
+							"id": "m8lqGHRMQRtoiDGYH",
+							"name": "Wishing",
+							"reference": "P73",
+							"local_notes": "For others only",
+							"disabled": true
+						},
+						{
+							"id": "mprq2monzIYQas1U2",
+							"name": "Game Time",
+							"reference": "P108",
+							"local_notes": "Uses per game week equal to its maximum possible uses per session",
+							"disabled": true
+						}
+					],
+					"points_per_level": 15,
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 15,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "tsnFlxTlQC-C3sbFs",
+					"name": "Speed of Thought",
+					"reference": "DF14:22",
+					"local_notes": "Enhanced Time Sense",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Psionics"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Psi Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 5
+								}
+							}
+						]
+					},
+					"modifiers": [
+						{
+							"id": "mMeRALdcBy_-wFn4r",
+							"name": "Psionics Only",
+							"cost_adj": "-20%"
+						}
+					],
+					"base_points": 45,
+					"calc": {
+						"points": 36
+					}
+				},
+				{
+					"id": "tXdns1OQRlkOIHL9R",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tQ3xiqvixTRB9d7zT"
+					},
+					"name": "Talent (Smooth Operator)",
+					"reference": "B90,PU3:15",
+					"tags": [
+						"Advantage",
+						"Mental",
+						"Talent"
+					],
+					"modifiers": [
+						{
+							"id": "m8eFNHpzAyB-hyV9y",
+							"name": "Alternate Benefit",
+							"local_notes": "Bonus to resist covered skills",
+							"disabled": true
+						},
+						{
+							"id": "mnbFSSjy_QbtptHLE",
+							"name": "Alternative Cost",
+							"cost_adj": "-2",
+							"affects": "levels_only",
+							"disabled": true
+						}
+					],
+					"points_per_level": 15,
+					"features": [
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Acting"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Carousing"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Detect Lies"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Diplomacy"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Fast-Talk"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Intimidation"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Leadership"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Panhandling"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Politics"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Public Speaking"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Savoir-Faire"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Sex Appeal"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is",
+								"qualifier": "Streetwise"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "skill_bonus",
+							"selection_type": "skills_with_name",
+							"name": {
+								"compare": "is"
+							},
+							"amount": 1,
+							"per_level": true
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 15,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "TiOQiGTQ0lKePDWDT",
+					"name": "Telesend Stunts",
+					"reference": "DF14:22",
+					"reference_highlight": "Telesend Stunts",
+					"children": [
+						{
+							"id": "tvHIfKImVRVZxgXtK",
+							"name": "Coordinator",
+							"reference": "DF14:22",
+							"reference_highlight": "Coordinator",
+							"local_notes": "Send thoughts to as many people as you want, at the range penalty of the most-distant subject and an extra -4. Costs an extra 2 FP/minute.",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Psi Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 3
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Telesend"
+										}
+									}
+								]
+							},
+							"base_points": 9,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "to coordinated ambushes, and Advice, Encouragement and Observation from [Onward to Victory!](DF2:11) when using Telesend (Coordinator)",
+									"amount": 4
+								}
+							],
+							"calc": {
+								"points": 9
+							}
+						},
+						{
+							"id": "tes3x4R1e1moc9gqA",
+							"name": "Mr. Universe",
+							"reference": "DF14:22",
+							"reference_highlight": "Mr. Universe",
+							"local_notes": "Thoughts sent are understood by any sapient, regardless of language. costs an extra 2 FP/minute.",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Psi Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Telesend"
+										}
+									}
+								]
+							},
+							"base_points": 7,
+							"calc": {
+								"points": 7
+							}
+						},
+						{
+							"id": "tioRylRSutTn6ZGbX",
+							"name": "Spotter 1",
+							"reference": "DF14:22",
+							"reference_highlight": "Spotter",
+							"local_notes": "Share your vision with the subject. Spellcasters can use your vision to cast spells as if they can see the target, range penalties are unaffected.",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Telesend"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Psi Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 2
+										}
+									}
+								]
+							},
+							"base_points": 6,
+							"calc": {
+								"points": 6
+							}
+						},
+						{
+							"id": "tqwFsu_1D-uHBbzwu",
+							"name": "Spotter 2",
+							"reference": "DF14:22",
+							"reference_highlight": "Spotter",
+							"local_notes": "Share all of your senses with the subject. Spellcasters can use your vision to cast spells as if they can see the target, range penalties are unaffected.",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Telesend"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Psi Talent"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 4
+										}
+									}
+								]
+							},
+							"base_points": 10,
+							"calc": {
+								"points": 10
+							}
+						}
+					],
+					"calc": {
+						"points": 32
+					}
+				},
+				{
+					"id": "tON-_y6aueHM7rkGk",
+					"name": "True Will",
+					"reference": "DF14:22",
+					"local_notes": "Protected Power (Psionics)",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Psionics"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": true,
+								"name": {
+									"compare": "is",
+									"qualifier": "Psi Talent"
+								},
+								"level": {
+									"compare": "at_least",
+									"qualifier": 1
+								}
+							}
+						]
+					},
+					"base_points": 5,
+					"calc": {
+						"points": 5
+					}
+				}
+			],
+			"calc": {
+				"points": 353
 			}
 		}
 	]

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 14/Mentalist Lens.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 14/Mentalist Lens.gct
@@ -1,0 +1,1423 @@
+{
+	"version": 5,
+	"id": "Bv2e6tfbmk2ecT0By",
+	"traits": [
+		{
+			"id": "TYDRJv_Y_L8VzO8JZ",
+			"name": "Mentalist Lens",
+			"reference": "PY14:19",
+			"reference_highlight": "Mentalist Lens",
+			"children": [
+				{
+					"id": "TJ9Ms4u50K7g1XmqO",
+					"name": "Secondary Characteristics",
+					"container_type": "attributes",
+					"children": [
+						{
+							"id": "tATD9mdbjJceTn7Tu",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tsIfS0jZqdshsDFOM"
+							},
+							"name": "Extra Fatigue Points",
+							"reference": "B16",
+							"tags": [
+								"Advantage",
+								"Attribute",
+								"Physical"
+							],
+							"points_per_level": 3,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "fp",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 3,
+								"current_level": 1
+							}
+						},
+						{
+							"id": "tjPE_zJS24dIXLEwY",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tERWfEKV80M6toQn3"
+							},
+							"name": "Increased Will",
+							"reference": "B16",
+							"tags": [
+								"Advantage",
+								"Attribute",
+								"Mental"
+							],
+							"points_per_level": 5,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "will",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 1,
+							"calc": {
+								"points": 5,
+								"current_level": 1
+							}
+						}
+					],
+					"calc": {
+						"points": 8
+					}
+				},
+				{
+					"id": "tBTC7Dexnm50j59bF",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+						"id": "twYbceNKP5XRucfbL"
+					},
+					"name": "Psi Talent",
+					"reference": "DF14:4",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Psionics"
+					],
+					"points_per_level": 5,
+					"max_levels": "6",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to ALL rolls involving Psionic Abilities",
+							"amount": 1,
+							"per_level": true
+						}
+					],
+					"can_level": true,
+					"levels": 1,
+					"calc": {
+						"points": 5,
+						"current_level": 1
+					}
+				},
+				{
+					"id": "tHRUX7AjlCpaO4Eug",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+						"id": "tDw_0VbKuFabwn_Jd"
+					},
+					"name": "Unusual Background (Psionic)",
+					"reference": "DF14:14",
+					"tags": [
+						"Advantage",
+						"Exotic",
+						"Mental",
+						"Psionics"
+					],
+					"base_points": 10,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "TMYtbaxJkfYSTTGEf",
+					"name": "Special Abilities",
+					"local_notes": "25 Points total in Psionics abilities, Psi Perks, and the Skills (Hypnotism, Mental Strength, and Mind Block)",
+					"template_picker": {
+						"type": "points",
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": 25
+						}
+					},
+					"children": [
+						{
+							"id": "Tdh19-4uQhPRUBvxG",
+							"name": "Alternate Psionic Abilities",
+							"reference": "DF14:5",
+							"reference_highlight": "Alternate Abilities",
+							"local_notes": "<script> const msgtxt = [self.children];  msgtxt.join(\"\\n* \") </script>",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": true,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unusual Background (Psionic)"
+										}
+									},
+									{
+										"type": "script_prereq",
+										"script": "const msgtxt = []\nif (self.children.some(child => child.findActiveModifier(\"Psionic\") === null)) msgtxt.push(\"You have a Non-Psionic Trait\");\nmsgtxt.join(\"\\n* \")"
+									}
+								]
+							},
+							"container_type": "alternative_abilities",
+							"calc": {
+								"points": 0
+							}
+						},
+						{
+							"id": "TLIO2FOZ4JwMO4mT2",
+							"name": "Anti-Psi",
+							"children": [
+								{
+									"id": "t6DUDpxjypRQTZPBF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "t-N0coAK8BBi9cv-P"
+									},
+									"name": "Mind Shield",
+									"reference": "DF14:8",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "script_prereq",
+												"script": "(self.level > Math.max(0,entity.traitLevel('Psi Talent')) + 6) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Condition": "Psionic Only"
+									},
+									"modifiers": [
+										{
+											"id": "mkT2F08qQlaHGKLEs",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mgnE0aUbxsWB1HcqW",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+												"id": "m2IwCpU9KwYmjiSSA"
+											},
+											"name": "Accessibility (@Condition@)",
+											"reference": "B110,P99",
+											"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+											"cost_adj": "-1%",
+											"levels": 50,
+											"calc": {}
+										}
+									],
+									"points_per_level": 4,
+									"max_levels": "12",
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "Resisting Psionic abilities",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 2,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tBl2R--SQHTrHvSpT",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "t41dc1qjJpsTwmo9d"
+									},
+									"name": "Psychic Armor",
+									"reference": "DF14:9",
+									"local_notes": "Damage Resistance",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "script_prereq",
+												"script": "(self.level > Math.max(0,entity.traitLevel('Psi Talent')) + 6) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Very Common Attack Form": "Psionic"
+									},
+									"modifiers": [
+										{
+											"id": "mQLSu79AZTYpCKWMb",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mGOXvuSKUB3Y6aUqF",
+											"name": "Limited",
+											"reference": "B46",
+											"local_notes": "@Very Common Attack Form@",
+											"cost_adj": "-20%",
+											"calc": {
+												"resolved_notes": "Psionic"
+											}
+										}
+									],
+									"points_per_level": 5,
+									"max_levels": "12",
+									"features": [
+										{
+											"type": "dr_bonus",
+											"locations": [
+												"all"
+											],
+											"specialization": "Psionic",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 4,
+										"current_level": 1
+									}
+								}
+							],
+							"calc": {
+								"points": 6
+							}
+						},
+						{
+							"id": "TWU_ENEX8LZDD9pLd",
+							"name": "ESP",
+							"children": [
+								{
+									"id": "tlsUPipDu3BqfuSqJ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "t_csCNxhoc0R3rvRV"
+									},
+									"name": "Psychic Sensitivity 1",
+									"reference": "DF14:9",
+									"local_notes": "Detect (Psionic Abilities)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "m6yeKRCMrmAGP42mA",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										}
+									],
+									"base_points": 10,
+									"calc": {
+										"points": 9
+									}
+								},
+								{
+									"id": "tlGhpNHkRePMwgpS_",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "toxav4n5IJrsq39nB"
+									},
+									"name": "Psychometry 1",
+									"reference": "DF14:10",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "m_tJPSsLygRmg-x4T",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										}
+									],
+									"base_points": 20,
+									"calc": {
+										"points": 18
+									}
+								},
+								{
+									"id": "t7NKF1Mf6LI7whcCD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "t-Oo-7smxxcl8lLTF"
+									},
+									"name": "Transdimensional Sight",
+									"reference": "DF14:11",
+									"local_notes": "See Invisible (Extradimensional)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mMYBhLfTjdDdH0P0D",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "m60yixSZHpd_wIc8N",
+											"name": "Nuisance Effect (Eyes can be eaten)",
+											"reference": "B112,P104",
+											"cost_adj": "-5%"
+										}
+									],
+									"base_points": 15,
+									"calc": {
+										"points": 13
+									}
+								}
+							],
+							"calc": {
+								"points": 40
+							}
+						},
+						{
+							"id": "Tcv2tF0Rvxn7o4VGe",
+							"name": "Psychokinesis",
+							"children": [
+								{
+									"id": "tKKNytp_JzZDQHTjL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "tCCpZB2-HnrIJ6RWS"
+									},
+									"name": "Ergokinetic Shield",
+									"reference": "DF14:6",
+									"local_notes": "Damage Resistance",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "script_prereq",
+												"script": "(self.level > Math.max(0,entity.traitLevel('Psi Talent')) + 6) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+											}
+										]
+									},
+									"replacements": {
+										"Very Common Attack Form": "Energy"
+									},
+									"modifiers": [
+										{
+											"id": "mLk9JvTVmBYf-y-3h",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mWd_OkKHH7GQacffX",
+											"name": "Limited",
+											"reference": "B46",
+											"local_notes": "@Very Common Attack Form@",
+											"cost_adj": "-20%",
+											"calc": {
+												"resolved_notes": "Energy"
+											}
+										}
+									],
+									"points_per_level": 5,
+									"max_levels": "12",
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 4,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "t6WfFlbjjdcGHiPeM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "tGOGdAac3YsZzxbJ_"
+									},
+									"name": "Levitation 1",
+									"reference": "DF14:6",
+									"local_notes": "Flight",
+									"tags": [
+										"Exotic",
+										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Psi Talent"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mEYPfZyQBwUFPohBf",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "m2Cn2MhpjNyQ8YOIM",
+											"name": "Low Ceiling",
+											"reference": "B56",
+											"local_notes": "5'",
+											"cost_adj": "-25%"
+										},
+										{
+											"id": "mTdh-iuBTJUY8uMJD",
+											"name": "Slow, Move 1",
+											"reference": "PSI14",
+											"cost_adj": "-45%"
+										}
+									],
+									"base_points": 40,
+									"calc": {
+										"points": 8
+									}
+								},
+								{
+									"id": "tM5R5Q62jEvYWpk8G",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "tcWKoSMXzAFvYXAYU"
+									},
+									"name": "Psychokinetic Lash",
+									"reference": "DF14:10",
+									"local_notes": "Innate Attack (Crush)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "script_prereq",
+												"script": "(self.level > entity.traitLevel('Psi Talent')) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "mQBHVg2HY0PO3k_qG",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mkuRS4W7LBDBrXzVw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mBUqeaOCkjZbdZXTV"
+											},
+											"name": "Variable",
+											"reference": "B109,P107",
+											"cost_adj": "5%"
+										}
+									],
+									"points_per_level": 5,
+									"max_levels": "6",
+									"weapons": [
+										{
+											"id": "w0EtE1_hXkQjKfizF",
+											"sv": 1,
+											"damage": {
+												"type": "",
+												"base_leveled": "1d"
+											},
+											"usage": "Parry",
+											"parry": "0",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -4
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Innate Attack"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Gaze"
+													}
+												}
+											],
+											"calc": {
+												"damage": "1d per level"
+											}
+										},
+										{
+											"id": "W-jsP7S68-VlcHMjO",
+											"sv": 1,
+											"damage": {
+												"type": "cr",
+												"base_leveled": "1d"
+											},
+											"usage": "Lash",
+											"accuracy": "3",
+											"range": "10/100",
+											"rate_of_fire": "1",
+											"recoil": "1",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -4
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Innate Attack"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Gaze"
+													}
+												}
+											],
+											"calc": {
+												"damage": "1d per level  cr"
+											}
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 5,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "t0EvBKHhGsutjhHJR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "tUg36TbXQg2z4--p4"
+									},
+									"name": "Pyrokinetic Bolt",
+									"reference": "DF14:10",
+									"local_notes": "Innate Attack (Burn)",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "script_prereq",
+												"script": "(self.level > entity.traitLevel('Psi Talent')) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"modifiers": [
+										{
+											"id": "m9gLGMxdI8aW4WC_V",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mzKzjvFoTlaNB2RyB",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+												"id": "mBUqeaOCkjZbdZXTV"
+											},
+											"name": "Variable",
+											"reference": "B109,P107",
+											"cost_adj": "5%"
+										}
+									],
+									"points_per_level": 5,
+									"max_levels": "6",
+									"weapons": [
+										{
+											"id": "w1eP-bO-0MJNQOozP",
+											"sv": 1,
+											"damage": {
+												"type": "",
+												"base_leveled": "1d"
+											},
+											"usage": "Parry",
+											"parry": "0",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -4
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Innate Attack"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Gaze"
+													}
+												}
+											],
+											"calc": {
+												"damage": "1d per level"
+											}
+										},
+										{
+											"id": "WSYuSzImf0_7Z7ui1",
+											"sv": 1,
+											"damage": {
+												"type": "burn",
+												"base_leveled": "1d"
+											},
+											"usage": "Bolt",
+											"accuracy": "3",
+											"range": "10/100",
+											"rate_of_fire": "1",
+											"recoil": "1",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -4
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Innate Attack"
+													},
+													"specialization": {
+														"compare": "is",
+														"qualifier": "Gaze"
+													}
+												}
+											],
+											"calc": {
+												"damage": "1d per level  burn"
+											}
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 5,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tbfioOEX3ROCSwqbq",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "td7oozECEczwnPR-C"
+									},
+									"name": "Telekinesis",
+									"reference": "B92,P82,PSI17",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Force",
+										"Mental",
+										"Physical"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "script_prereq",
+												"script": "(self.level > Math.max(0,entity.traitLevel('Psi Talent')) + 10) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												},
+												"level": {
+													"compare": "at_least"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Disciplines of Faith or Major Vow": "Disciplines of Faith or Major Vow"
+									},
+									"modifiers": [
+										{
+											"id": "mKx-mix3NJqPRIdN6",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mZycSfil5iXFkv3Tt",
+											"name": "Cannot Affect Self",
+											"reference": "PSI17",
+											"cost_adj": "-20%"
+										}
+									],
+									"points_per_level": 5,
+									"max_levels": "16",
+									"weapons": [
+										{
+											"id": "w0IIa0_cjSJwWylmQ",
+											"sv": 1,
+											"damage": {
+												"type": "cr",
+												"st": "tk_thr"
+											},
+											"usage": "Grab",
+											"reach": "C,1-10",
+											"defaults": [
+												{
+													"type": "dx"
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Judo"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Sumo Wrestling"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Wrestling"
+													}
+												}
+											],
+											"calc": {
+												"damage": "telekinetic thr cr"
+											}
+										},
+										{
+											"id": "wJYs7Nt2kKmnr23DK",
+											"sv": 1,
+											"damage": {
+												"type": "cr",
+												"st": "tk_thr"
+											},
+											"usage": "Shove",
+											"usage_notes": "No Damage, Double Knockback",
+											"reach": "C,1-10",
+											"defaults": [
+												{
+													"type": "dx"
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Sumo Wrestling"
+													}
+												}
+											],
+											"calc": {
+												"damage": "telekinetic thr cr"
+											}
+										},
+										{
+											"id": "wmoHIH8g4MzTWgiiH",
+											"sv": 1,
+											"damage": {
+												"type": "cr",
+												"st": "tk_thr"
+											},
+											"usage": "Strike",
+											"reach": "C,1-10",
+											"parry": "0",
+											"defaults": [
+												{
+													"type": "dx"
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Boxing"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Brawling"
+													}
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Karate"
+													}
+												}
+											],
+											"calc": {
+												"damage": "telekinetic thr cr"
+											}
+										}
+									],
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "Skill use of High Manual Dexterity as per B92+",
+											"amount": 4
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 4,
+										"current_level": 1
+									}
+								}
+							],
+							"calc": {
+								"points": 26
+							}
+						},
+						{
+							"id": "TwZE1Dsdzo4AmXI8O",
+							"name": "Telepathy",
+							"children": [
+								{
+									"id": "t9diYVpj1pGAou-3a",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "tZkafJWp7VeDD-Szf"
+									},
+									"name": "Empathy",
+									"reference": "DF14:6",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Condition": "Not on Elder Things"
+									},
+									"modifiers": [
+										{
+											"id": "mxF2Ym5Y_wRbwTwGC",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mYbdXN-8497hFyySo",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+												"id": "m2IwCpU9KwYmjiSSA"
+											},
+											"name": "Accessibility (@Condition@)",
+											"reference": "B110,P99",
+											"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+											"cost_adj": "-1%",
+											"levels": 5,
+											"calc": {}
+										}
+									],
+									"base_points": 15,
+									"calc": {
+										"points": 13
+									}
+								},
+								{
+									"id": "tqXweG4HMLEoqfQRg",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "tePelkGSO0FP9l3Bz"
+									},
+									"name": "Intuition",
+									"reference": "DF14:6",
+									"tags": [
+										"Advantage",
+										"Exotic",
+										"Mental",
+										"Psionics"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											}
+										]
+									},
+									"replacements": {
+										"Condition": "Not places that have never had sentient visitors or a past"
+									},
+									"modifiers": [
+										{
+											"id": "mbF4F7OgneFtpNaAo",
+											"name": "Psionic",
+											"reference": "DF14:5",
+											"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+											"cost_adj": "-10%"
+										},
+										{
+											"id": "mZIkzxb6dygyhhIHU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+												"id": "m2IwCpU9KwYmjiSSA"
+											},
+											"name": "Accessibility (@Condition@)",
+											"reference": "B110,P99",
+											"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+											"cost_adj": "-1%",
+											"levels": 5,
+											"calc": {}
+										}
+									],
+									"base_points": 15,
+									"calc": {
+										"points": 13
+									}
+								}
+							],
+							"calc": {
+								"points": 26
+							}
+						}
+					],
+					"calc": {
+						"points": 98
+					}
+				}
+			],
+			"calc": {
+				"points": 121
+			}
+		}
+	],
+	"skills": [
+		{
+			"id": "SIT6dGeqakeeER1wG",
+			"name": "Mentalist Lens",
+			"reference": "DF14:19",
+			"reference_highlight": "Mentalist Lens",
+			"children": [
+				{
+					"id": "SqZr8tXZLpZ3NE5wH",
+					"name": "Special Abilities",
+					"local_notes": "25 Points total in Psionics abilities, Psi Perks, and the Skills (Hypnotism, Mental Strength, and Mind Block)",
+					"template_picker": {
+						"type": "points",
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": 25
+						}
+					},
+					"children": [
+						{
+							"id": "s6c7c_M7CTH582Ch6",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sm-zCRgqY_1QXowLd"
+							},
+							"name": "Hypnotism",
+							"reference": "B201",
+							"tags": [
+								"Medical"
+							],
+							"difficulty": "iq/h",
+							"points": 1
+						},
+						{
+							"id": "sdMhFFWImzDQNiBYm",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sxDgiqntG5jIWBGld"
+							},
+							"name": "Mental Strength",
+							"reference": "B209",
+							"tags": [
+								"Esoteric"
+							],
+							"difficulty": "will/e",
+							"prereqs": {
+								"type": "prereq_list",
+								"all": false,
+								"prereqs": [
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"notes": {
+											"compare": "contains",
+											"qualifier": "Permits Mental Strength"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Unusual Background (Psionic)"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "Magery"
+										},
+										"level": {
+											"compare": "at_least",
+											"qualifier": 1
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "starts_with",
+											"qualifier": "weapon master"
+										}
+									},
+									{
+										"type": "trait_prereq",
+										"has": true,
+										"name": {
+											"compare": "is",
+											"qualifier": "trained by a master"
+										}
+									}
+								]
+							},
+							"points": 1
+						},
+						{
+							"id": "sip4EPf7jM2FrX95G",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s_6AWhlyx4j6tK_OF"
+							},
+							"name": "Mind Block",
+							"reference": "B210",
+							"tags": [
+								"Esoteric"
+							],
+							"difficulty": "will/a",
+							"defaults": [
+								{
+									"type": "will",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Meditation"
+									},
+									"modifier": -5
+								}
+							],
+							"points": 1
+						}
+					]
+				},
+				{
+					"id": "SFA2nnKN4z50lA7GM",
+					"name": "Primary Skills",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "is",
+							"qualifier": 1
+						}
+					},
+					"children": [
+						{
+							"id": "s4LsRJ_G34IwzU0rE",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sIGnp4W_M8XBodpEH"
+							},
+							"name": "Hidden Lore",
+							"reference": "B199,MA57",
+							"tags": [
+								"Knowledge"
+							],
+							"replacements": {
+								"Subject": "Psi"
+							},
+							"specialization": "@Subject@",
+							"difficulty": "iq/a",
+							"points": 2
+						},
+						{
+							"id": "sPE724e7IqPIgeYSX",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sIGnp4W_M8XBodpEH"
+							},
+							"name": "Hidden Lore",
+							"reference": "B199,MA57",
+							"tags": [
+								"Knowledge"
+							],
+							"replacements": {
+								"Subject": "Elder Things"
+							},
+							"specialization": "@Subject@",
+							"difficulty": "iq/a",
+							"points": 2
+						},
+						{
+							"id": "S5zsWClaloruSXHec",
+							"name": "Both",
+							"children": [
+								{
+									"id": "sGoa0wuim5jIatB_R",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sIGnp4W_M8XBodpEH"
+									},
+									"name": "Hidden Lore",
+									"reference": "B199,MA57",
+									"tags": [
+										"Knowledge"
+									],
+									"replacements": {
+										"Subject": "Psi"
+									},
+									"specialization": "@Subject@",
+									"difficulty": "iq/a",
+									"points": 1
+								},
+								{
+									"id": "s9luTXPPs2GXtHuOg",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sIGnp4W_M8XBodpEH"
+									},
+									"name": "Hidden Lore",
+									"reference": "B199,MA57",
+									"tags": [
+										"Knowledge"
+									],
+									"replacements": {
+										"Subject": "Elder Things"
+									},
+									"specialization": "@Subject@",
+									"difficulty": "iq/a",
+									"points": 1
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 14/Mentalist.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 14/Mentalist.gct
@@ -9,9 +9,15 @@
 				{
 					"id": "TrBp63nig3UNaGwUG",
 					"name": "Attributes",
+					"container_type": "attributes",
 					"children": [
 						{
-							"id": "tJmojsjRcIll8jWtl",
+							"id": "tmv49PtswhiyB_9cC",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "thI3hK3riuknUwkHF"
+							},
 							"name": "Decreased Strength",
 							"reference": "B14",
 							"tags": [
@@ -36,7 +42,12 @@
 							}
 						},
 						{
-							"id": "t2CtDEOM4Nsp4P0X0",
+							"id": "tFB7wZwd_qTjREfaa",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tGWOSEE6SmBHACE6Y"
+							},
 							"name": "Increased Dexterity",
 							"reference": "B15",
 							"tags": [
@@ -46,7 +57,7 @@
 							],
 							"modifiers": [
 								{
-									"id": "msS6h8MdWvgcl-XLJ",
+									"id": "mapxz9iHjLJfWBEOf",
 									"name": "No Fine Manipulators",
 									"cost_adj": "-40%",
 									"disabled": true
@@ -69,32 +80,12 @@
 							}
 						},
 						{
-							"id": "tOCxYN5YulMQ43L2U",
-							"name": "Increased Intelligence",
-							"reference": "B15",
-							"tags": [
-								"Advantage",
-								"Attribute",
-								"Mental"
-							],
-							"points_per_level": 20,
-							"features": [
-								{
-									"type": "attribute_bonus",
-									"attribute": "iq",
-									"amount": 1,
-									"per_level": true
-								}
-							],
-							"can_level": true,
-							"levels": 4,
-							"calc": {
-								"points": 80,
-								"current_level": 4
-							}
-						},
-						{
-							"id": "ttJwp9ovMzSDoG8Pq",
+							"id": "taL-dYHQOUXsBowRn",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tVt3SvdGWNchJ8z4o"
+							},
 							"name": "Increased Health",
 							"reference": "B14",
 							"tags": [
@@ -117,6 +108,36 @@
 								"points": 20,
 								"current_level": 2
 							}
+						},
+						{
+							"id": "twELPgdJuUnT69o2X",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "t1w1RFcFceKR2T9_e"
+							},
+							"name": "Increased Intelligence",
+							"reference": "B15",
+							"tags": [
+								"Advantage",
+								"Attribute",
+								"Mental"
+							],
+							"points_per_level": 20,
+							"features": [
+								{
+									"type": "attribute_bonus",
+									"attribute": "iq",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"can_level": true,
+							"levels": 4,
+							"calc": {
+								"points": 80,
+								"current_level": 4
+							}
 						}
 					],
 					"calc": {
@@ -125,10 +146,16 @@
 				},
 				{
 					"id": "TvdSKWnCJVfpZvKms",
-					"name": "Secondary Attributes",
+					"name": "Secondary Characteristics",
+					"container_type": "attributes",
 					"children": [
 						{
-							"id": "tXYsCcARD9Z8uYr74",
+							"id": "tEGhNS1ooVFipyXLo",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tsIfS0jZqdshsDFOM"
+							},
 							"name": "Extra Fatigue Points",
 							"reference": "B16",
 							"tags": [
@@ -153,7 +180,12 @@
 							}
 						},
 						{
-							"id": "tV_10oIKeN8jmDD0x",
+							"id": "tDEBofApzL8CaDAAI",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Traits.adq",
+								"id": "tERWfEKV80M6toQn3"
+							},
 							"name": "Increased Will",
 							"reference": "B16",
 							"tags": [
@@ -187,7 +219,12 @@
 					"name": "Advantages",
 					"children": [
 						{
-							"id": "t76lJE6rvLKo7rDkN",
+							"id": "ttfVf9fAmdOEEDyKz",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+								"id": "twYbceNKP5XRucfbL"
+							},
 							"name": "Psi Talent",
 							"reference": "DF14:4",
 							"tags": [
@@ -197,14 +234,11 @@
 								"Psionics"
 							],
 							"points_per_level": 5,
+							"max_levels": "6",
 							"features": [
 								{
-									"type": "skill_bonus",
-									"selection_type": "skills_with_name",
-									"tags": {
-										"compare": "is",
-										"qualifier": "Psionics"
-									},
+									"type": "conditional_modifier",
+									"situation": "to ALL rolls involving Psionic Abilities",
 									"amount": 1,
 									"per_level": true
 								}
@@ -217,7 +251,12 @@
 							}
 						},
 						{
-							"id": "tiF2CxlYchPslKmiT",
+							"id": "t_IEMFr5_cO54_9cR",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+								"id": "tDw_0VbKuFabwn_Jd"
+							},
 							"name": "Unusual Background (Psionic)",
 							"reference": "DF14:14",
 							"tags": [
@@ -239,2956 +278,220 @@
 							],
 							"children": [
 								{
-									"id": "Ty7QVJyElm3e1Wz-h",
+									"id": "TZIkO7FS91ugk7hiM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "TOPmoEpxNVOENhuke"
+									},
 									"name": "Psionic Abilities",
+									"reference": "DF14:5",
 									"children": [
 										{
-											"id": "TDJ5swFE1gdabEel7",
-											"name": "Battlesense",
+											"id": "Ti7PinJbOHt1jm8Hr",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "TyOFku13Cni2U2XKj"
+											},
+											"name": "Alternate Psionic Abilities",
 											"reference": "DF14:5",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
-											"children": [
-												{
-													"id": "tR9kO5i36itvGGdoa",
-													"name": "Battlesense",
-													"reference": "DF14:5",
-													"local_notes": "When Active: +1 to active defense rolls against sentient foes; 1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Mind Reading"
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 2
-																}
-															}
-														]
-													},
-													"points_per_level": 24,
-													"features": [
-														{
-															"type": "attribute_bonus",
-															"attribute": "dodge",
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "attribute_bonus",
-															"attribute": "parry",
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "attribute_bonus",
-															"attribute": "block",
-															"amount": 1,
-															"per_level": true
+											"reference_highlight": "Alternate Abilities",
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Unusual Background (Psionic)"
 														}
-													],
-													"can_level": true,
-													"levels": 1,
-													"calc": {
-														"points": 24,
-														"current_level": 1
-													}
-												},
-												{
-													"id": "tt9J6zCFtLogWtY8L",
-													"name": "Battlesense",
-													"reference": "DF14:5",
-													"local_notes": "When Active: +2 to active defense rolls against sentient foes; 1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Mind Reading"
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 4
-																}
-															}
-														]
 													},
-													"points_per_level": 24,
-													"features": [
-														{
-															"type": "attribute_bonus",
-															"attribute": "dodge",
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "attribute_bonus",
-															"attribute": "parry",
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "attribute_bonus",
-															"attribute": "block",
-															"amount": 1,
-															"per_level": true
-														}
-													],
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 48,
-														"current_level": 2
+													{
+														"type": "script_prereq",
+														"script": "const msgtxt = []\nif (self.children.some(child => child.findActiveModifier(\"Psionic\") === null)) msgtxt.push(\"You have a Non-Psionic Trait\");\nmsgtxt.join(\"\\n* \")"
 													}
-												},
-												{
-													"id": "tdcm8CYOa-hG85Qun",
-													"name": "Battlesense",
-													"reference": "DF14:5",
-													"local_notes": "When Active: +3 to active defense rolls against sentient foes; 1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Mind Reading"
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 6
-																}
-															}
-														]
-													},
-													"points_per_level": 24,
-													"features": [
-														{
-															"type": "attribute_bonus",
-															"attribute": "dodge",
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "attribute_bonus",
-															"attribute": "parry",
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "attribute_bonus",
-															"attribute": "block",
-															"amount": 1,
-															"per_level": true
-														}
-													],
-													"can_level": true,
-													"levels": 3,
-													"calc": {
-														"points": 72,
-														"current_level": 3
-													}
-												}
-											],
+												]
+											},
+											"container_type": "alternative_abilities",
 											"calc": {
-												"points": 144
+												"points": 0
 											}
 										},
 										{
-											"id": "T1WHRM__wlwQ4KSDx",
-											"name": "Dispel Psi",
-											"reference": "DF14:5",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
+											"id": "T5rVxQqpjfVw_1Z_v",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "TlriqjaC9ObjC3vmw"
+											},
+											"name": "Anti-Psi",
 											"children": [
 												{
-													"id": "t_IsjTZn2kCyCRQ_4",
+													"id": "TU9HSG6AXih-LrlgI",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "T-FL0lMLmezBuBTk_"
+													},
 													"name": "Dispel Psi",
 													"reference": "DF14:5",
 													"tags": [
 														"Advantage",
-														"Exotic",
-														"Mental",
 														"Psionics"
 													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 2
-																}
+													"children": [
+														{
+															"id": "tIvwJOBx9QYXjjuZ8",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "twZLjdPOHrISMMWMr"
 															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"points_per_level": 20,
-													"can_level": true,
-													"levels": 1,
-													"calc": {
-														"points": 20,
-														"current_level": 1
-													}
-												},
-												{
-													"id": "tnoGT6Xs7XTVDR269",
-													"name": "Dispel Psi",
-													"reference": "DF14:5",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 4
-																}
+															"name": "Dispel Psi 1",
+															"reference": "DF14:5",
+															"local_notes": "Neutralize",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 2
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
 															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"points_per_level": 20,
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 40,
-														"current_level": 2
-													}
-												}
-											],
-											"calc": {
-												"points": 60
-											}
-										},
-										{
-											"id": "t69MQZtmavJ_IjSz-",
-											"name": "Empathy",
-											"reference": "DF14:6",
-											"local_notes": "Acts as Empathy (Accessibility, Not on Elder Things); 1 FP/use",
-											"tags": [
-												"Advantage",
-												"Exotic",
-												"Mental",
-												"Psionics"
-											],
-											"prereqs": {
-												"type": "prereq_list",
-												"all": true,
-												"prereqs": [
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Unusual Background (Psionic)"
-														}
-													}
-												]
-											},
-											"base_points": 13,
-											"calc": {
-												"points": 13
-											}
-										},
-										{
-											"id": "T1GspxaYIyrUqsm1l",
-											"name": "Ergokinetic Shield",
-											"reference": "DF14:6",
-											"children": [
-												{
-													"id": "tEdczV0UPrLJ85O4S",
-													"name": "Ergokinetic Shield",
-													"reference": "DF14:6",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
+															"modifiers": [
+																{
+																	"id": "mZiWzhSUFlgKP85jW",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
 																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
+																{
+																	"id": "mBjPByRFCYPaP-jeP",
+																	"name": "Interruption",
+																	"reference": "PSI16",
+																	"cost_adj": "-50%"
 																}
+															],
+															"base_points": 50,
+															"calc": {
+																"points": 20
 															}
-														]
-													},
-													"base_points": 1,
-													"points_per_level": 3,
-													"features": [
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"eye"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"skull"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"face"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"neck"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"torso"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"vitals"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"groin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"arm"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"hand"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"leg"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"foot"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"tail"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"wing"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"fin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"brain"
-															],
-															"amount": 1,
-															"per_level": true
-														}
-													],
-													"can_level": true,
-													"levels": 1,
-													"calc": {
-														"points": 4,
-														"current_level": 1
-													}
-												},
-												{
-													"id": "tfrP_X0SX-j9mKhvG",
-													"name": "Ergokinetic Shield",
-													"reference": "DF14:6",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															}
-														]
-													},
-													"base_points": 1,
-													"points_per_level": 3,
-													"features": [
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"eye"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"skull"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"face"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"neck"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"torso"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"vitals"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"groin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"arm"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"hand"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"leg"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"foot"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"tail"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"wing"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"fin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"brain"
-															],
-															"amount": 1,
-															"per_level": true
-														}
-													],
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 7,
-														"current_level": 2
-													}
-												},
-												{
-													"id": "tmUpAzejInyZgd3qQ",
-													"name": "Ergokinetic Shield",
-													"reference": "DF14:6",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 2
-																}
-															}
-														]
-													},
-													"base_points": 2,
-													"points_per_level": 3,
-													"features": [
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"eye"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"skull"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"face"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"neck"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"torso"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"vitals"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"groin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"arm"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"hand"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"leg"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"foot"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"tail"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"wing"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"fin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"brain"
-															],
-															"amount": 1,
-															"per_level": true
-														}
-													],
-													"can_level": true,
-													"levels": 3,
-													"calc": {
-														"points": 11,
-														"current_level": 3
-													}
-												},
-												{
-													"id": "tCYPeRsbV0slVft5E",
-													"name": "Ergokinetic Shield",
-													"reference": "DF14:6",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 2
-																}
-															}
-														]
-													},
-													"base_points": 2,
-													"points_per_level": 3,
-													"features": [
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"eye"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"skull"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"face"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"neck"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"torso"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"vitals"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"groin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"arm"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"hand"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"leg"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"foot"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"tail"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"wing"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"fin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"brain"
-															],
-															"amount": 1,
-															"per_level": true
-														}
-													],
-													"can_level": true,
-													"levels": 4,
-													"calc": {
-														"points": 14,
-														"current_level": 4
-													}
-												},
-												{
-													"id": "tm-tqTFfbdD6Kc3M2",
-													"name": "Ergokinetic Shield",
-													"reference": "DF14:6",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 3
-																}
-															}
-														]
-													},
-													"base_points": 3,
-													"points_per_level": 3,
-													"features": [
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"eye"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"skull"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"face"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"neck"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"torso"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"vitals"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"groin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"arm"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"hand"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"leg"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"foot"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"tail"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"wing"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"fin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"brain"
-															],
-															"amount": 1,
-															"per_level": true
-														}
-													],
-													"can_level": true,
-													"levels": 5,
-													"calc": {
-														"points": 18,
-														"current_level": 5
-													}
-												},
-												{
-													"id": "tEUFaoQXDXinBljFG",
-													"name": "Ergokinetic Shield",
-													"reference": "DF14:6",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 3
-																}
-															}
-														]
-													},
-													"base_points": 3,
-													"points_per_level": 3,
-													"features": [
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"eye"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"skull"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"face"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"neck"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"torso"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"vitals"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"groin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"arm"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"hand"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"leg"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"foot"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"tail"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"wing"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"fin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"brain"
-															],
-															"amount": 1,
-															"per_level": true
-														}
-													],
-													"can_level": true,
-													"levels": 6,
-													"calc": {
-														"points": 21,
-														"current_level": 6
-													}
-												},
-												{
-													"id": "tlvxG9zFoeeItGkfq",
-													"name": "Ergokinetic Shield",
-													"reference": "DF14:6",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 4
-																}
-															}
-														]
-													},
-													"base_points": 4,
-													"points_per_level": 3,
-													"features": [
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"eye"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"skull"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"face"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"neck"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"torso"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"vitals"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"groin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"arm"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"hand"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"leg"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"foot"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"tail"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"wing"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"fin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"brain"
-															],
-															"amount": 1,
-															"per_level": true
-														}
-													],
-													"can_level": true,
-													"levels": 7,
-													"calc": {
-														"points": 25,
-														"current_level": 7
-													}
-												},
-												{
-													"id": "t0n3C2zMJCd5avA5G",
-													"name": "Ergokinetic Shield",
-													"reference": "DF14:6",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 4
-																}
-															}
-														]
-													},
-													"base_points": 4,
-													"points_per_level": 3,
-													"features": [
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"eye"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"skull"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"face"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"neck"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"torso"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"vitals"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"groin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"arm"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"hand"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"leg"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"foot"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"tail"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"wing"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"fin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"brain"
-															],
-															"amount": 1,
-															"per_level": true
-														}
-													],
-													"can_level": true,
-													"levels": 8,
-													"calc": {
-														"points": 28,
-														"current_level": 8
-													}
-												},
-												{
-													"id": "txGceJCyW0uf9K9VW",
-													"name": "Ergokinetic Shield",
-													"reference": "DF14:6",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 5
-																}
-															}
-														]
-													},
-													"base_points": 5,
-													"points_per_level": 3,
-													"features": [
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"eye"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"skull"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"face"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"neck"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"torso"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"vitals"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"groin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"arm"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"hand"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"leg"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"foot"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"tail"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"wing"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"fin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"brain"
-															],
-															"amount": 1,
-															"per_level": true
-														}
-													],
-													"can_level": true,
-													"levels": 9,
-													"calc": {
-														"points": 32,
-														"current_level": 9
-													}
-												},
-												{
-													"id": "txXQemkuExcnHD3f7",
-													"name": "Ergokinetic Shield",
-													"reference": "DF14:6",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 5
-																}
-															}
-														]
-													},
-													"base_points": 5,
-													"points_per_level": 3,
-													"features": [
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"eye"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"skull"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"face"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"neck"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"torso"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"vitals"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"groin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"arm"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"hand"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"leg"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"foot"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"tail"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"wing"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"fin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"brain"
-															],
-															"amount": 1,
-															"per_level": true
-														}
-													],
-													"can_level": true,
-													"levels": 10,
-													"calc": {
-														"points": 35,
-														"current_level": 10
-													}
-												},
-												{
-													"id": "tJUvifjlCg6FuUMfX",
-													"name": "Ergokinetic Shield",
-													"reference": "DF14:6",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 6
-																}
-															}
-														]
-													},
-													"base_points": 6,
-													"points_per_level": 3,
-													"features": [
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"eye"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"skull"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"face"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"neck"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"torso"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"vitals"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"groin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"arm"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"hand"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"leg"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"foot"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"tail"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"wing"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"fin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"brain"
-															],
-															"amount": 1,
-															"per_level": true
-														}
-													],
-													"can_level": true,
-													"levels": 11,
-													"calc": {
-														"points": 39,
-														"current_level": 11
-													}
-												},
-												{
-													"id": "tN7x_zdzvzXJ2MwBV",
-													"name": "Ergokinetic Shield",
-													"reference": "DF14:6",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 6
-																}
-															}
-														]
-													},
-													"base_points": 6,
-													"points_per_level": 3,
-													"features": [
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"eye"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"skull"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"face"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"neck"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"torso"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"vitals"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"groin"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"arm"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"hand"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"leg"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"foot"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"tail"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"wing"
-															],
-															"amount": 1,
-															"per_level": true
-														},
-														{
-															"type": "dr_bonus",
-															"locations": [
-																"fin"
-															],
-															"amount": 1,
-															"per_level": true
 														},
 														{
-															"type": "dr_bonus",
-															"locations": [
-																"brain"
-															],
-															"amount": 1,
-															"per_level": true
-														}
-													],
-													"can_level": true,
-													"levels": 12,
-													"calc": {
-														"points": 42,
-														"current_level": 12
-													}
-												}
-											],
-											"calc": {
-												"points": 276
-											}
-										},
-										{
-											"id": "tbCLC6FtQGWajHOT5",
-											"name": "Fear",
-											"reference": "DF14:6",
-											"local_notes": "1 FP/attempt",
-											"tags": [
-												"Advantage",
-												"Exotic",
-												"Mental",
-												"Psionics"
-											],
-											"prereqs": {
-												"type": "prereq_list",
-												"all": true,
-												"prereqs": [
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Telesend"
-														}
-													}
-												]
-											},
-											"base_points": 27,
-											"calc": {
-												"points": 27
-											}
-										},
-										{
-											"id": "tx7M3TNABriUZmLeI",
-											"name": "Intuition",
-											"reference": "DF14:6",
-											"local_notes": "1 FP/use",
-											"tags": [
-												"Advantage",
-												"Exotic",
-												"Mental",
-												"Psionics"
-											],
-											"prereqs": {
-												"type": "prereq_list",
-												"all": true,
-												"prereqs": [
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Unusual Background (Psionic)"
-														}
-													}
-												]
-											},
-											"base_points": 13,
-											"calc": {
-												"points": 13
-											}
-										},
-										{
-											"id": "TcFS_DqWP4iEUeBUV",
-											"name": "Levitation",
-											"reference": "DF14:6",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
-											"children": [
-												{
-													"id": "tSqnE48vGCzAAU5Vh",
-													"name": "Levitation",
-													"reference": "DF14:6",
-													"local_notes": "Flight: Move 1, within 5' of horizontal surface",
-													"tags": [
-														"Exotic",
-														"Physical"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
+															"id": "tdmYRJmec1AmkvY_0",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tDpufqECai5-mcF06"
 															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 8,
-													"can_level": true,
-													"levels": 1,
-													"calc": {
-														"points": 8,
-														"current_level": 1
-													}
-												},
-												{
-													"id": "tDkW1uo2rkEhHcGZ8",
-													"name": "Levitation",
-													"reference": "DF14:6",
-													"local_notes": "Flight: Basic Move, within 10' of horizontal surface",
-													"tags": [
-														"Exotic",
-														"Physical"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 2
-																}
+															"name": "Dispel Psi 2",
+															"reference": "DF14:5",
+															"local_notes": "Neutralize",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 4
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
 															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 8,
-													"points_per_level": 10,
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 28,
-														"current_level": 2
-													}
-												},
-												{
-													"id": "tWJV8zA4PyMWEBHIW",
-													"name": "Levitation",
-													"reference": "DF14:6",
-													"local_notes": "Flight: 2xBasic Move, within 10' of horizontal surface",
-													"tags": [
-														"Exotic",
-														"Physical"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
+															"modifiers": [
+																{
+																	"id": "mW3lCcP_OjlEYON2S",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
 																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 2
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 8,
-													"points_per_level": 10,
-													"can_level": true,
-													"levels": 3,
-													"calc": {
-														"points": 38,
-														"current_level": 3
-													}
-												}
-											],
-											"calc": {
-												"points": 74
-											}
-										},
-										{
-											"id": "TxLdn9PIDIXIX4jzM",
-											"name": "Madness",
-											"reference": "DF14:7",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
-											"children": [
-												{
-													"id": "tXvWa_jW_iDuryByZ",
-													"name": "Madness",
-													"reference": "DF14:7",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Physical",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 23,
-													"points_per_level": 5,
-													"can_level": true,
-													"levels": 1,
-													"calc": {
-														"points": 28,
-														"current_level": 1
-													}
-												},
-												{
-													"id": "tD9m11-NCI2fWzw1y",
-													"name": "Madness",
-													"reference": "DF14:7",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
+																{
+																	"id": "mvAI5xk2MwlompCc6",
+																	"name": "Interruption",
+																	"reference": "PSI16",
+																	"cost_adj": "-50%"
 																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 2
+																{
+																	"id": "mZqi3rG0h2UdMKcax",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mlMYKfQnlVJoEWb5w"
+																	},
+																	"name": "Ranged",
+																	"reference": "B107,P105",
+																	"cost_adj": "40%"
 																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
+															],
+															"base_points": 50,
+															"calc": {
+																"points": 40
 															}
-														]
-													},
-													"base_points": 23,
-													"points_per_level": 5,
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 33,
-														"current_level": 2
-													}
-												},
-												{
-													"id": "tWJ_sn5YsYXaIhE9q",
-													"name": "Madness",
-													"reference": "DF14:7",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 4
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 23,
-													"points_per_level": 5,
-													"can_level": true,
-													"levels": 3,
-													"calc": {
-														"points": 38,
-														"current_level": 3
-													}
-												}
-											],
-											"calc": {
-												"points": 99
-											}
-										},
-										{
-											"id": "TSGEqpzIKlWsSoRxo",
-											"name": "Mind Blast",
-											"reference": "DF14:7",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
-											"children": [
-												{
-													"id": "t85HKBFh9d6__0c3d",
-													"name": "Mind Blast",
-													"reference": "DF14:7",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 24,
-													"points_per_level": 5,
-													"can_level": true,
-													"levels": 1,
-													"calc": {
-														"points": 29,
-														"current_level": 1
-													}
-												},
-												{
-													"id": "teGT6YgHLGI4QX6Ws",
-													"name": "Mind Blast",
-													"reference": "DF14:7",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 2
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 24,
-													"points_per_level": 5,
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 34,
-														"current_level": 2
-													}
-												},
-												{
-													"id": "tmpKaznuOaZ2hgidl",
-													"name": "Mind Blast",
-													"reference": "DF14:7",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 4
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 24,
-													"points_per_level": 5,
-													"can_level": true,
-													"levels": 3,
-													"calc": {
-														"points": 39,
-														"current_level": 3
-													}
-												}
-											],
-											"calc": {
-												"points": 102
-											}
-										},
-										{
-											"id": "Tzixv6uwXtPtrnBGm",
-											"name": "Mind Control",
-											"reference": "DF14:7",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
-											"children": [
-												{
-													"id": "tw8e3wHx0O9E3FH_8",
-													"name": "Mind Control",
-													"reference": "DF14:7",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 2
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Telesend"
-																}
-															}
-														]
-													},
-													"base_points": 15,
-													"points_per_level": 15,
-													"can_level": true,
-													"levels": 1,
-													"calc": {
-														"points": 30,
-														"current_level": 1
-													}
-												},
-												{
-													"id": "t7xhNg5g_7D9XI7-D",
-													"name": "Mind Control",
-													"reference": "DF14:7",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 4
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Telesend"
-																}
-															}
-														]
-													},
-													"base_points": 15,
-													"points_per_level": 15,
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 45,
-														"current_level": 2
-													}
-												}
-											],
-											"calc": {
-												"points": 75
-											}
-										},
-										{
-											"id": "tmphgW0QXjkpOciWv",
-											"name": "Mind Meld",
-											"reference": "DF14:8",
-											"local_notes": "1 FP/min",
-											"tags": [
-												"Advantage",
-												"Exotic",
-												"Mental",
-												"Psionics"
-											],
-											"prereqs": {
-												"type": "prereq_list",
-												"all": true,
-												"prereqs": [
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Unusual Background (Psionic)"
 														}
-													},
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Psi Talent"
-														},
-														"level": {
-															"compare": "at_least",
-															"qualifier": 2
-														}
+													],
+													"calc": {
+														"points": 60
 													}
-												]
-											},
-											"base_points": 12,
-											"calc": {
-												"points": 12
-											}
-										},
-										{
-											"id": "t4_YMoYdYnlI-jbDT",
-											"name": "Mind Reading",
-											"reference": "DF14:8",
-											"local_notes": "1 FP/use",
-											"tags": [
-												"Advantage",
-												"Exotic",
-												"Mental",
-												"Psionics"
-											],
-											"prereqs": {
-												"type": "prereq_list",
-												"all": true,
-												"prereqs": [
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Unusual Background (Psionic)"
-														}
-													}
-												]
-											},
-											"base_points": 27,
-											"calc": {
-												"points": 27
-											}
-										},
-										{
-											"id": "T4WAhl8L9Sc9f85DV",
-											"name": "Mind Shield",
-											"reference": "DF14:8",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
-											"children": [
+												},
 												{
-													"id": "t03mhqAqnYPI0oba_",
+													"id": "tR5b0KQD__MngSphV",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "t-N0coAK8BBi9cv-P"
+													},
 													"name": "Mind Shield",
 													"reference": "DF14:8",
-													"local_notes": "1 FP/min",
 													"tags": [
 														"Advantage",
 														"Exotic",
@@ -3200,6 +503,10 @@
 														"all": true,
 														"prereqs": [
 															{
+																"type": "script_prereq",
+																"script": "(self.level > Math.max(0,entity.traitLevel('Psi Talent')) + 6) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+															},
+															{
 																"type": "trait_prereq",
 																"has": true,
 																"name": {
@@ -3209,7 +516,42 @@
 															}
 														]
 													},
-													"points_per_level": 2,
+													"replacements": {
+														"Condition": "Psionic Only"
+													},
+													"modifiers": [
+														{
+															"id": "mq0uoWoaD2AdyWQDh",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
+														},
+														{
+															"id": "mFs26WwDXmJPBZVX9",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+																"id": "m2IwCpU9KwYmjiSSA"
+															},
+															"name": "Accessibility (@Condition@)",
+															"reference": "B110,P99",
+															"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+															"cost_adj": "-1%",
+															"levels": 50,
+															"calc": {}
+														}
+													],
+													"points_per_level": 4,
+													"max_levels": "12",
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Resisting Psionic abilities",
+															"amount": 1,
+															"per_level": true
+														}
+													],
 													"can_level": true,
 													"levels": 1,
 													"calc": {
@@ -3218,469 +560,15 @@
 													}
 												},
 												{
-													"id": "tF9i8TNaMyga2s6X0",
-													"name": "Mind Shield",
-													"reference": "DF14:8",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
+													"id": "tJH_fUc9VHkpMzuen",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "t41dc1qjJpsTwmo9d"
 													},
-													"points_per_level": 2,
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 4,
-														"current_level": 2
-													}
-												},
-												{
-													"id": "tLTpzc60yxaUw2e3D",
-													"name": "Mind Shield",
-													"reference": "DF14:8",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -1,
-													"points_per_level": 2,
-													"can_level": true,
-													"levels": 3,
-													"calc": {
-														"points": 5,
-														"current_level": 3
-													}
-												},
-												{
-													"id": "tUJIf829uGWV06okc",
-													"name": "Mind Shield",
-													"reference": "DF14:8",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -1,
-													"points_per_level": 2,
-													"can_level": true,
-													"levels": 4,
-													"calc": {
-														"points": 7,
-														"current_level": 4
-													}
-												},
-												{
-													"id": "tOulPO42Rg-dgVGNE",
-													"name": "Mind Shield",
-													"reference": "DF14:8",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -2,
-													"points_per_level": 2,
-													"can_level": true,
-													"levels": 5,
-													"calc": {
-														"points": 8,
-														"current_level": 5
-													}
-												},
-												{
-													"id": "tv6mcjPm5F6iSJgSR",
-													"name": "Mind Shield",
-													"reference": "DF14:8",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -2,
-													"points_per_level": 2,
-													"can_level": true,
-													"levels": 6,
-													"calc": {
-														"points": 10,
-														"current_level": 6
-													}
-												},
-												{
-													"id": "tBMQ_RQSTNA3Fnd5N",
-													"name": "Mind Shield",
-													"reference": "DF14:8",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -2,
-													"points_per_level": 2,
-													"can_level": true,
-													"levels": 7,
-													"calc": {
-														"points": 12,
-														"current_level": 7
-													}
-												},
-												{
-													"id": "tv4gAKBXigxaGLzX4",
-													"name": "Mind Shield",
-													"reference": "DF14:8",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 2
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -3,
-													"points_per_level": 2,
-													"can_level": true,
-													"levels": 8,
-													"calc": {
-														"points": 13,
-														"current_level": 8
-													}
-												},
-												{
-													"id": "tQh4EKiADEphrUshJ",
-													"name": "Mind Shield",
-													"reference": "DF14:8",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 3
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -3,
-													"points_per_level": 2,
-													"can_level": true,
-													"levels": 9,
-													"calc": {
-														"points": 15,
-														"current_level": 9
-													}
-												},
-												{
-													"id": "tf1CD5JrkqH-mvqTU",
-													"name": "Mind Shield",
-													"reference": "DF14:8",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 4
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -4,
-													"points_per_level": 2,
-													"can_level": true,
-													"levels": 10,
-													"calc": {
-														"points": 16,
-														"current_level": 10
-													}
-												},
-												{
-													"id": "tOvlBrBSwz4usuFaa",
-													"name": "Mind Shield",
-													"reference": "DF14:8",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 5
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -4,
-													"points_per_level": 2,
-													"can_level": true,
-													"levels": 11,
-													"calc": {
-														"points": 18,
-														"current_level": 11
-													}
-												},
-												{
-													"id": "teDsmlc2ENLBfGTcp",
-													"name": "Mind Shield",
-													"reference": "DF14:8",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 6
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -4,
-													"points_per_level": 2,
-													"can_level": true,
-													"levels": 12,
-													"calc": {
-														"points": 20,
-														"current_level": 12
-													}
-												}
-											],
-											"calc": {
-												"points": 130
-											}
-										},
-										{
-											"id": "TuY0Jfx9CROdGDqVX",
-											"name": "Mind Stab",
-											"reference": "DF14:9",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
-											"children": [
-												{
-													"id": "tJn0ZIy5YIWmf7f5h",
-													"name": "Mind Stab",
+													"name": "Psychic Armor",
 													"reference": "DF14:9",
-													"local_notes": "1 FP/use",
+													"local_notes": "Damage Resistance",
 													"tags": [
 														"Advantage",
 														"Exotic",
@@ -3692,177 +580,85 @@
 														"all": true,
 														"prereqs": [
 															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 2
-																}
+																"type": "script_prereq",
+																"script": "(self.level > Math.max(0,entity.traitLevel('Psi Talent')) + 6) ? \"You do NOT have Enough Psi Talent!\" : \"\""
 															},
 															{
 																"type": "trait_prereq",
 																"has": true,
 																"name": {
 																	"compare": "is",
-																	"qualifier": "Telesend"
+																	"qualifier": "Unusual Background (Psionic)"
 																}
 															}
 														]
 													},
-													"base_points": 30,
-													"points_per_level": 16,
+													"replacements": {
+														"Very Common Attack Form": "Psionic"
+													},
+													"modifiers": [
+														{
+															"id": "mTQbmCVOWnjtD4ao6",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
+														},
+														{
+															"id": "m9Nj4NW0kePrgaQNe",
+															"name": "Limited",
+															"reference": "B46",
+															"local_notes": "@Very Common Attack Form@",
+															"cost_adj": "-20%",
+															"calc": {
+																"resolved_notes": "Psionic"
+															}
+														}
+													],
+													"points_per_level": 5,
+													"max_levels": "12",
+													"features": [
+														{
+															"type": "dr_bonus",
+															"locations": [
+																"all"
+															],
+															"specialization": "Psionic",
+															"amount": 1,
+															"per_level": true
+														}
+													],
 													"can_level": true,
 													"levels": 1,
 													"calc": {
-														"points": 46,
+														"points": 4,
 														"current_level": 1
-													}
-												},
-												{
-													"id": "tpWuph1Ze_v3kSiMA",
-													"name": "Mind Stab",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 4
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Telesend"
-																}
-															}
-														]
-													},
-													"base_points": 30,
-													"points_per_level": 16,
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 62,
-														"current_level": 2
-													}
-												},
-												{
-													"id": "txRxSWW3hVGXx2fZx",
-													"name": "Mind Stab",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 6
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Telesend"
-																}
-															}
-														]
-													},
-													"base_points": 30,
-													"points_per_level": 16,
-													"can_level": true,
-													"levels": 3,
-													"calc": {
-														"points": 78,
-														"current_level": 3
 													}
 												}
 											],
 											"calc": {
-												"points": 186
+												"points": 66
 											}
 										},
 										{
-											"id": "t5IuCkifYgpC-5i8N",
-											"name": "Psight",
-											"reference": "DF14:9",
-											"local_notes": "1 FP/min",
-											"tags": [
-												"Advantage",
-												"Exotic",
-												"Mental",
-												"Psionics"
-											],
-											"prereqs": {
-												"type": "prereq_list",
-												"all": true,
-												"prereqs": [
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Unusual Background (Psionic)"
-														}
-													}
-												]
+											"id": "ThzyCEKP9J7wIvKxm",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "Tyvd1CFrO8eJUnPo2"
 											},
-											"base_points": 36,
-											"calc": {
-												"points": 36
-											}
-										},
-										{
-											"id": "TVdky7d6vD0zYwb5I",
-											"name": "Psychic Armor",
-											"reference": "DF14:9",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
+											"name": "ESP",
 											"children": [
 												{
-													"id": "trLIa9TUlUqRlG98H",
-													"name": "Psychic Armor",
+													"id": "t72l7N_GZpKyAgWBu",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tAIl6UZXIwIKyejVd"
+													},
+													"name": "Psight",
 													"reference": "DF14:9",
-													"local_notes": "1 FP/min",
+													"local_notes": "Scanning Sense (Para-Radar)",
 													"tags": [
 														"Advantage",
 														"Exotic",
@@ -3883,8 +679,709 @@
 															}
 														]
 													},
-													"base_points": 1,
-													"points_per_level": 3,
+													"modifiers": [
+														{
+															"id": "mYIN6tjOLcxdSlsTI",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
+														}
+													],
+													"base_points": 40,
+													"calc": {
+														"points": 36
+													}
+												},
+												{
+													"id": "TQaNVHOQ3tvRl0nqf",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "TtkLgm-_FUKjSB5MM"
+													},
+													"name": "Psychic Sensitivity",
+													"reference": "DF14:9",
+													"tags": [
+														"Advantage",
+														"Psionics"
+													],
+													"children": [
+														{
+															"id": "txRXaXgQhdBlBQaq9",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "t_csCNxhoc0R3rvRV"
+															},
+															"name": "Psychic Sensitivity 1",
+															"reference": "DF14:9",
+															"local_notes": "Detect (Psionic Abilities)",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"modifiers": [
+																{
+																	"id": "mn1YLC4761bmxtx3E",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																}
+															],
+															"base_points": 10,
+															"calc": {
+																"points": 9
+															}
+														},
+														{
+															"id": "tua5yarz8zCthJUAZ",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tkBFqf6kj84xQjvHe"
+															},
+															"name": "Psychic Sensitivity 2",
+															"reference": "DF14:9",
+															"local_notes": "Detect (Psionics Abilities and Beings)",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 2
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"modifiers": [
+																{
+																	"id": "mYZWwgp0Gcp284YJ2",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																}
+															],
+															"base_points": 20,
+															"calc": {
+																"points": 18
+															}
+														},
+														{
+															"id": "tQmjBnyCwaXlAfyAu",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "t1rPlPMEFO-M8KRuy"
+															},
+															"name": "Psychic Sensitivity 3",
+															"reference": "DF14:9",
+															"local_notes": "Detect (All Psi related phenomena)",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 4
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"modifiers": [
+																{
+																	"id": "mAmOAcDp1eRkI2MlF",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																}
+															],
+															"base_points": 30,
+															"calc": {
+																"points": 27
+															}
+														}
+													],
+													"calc": {
+														"points": 54
+													}
+												},
+												{
+													"id": "TwXd4j7ag_es1fd_O",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "TXjINaGQQRyibII2n"
+													},
+													"name": "Psychometry",
+													"reference": "DF14:10",
+													"tags": [
+														"Advantage",
+														"Psionics"
+													],
+													"children": [
+														{
+															"id": "tvEsf96xSVFUd0QaK",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "toxav4n5IJrsq39nB"
+															},
+															"name": "Psychometry 1",
+															"reference": "DF14:10",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"modifiers": [
+																{
+																	"id": "mSnMjouU_Jo-tZzkc",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																}
+															],
+															"base_points": 20,
+															"calc": {
+																"points": 18
+															}
+														},
+														{
+															"id": "tZKzauGv0Lru1zIGS",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tugXU5K_ir3eOXLRk"
+															},
+															"name": "Psychometry 2",
+															"reference": "DF14:10",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 2
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"modifiers": [
+																{
+																	"id": "mnP4kmQuSxQtc6VKi",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "mWc1KbR8txqfSV0d9",
+																	"name": "Visions",
+																	"reference": "PSI17",
+																	"cost_adj": "50%"
+																}
+															],
+															"base_points": 20,
+															"calc": {
+																"points": 28
+															}
+														},
+														{
+															"id": "tcZNNM0_IMdKixB3M",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tdmgzderARDkvroCE"
+															},
+															"name": "Psychometry 3",
+															"reference": "DF14:10",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 4
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"modifiers": [
+																{
+																	"id": "mByuGfg-RbM2fM37k",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "mXps9GHWb4vx0C0KW",
+																	"name": "Immersive",
+																	"reference": "P69",
+																	"cost_adj": "100%"
+																}
+															],
+															"base_points": 20,
+															"calc": {
+																"points": 38
+															}
+														}
+													],
+													"calc": {
+														"points": 84
+													}
+												},
+												{
+													"id": "T6XGnpEALe8IhnsOM",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "TpcfzVnz3ITGKt5xv"
+													},
+													"name": "Remote Viewing",
+													"reference": "DF14:10",
+													"tags": [
+														"Advantage",
+														"Psionics"
+													],
+													"children": [
+														{
+															"id": "tq6mOJllNkbgLfSfd",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "twBbzT_AzQLGjA4Za"
+															},
+															"name": "Remote Viewing 1",
+															"reference": "DF14:10",
+															"local_notes": "Clairsentance",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 1
+																		}
+																	}
+																]
+															},
+															"modifiers": [
+																{
+																	"id": "mAoaMCZ1i4ffYJA4x",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "meCMdZw_iV_DQhdRu",
+																	"name": "Clairvoyance",
+																	"cost_adj": "-10%"
+																}
+															],
+															"base_points": 50,
+															"calc": {
+																"points": 40
+															}
+														},
+														{
+															"id": "t2371wiJTJR869rX1",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "t7hTC8Ps78kc_MsJO"
+															},
+															"name": "Remote Viewing 2",
+															"reference": "DF14:10",
+															"local_notes": "Clairsentance",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 1
+																		}
+																	}
+																]
+															},
+															"modifiers": [
+																{
+																	"id": "m6FthvX_hTK-VjLCU",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																}
+															],
+															"base_points": 50,
+															"calc": {
+																"points": 45
+															}
+														},
+														{
+															"id": "t44_G0xP2w8bf8tVZ",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tIXRibv7FHGkf-2qh"
+															},
+															"name": "Remote Viewing 3",
+															"reference": "DF14:10",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "prereq_list",
+																		"all": false,
+																		"prereqs": [
+																			{
+																				"type": "trait_prereq",
+																				"has": true,
+																				"name": {
+																					"compare": "is",
+																					"qualifier": "psi talent"
+																				},
+																				"level": {
+																					"compare": "at_least",
+																					"qualifier": 1
+																				}
+																			},
+																			{
+																				"type": "trait_prereq",
+																				"has": true,
+																				"name": {
+																					"compare": "is",
+																					"qualifier": "psight"
+																				}
+																			}
+																		]
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"modifiers": [
+																{
+																	"id": "mvtcm6jcTPloYxLFW",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "mQCZhLlP7F0-8ey52",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mIgewYjuzmPvs7Jx9"
+																	},
+																	"name": "2x Increased Range",
+																	"reference": "B106",
+																	"cost_adj": "10%"
+																}
+															],
+															"base_points": 50,
+															"calc": {
+																"points": 50
+															}
+														}
+													],
+													"calc": {
+														"points": 135
+													}
+												},
+												{
+													"id": "tgEpfFlhC1eisolmr",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "t-Oo-7smxxcl8lLTF"
+													},
+													"name": "Transdimensional Sight",
+													"reference": "DF14:11",
+													"local_notes": "See Invisible (Extradimensional)",
+													"tags": [
+														"Advantage",
+														"Exotic",
+														"Mental",
+														"Psionics"
+													],
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Unusual Background (Psionic)"
+																}
+															}
+														]
+													},
+													"modifiers": [
+														{
+															"id": "mxAFO1a-ZQy8ibM1P",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
+														},
+														{
+															"id": "mwiR2Ka9Jcm3jyWTB",
+															"name": "Nuisance Effect (Eyes can be eaten)",
+															"reference": "B112,P104",
+															"cost_adj": "-5%"
+														}
+													],
+													"base_points": 15,
+													"calc": {
+														"points": 13
+													}
+												}
+											],
+											"calc": {
+												"points": 322
+											}
+										},
+										{
+											"id": "TxQHR3rDhH3LPkqCF",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "TWHvefnnTO1syG-4A"
+											},
+											"name": "Psychokinesis",
+											"children": [
+												{
+													"id": "tXMKcwNuNUb28eP_q",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tCCpZB2-HnrIJ6RWS"
+													},
+													"name": "Ergokinetic Shield",
+													"reference": "DF14:6",
+													"local_notes": "Damage Resistance",
+													"tags": [
+														"Advantage",
+														"Exotic",
+														"Mental",
+														"Psionics"
+													],
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "script_prereq",
+																"script": "(self.level > Math.max(0,entity.traitLevel('Psi Talent')) + 6) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+															}
+														]
+													},
+													"replacements": {
+														"Very Common Attack Form": "Energy"
+													},
+													"modifiers": [
+														{
+															"id": "mPVNW6xkoou13tD5c",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
+														},
+														{
+															"id": "mfFImBPeHpAuTx_X8",
+															"name": "Limited",
+															"reference": "B46",
+															"local_notes": "@Very Common Attack Form@",
+															"cost_adj": "-20%",
+															"calc": {
+																"resolved_notes": "Energy"
+															}
+														}
+													],
+													"points_per_level": 5,
+													"max_levels": "12",
 													"can_level": true,
 													"levels": 1,
 													"calc": {
@@ -3893,671 +1390,334 @@
 													}
 												},
 												{
-													"id": "tZAADlNz6bm3kRKGO",
-													"name": "Psychic Armor",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/min",
+													"id": "TvrB18xixzUJqQmJU",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "TmZJd5sZeVYMZohCC"
+													},
+													"name": "Levitation",
+													"reference": "DF14:6",
 													"tags": [
 														"Advantage",
-														"Exotic",
-														"Mental",
 														"Psionics"
 													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 1,
-													"points_per_level": 3,
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 7,
-														"current_level": 2
-													}
-												},
-												{
-													"id": "tLzeES1vRJ7eQrrcN",
-													"name": "Psychic Armor",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 2,
-													"points_per_level": 3,
-													"can_level": true,
-													"levels": 3,
-													"calc": {
-														"points": 11,
-														"current_level": 3
-													}
-												},
-												{
-													"id": "tzNtEmz9vOecmIx7G",
-													"name": "Psychic Armor",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 2,
-													"points_per_level": 3,
-													"can_level": true,
-													"levels": 4,
-													"calc": {
-														"points": 14,
-														"current_level": 4
-													}
-												},
-												{
-													"id": "tKV1ORkmSyW3aU2QN",
-													"name": "Psychic Armor",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 3,
-													"points_per_level": 3,
-													"can_level": true,
-													"levels": 5,
-													"calc": {
-														"points": 18,
-														"current_level": 5
-													}
-												},
-												{
-													"id": "txig3HvGniTY6IcI2",
-													"name": "Psychic Armor",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 3,
-													"points_per_level": 3,
-													"can_level": true,
-													"levels": 6,
-													"calc": {
-														"points": 21,
-														"current_level": 6
-													}
-												},
-												{
-													"id": "t1JJYfFvpFz3rjuN5",
-													"name": "Psychic Armor",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 4,
-													"points_per_level": 3,
-													"can_level": true,
-													"levels": 7,
-													"calc": {
-														"points": 25,
-														"current_level": 7
-													}
-												},
-												{
-													"id": "tNMR0oG-30hchVlKO",
-													"name": "Psychic Armor",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 2
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 4,
-													"points_per_level": 3,
-													"can_level": true,
-													"levels": 8,
-													"calc": {
-														"points": 28,
-														"current_level": 8
-													}
-												},
-												{
-													"id": "tvDmJ5iGUDpPHxkNl",
-													"name": "Psychic Armor",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 3
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 5,
-													"points_per_level": 3,
-													"can_level": true,
-													"levels": 9,
-													"calc": {
-														"points": 32,
-														"current_level": 9
-													}
-												},
-												{
-													"id": "tmbfIB4Oiv984Fc_p",
-													"name": "Psychic Armor",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 4
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 5,
-													"points_per_level": 3,
-													"can_level": true,
-													"levels": 10,
-													"calc": {
-														"points": 35,
-														"current_level": 10
-													}
-												},
-												{
-													"id": "tChSD3OaUFqaXUx3c",
-													"name": "Psychic Armor",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 5
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 6,
-													"points_per_level": 3,
-													"can_level": true,
-													"levels": 11,
-													"calc": {
-														"points": 39,
-														"current_level": 11
-													}
-												},
-												{
-													"id": "t62MpSMbc4NXEw4sJ",
-													"name": "Psychic Armor",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 6
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 6,
-													"points_per_level": 3,
-													"can_level": true,
-													"levels": 12,
-													"calc": {
-														"points": 42,
-														"current_level": 12
-													}
-												}
-											],
-											"calc": {
-												"points": 276
-											}
-										},
-										{
-											"id": "TYsDsglXdWHmRvHlA",
-											"name": "Psychic Sensitivity",
-											"reference": "DF14:9",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
-											"children": [
-												{
-													"id": "tlke7zhhFtvEjCdqc",
-													"name": "Psychic Sensitivity",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"points_per_level": 9,
-													"can_level": true,
-													"levels": 1,
-													"calc": {
-														"points": 9,
-														"current_level": 1
-													}
-												},
-												{
-													"id": "t68YkQx1NsDudeB6m",
-													"name": "Psychic Sensitivity",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 2
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"points_per_level": 9,
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 18,
-														"current_level": 2
-													}
-												},
-												{
-													"id": "thCCvNAoEuWnL_5AQ",
-													"name": "Psychic Sensitivity",
-													"reference": "DF14:9",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 4
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"points_per_level": 9,
-													"can_level": true,
-													"levels": 3,
-													"calc": {
-														"points": 27,
-														"current_level": 3
-													}
-												}
-											],
-											"calc": {
-												"points": 54
-											}
-										},
-										{
-											"id": "TN4v7x3RSwNHDD2rQ",
-											"name": "Psychokinetic Lash",
-											"reference": "DF14:10",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
-											"children": [
-												{
-													"id": "tVrEAVfOWiqtHv32J",
-													"name": "Psychokinetic Lash",
-													"reference": "DF14:10",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"points_per_level": 5,
-													"weapons": [
+													"children": [
 														{
-															"id": "whm4jfxQiibO9M-2C",
-															"sv": 1,
-															"damage": {
-																"type": ""
+															"id": "tARx-evgE26LLYMWg",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tGOGdAac3YsZzxbJ_"
 															},
-															"usage": "Psychokinetic Parry",
-															"parry": "1",
-															"defaults": [
+															"name": "Levitation 1",
+															"reference": "DF14:6",
+															"local_notes": "Flight",
+															"tags": [
+																"Exotic",
+																"Physical"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 1
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"modifiers": [
 																{
-																	"type": "parry",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
+																	"id": "ml2LJLGh_Bfg6YsMw",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "mX7spky4PF3L1dX6p",
+																	"name": "Low Ceiling",
+																	"reference": "B56",
+																	"local_notes": "5'",
+																	"cost_adj": "-25%"
+																},
+																{
+																	"id": "m17uDvhBmPHCnk6eY",
+																	"name": "Slow, Move 1",
+																	"reference": "PSI14",
+																	"cost_adj": "-45%"
 																}
-															]
+															],
+															"base_points": 40,
+															"calc": {
+																"points": 8
+															}
 														},
 														{
-															"id": "WDt64iET9N178XT-B",
+															"id": "tDg2SpbMqj-oYU5Fe",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tLR4TUVDYR8lgFYex"
+															},
+															"name": "Levitation 2",
+															"reference": "DF14:6",
+															"local_notes": "Flight",
+															"tags": [
+																"Exotic",
+																"Physical"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 2
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"modifiers": [
+																{
+																	"id": "mrK8uWKN29fZBgAoQ",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "mrvqOL9FE43-S3s5N",
+																	"name": "Low Ceiling",
+																	"reference": "B56",
+																	"local_notes": "10'",
+																	"cost_adj": "-20%"
+																},
+																{
+																	"id": "mh6jXlp3qcx3nluWF",
+																	"name": "Slow",
+																	"reference": "PSI14",
+																	"local_notes": "Basic Speed",
+																	"cost_adj": "-25%"
+																}
+															],
+															"base_points": 40,
+															"calc": {
+																"points": 18
+															}
+														},
+														{
+															"id": "tD75bWNBVGpMJRERT",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tWAfvBp6H_TonJeOS"
+															},
+															"name": "Levitation 3",
+															"reference": "DF14:6",
+															"local_notes": "Flight",
+															"tags": [
+																"Exotic",
+																"Physical"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 4
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"modifiers": [
+																{
+																	"id": "muIzGzS4WoXg8jnOY",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "mEFrraDx3kXv5l6b-",
+																	"name": "Low Ceiling",
+																	"reference": "B56",
+																	"local_notes": "10'",
+																	"cost_adj": "-20%"
+																}
+															],
+															"base_points": 40,
+															"calc": {
+																"points": 28
+															}
+														}
+													],
+													"calc": {
+														"points": 54
+													}
+												},
+												{
+													"id": "tlK6u01_VwAHDX5Xd",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tcWKoSMXzAFvYXAYU"
+													},
+													"name": "Psychokinetic Lash",
+													"reference": "DF14:10",
+													"local_notes": "Innate Attack (Crush)",
+													"tags": [
+														"Advantage",
+														"Exotic",
+														"Mental",
+														"Psionics"
+													],
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "script_prereq",
+																"script": "(self.level > entity.traitLevel('Psi Talent')) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+															},
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Unusual Background (Psionic)"
+																}
+															}
+														]
+													},
+													"modifiers": [
+														{
+															"id": "mYqe9WDNeej0M-7vr",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
+														},
+														{
+															"id": "mE3MiDymj4UWrir6N",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																"id": "mBUqeaOCkjZbdZXTV"
+															},
+															"name": "Variable",
+															"reference": "B109,P107",
+															"cost_adj": "5%"
+														}
+													],
+													"points_per_level": 5,
+													"max_levels": "6",
+													"weapons": [
+														{
+															"id": "wQG_vZEWvw3zidmQi",
+															"sv": 1,
+															"damage": {
+																"type": "",
+																"base_leveled": "1d"
+															},
+															"usage": "Parry",
+															"parry": "0",
+															"defaults": [
+																{
+																	"type": "dx",
+																	"modifier": -4
+																},
+																{
+																	"type": "skill",
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "Innate Attack"
+																	},
+																	"specialization": {
+																		"compare": "is",
+																		"qualifier": "Gaze"
+																	}
+																}
+															],
+															"calc": {
+																"damage": "1d per level"
+															}
+														},
+														{
+															"id": "WYHLcaf6Q8CR_yhgE",
 															"sv": 1,
 															"damage": {
 																"type": "cr",
 																"base_leveled": "1d"
 															},
-															"usage": "Psychokinetic Lash",
+															"usage": "Lash",
 															"accuracy": "3",
 															"range": "10/100",
+															"rate_of_fire": "1",
+															"recoil": "1",
 															"defaults": [
 																{
+																	"type": "dx",
+																	"modifier": -4
+																},
+																{
 																	"type": "skill",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "Innate Attack"
+																	},
+																	"specialization": {
+																		"compare": "is",
+																		"qualifier": "Gaze"
+																	}
 																}
 															],
 															"calc": {
@@ -4573,581 +1733,15 @@
 													}
 												},
 												{
-													"id": "tUuEBTmpBkOLAufQG",
-													"name": "Psychokinetic Lash",
-													"reference": "DF14:10",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
+													"id": "tLkpyUMlCGN3h2cNa",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tUg36TbXQg2z4--p4"
 													},
-													"points_per_level": 5,
-													"weapons": [
-														{
-															"id": "wRvwvmbDf1X4GruZy",
-															"sv": 1,
-															"damage": {
-																"type": ""
-															},
-															"usage": "Psychokinetic Parry",
-															"parry": "2",
-															"defaults": [
-																{
-																	"type": "parry",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															]
-														},
-														{
-															"id": "W0YR86JuUxZNoj8H5",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d"
-															},
-															"usage": "Psychokinetic Lash",
-															"accuracy": "3",
-															"range": "10/100",
-															"defaults": [
-																{
-																	"type": "skill",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															],
-															"calc": {
-																"damage": "1d per level  cr"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 10,
-														"current_level": 2
-													}
-												},
-												{
-													"id": "t0s-uW_q9gwqIdWVc",
-													"name": "Psychokinetic Lash",
-													"reference": "DF14:10",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"points_per_level": 5,
-													"weapons": [
-														{
-															"id": "wjPntMLV0rb90C_Rm",
-															"sv": 1,
-															"damage": {
-																"type": ""
-															},
-															"usage": "Psychokinetic Parry",
-															"parry": "3",
-															"defaults": [
-																{
-																	"type": "parry",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															]
-														},
-														{
-															"id": "WnGTV4RNCxXDZa0__",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d"
-															},
-															"usage": "Psychokinetic Lash",
-															"accuracy": "3",
-															"range": "10/100",
-															"defaults": [
-																{
-																	"type": "skill",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															],
-															"calc": {
-																"damage": "1d per level  cr"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 3,
-													"calc": {
-														"points": 15,
-														"current_level": 3
-													}
-												},
-												{
-													"id": "tHe8IEoEgUF5yOzFK",
-													"name": "Psychokinetic Lash",
-													"reference": "DF14:10",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -1,
-													"points_per_level": 5,
-													"weapons": [
-														{
-															"id": "wTVgGrTdfWHmXaWvN",
-															"sv": 1,
-															"damage": {
-																"type": ""
-															},
-															"usage": "Psychokinetic Parry",
-															"parry": "4",
-															"defaults": [
-																{
-																	"type": "parry",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															]
-														},
-														{
-															"id": "WdCjy0sR9mhvGuzbK",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d"
-															},
-															"usage": "Psychokinetic Lash",
-															"accuracy": "3",
-															"range": "10/100",
-															"defaults": [
-																{
-																	"type": "skill",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															],
-															"calc": {
-																"damage": "1d per level  cr"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 4,
-													"calc": {
-														"points": 19,
-														"current_level": 4
-													}
-												},
-												{
-													"id": "tNWvltyzFxY3vjGVQ",
-													"name": "Psychokinetic Lash",
-													"reference": "DF14:10",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -1,
-													"points_per_level": 5,
-													"weapons": [
-														{
-															"id": "wbFN9olQJwd11hjne",
-															"sv": 1,
-															"damage": {
-																"type": ""
-															},
-															"usage": "Psychokinetic Parry",
-															"parry": "5",
-															"defaults": [
-																{
-																	"type": "parry",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															]
-														},
-														{
-															"id": "WaiPHXd3JkR6qwID6",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d"
-															},
-															"usage": "Psychokinetic Lash",
-															"accuracy": "3",
-															"range": "10/100",
-															"defaults": [
-																{
-																	"type": "skill",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															],
-															"calc": {
-																"damage": "1d per level  cr"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 5,
-													"calc": {
-														"points": 24,
-														"current_level": 5
-													}
-												},
-												{
-													"id": "tKOlbnwc812lMdSUe",
-													"name": "Psychokinetic Lash",
-													"reference": "DF14:10",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -1,
-													"points_per_level": 5,
-													"weapons": [
-														{
-															"id": "wFhoBCZuLXy3MyrkL",
-															"sv": 1,
-															"damage": {
-																"type": ""
-															},
-															"usage": "Psychokinetic Parry",
-															"parry": "6",
-															"defaults": [
-																{
-																	"type": "parry",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															]
-														},
-														{
-															"id": "W4sbKF5v3maMP7edd",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "6d"
-															},
-															"usage": "Psychokinetic Lash",
-															"accuracy": "3",
-															"range": "10/100",
-															"defaults": [
-																{
-																	"type": "skill",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															],
-															"calc": {
-																"damage": "6d per level  cr"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 6,
-													"calc": {
-														"points": 29,
-														"current_level": 6
-													}
-												}
-											],
-											"calc": {
-												"points": 102
-											}
-										},
-										{
-											"id": "TIsZN0ZX3bgezzNkh",
-											"name": "Psychometry",
-											"reference": "DF14:10",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
-											"children": [
-												{
-													"id": "tW-p7ltvi3awb7s8G",
-													"name": "Psychometry",
-													"reference": "DF14:10",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 8,
-													"points_per_level": 10,
-													"can_level": true,
-													"levels": 1,
-													"calc": {
-														"points": 18,
-														"current_level": 1
-													}
-												},
-												{
-													"id": "tUFyypGrFw7S5x3-j",
-													"name": "Psychometry",
-													"reference": "DF14:10",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 2
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 8,
-													"points_per_level": 10,
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 28,
-														"current_level": 2
-													}
-												},
-												{
-													"id": "t2Kcq3cDui4oWDhn_",
-													"name": "Psychometry",
-													"reference": "DF14:10",
-													"local_notes": "1 FP/use",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 4
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 8,
-													"points_per_level": 10,
-													"can_level": true,
-													"levels": 3,
-													"calc": {
-														"points": 38,
-														"current_level": 3
-													}
-												}
-											],
-											"calc": {
-												"points": 84
-											}
-										},
-										{
-											"id": "TNaNKx0LOGlz12e3L",
-											"name": "Pyrokinetic Bolt",
-											"reference": "DF14:10",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
-											"children": [
-												{
-													"id": "tF-3d045W7bQ0ejxV",
 													"name": "Pyrokinetic Bolt",
 													"reference": "DF14:10",
+													"local_notes": "Innate Attack (Burn)",
 													"tags": [
 														"Advantage",
 														"Exotic",
@@ -5159,16 +1753,8 @@
 														"all": true,
 														"prereqs": [
 															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
+																"type": "script_prereq",
+																"script": "(self.level > entity.traitLevel('Psi Talent')) ? \"You do NOT have Enough Psi Talent!\" : \"\""
 															},
 															{
 																"type": "trait_prereq",
@@ -5180,39 +1766,86 @@
 															}
 														]
 													},
-													"points_per_level": 5,
-													"weapons": [
+													"modifiers": [
 														{
-															"id": "wE0cJLz1CO_5If3BE",
-															"sv": 1,
-															"damage": {
-																"type": ""
-															},
-															"usage": "Psychokinetic Parry",
-															"parry": "1",
-															"defaults": [
-																{
-																	"type": "parry",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															]
+															"id": "mYgIRsAuaToQ5oJBy",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
 														},
 														{
-															"id": "Wh3pvDnKFLEvapz1V",
+															"id": "mv-AzH2z5OZdePMAo",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																"id": "mBUqeaOCkjZbdZXTV"
+															},
+															"name": "Variable",
+															"reference": "B109,P107",
+															"cost_adj": "5%"
+														}
+													],
+													"points_per_level": 5,
+													"max_levels": "6",
+													"weapons": [
+														{
+															"id": "wTxKyOnyDTdTV1LuI",
+															"sv": 1,
+															"damage": {
+																"type": "",
+																"base_leveled": "1d"
+															},
+															"usage": "Parry",
+															"parry": "0",
+															"defaults": [
+																{
+																	"type": "dx",
+																	"modifier": -4
+																},
+																{
+																	"type": "skill",
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "Innate Attack"
+																	},
+																	"specialization": {
+																		"compare": "is",
+																		"qualifier": "Gaze"
+																	}
+																}
+															],
+															"calc": {
+																"damage": "1d per level"
+															}
+														},
+														{
+															"id": "Wlz19FHP6ngKkelIj",
 															"sv": 1,
 															"damage": {
 																"type": "burn",
 																"base_leveled": "1d"
 															},
-															"usage": "Psychokinetic Lash",
+															"usage": "Bolt",
 															"accuracy": "3",
 															"range": "10/100",
+															"rate_of_fire": "1",
+															"recoil": "1",
 															"defaults": [
 																{
+																	"type": "dx",
+																	"modifier": -4
+																},
+																{
 																	"type": "skill",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "Innate Attack"
+																	},
+																	"specialization": {
+																		"compare": "is",
+																		"qualifier": "Gaze"
+																	}
 																}
 															],
 															"calc": {
@@ -5228,669 +1861,181 @@
 													}
 												},
 												{
-													"id": "tpsd9L9UxNLXTcU7l",
-													"name": "Pyrokinetic Bolt",
-													"reference": "DF14:10",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
+													"id": "ts4qEQ5yjHE9vNZcU",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "td7oozECEczwnPR-C"
 													},
-													"points_per_level": 5,
-													"weapons": [
-														{
-															"id": "w_ojRU1yFUtQRb23n",
-															"sv": 1,
-															"damage": {
-																"type": ""
-															},
-															"usage": "Psychokinetic Parry",
-															"parry": "2",
-															"defaults": [
-																{
-																	"type": "parry",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															]
-														},
-														{
-															"id": "WFlsY9IsAUgAJB9Cs",
-															"sv": 1,
-															"damage": {
-																"type": "burn",
-																"base_leveled": "2d"
-															},
-															"usage": "Psychokinetic Lash",
-															"accuracy": "3",
-															"range": "10/100",
-															"defaults": [
-																{
-																	"type": "skill",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															],
-															"calc": {
-																"damage": "2d per level  burn"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 10,
-														"current_level": 2
-													}
-												},
-												{
-													"id": "tb7CIzwVuuRsyD_TI",
-													"name": "Pyrokinetic Bolt",
-													"reference": "DF14:10",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"points_per_level": 5,
-													"weapons": [
-														{
-															"id": "wAQvmD2_rsl8O0Pcs",
-															"sv": 1,
-															"damage": {
-																"type": ""
-															},
-															"usage": "Psychokinetic Parry",
-															"parry": "3",
-															"defaults": [
-																{
-																	"type": "parry",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															]
-														},
-														{
-															"id": "WqCzI_ZR9G6oQR_ap",
-															"sv": 1,
-															"damage": {
-																"type": "burn",
-																"base_leveled": "3d"
-															},
-															"usage": "Psychokinetic Lash",
-															"accuracy": "3",
-															"range": "10/100",
-															"defaults": [
-																{
-																	"type": "skill",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															],
-															"calc": {
-																"damage": "3d per level  burn"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 3,
-													"calc": {
-														"points": 15,
-														"current_level": 3
-													}
-												},
-												{
-													"id": "tA603rK4AkfU1gWHe",
-													"name": "Pyrokinetic Bolt",
-													"reference": "DF14:10",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -1,
-													"points_per_level": 5,
-													"weapons": [
-														{
-															"id": "w07Dmu8l9Fo_wqmx1",
-															"sv": 1,
-															"damage": {
-																"type": ""
-															},
-															"usage": "Psychokinetic Parry",
-															"parry": "4",
-															"defaults": [
-																{
-																	"type": "parry",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															]
-														},
-														{
-															"id": "WyFH1NRhP21CTJCh-",
-															"sv": 1,
-															"damage": {
-																"type": "burn",
-																"base_leveled": "4d"
-															},
-															"usage": "Psychokinetic Lash",
-															"accuracy": "3",
-															"range": "10/100",
-															"defaults": [
-																{
-																	"type": "skill",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															],
-															"calc": {
-																"damage": "4d per level  burn"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 4,
-													"calc": {
-														"points": 19,
-														"current_level": 4
-													}
-												},
-												{
-													"id": "tGbaQFUcVP4CuG-hB",
-													"name": "Pyrokinetic Bolt",
-													"reference": "DF14:10",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -1,
-													"points_per_level": 5,
-													"weapons": [
-														{
-															"id": "wxCmOcTdSdqXPbqWj",
-															"sv": 1,
-															"damage": {
-																"type": ""
-															},
-															"usage": "Psychokinetic Parry",
-															"parry": "5",
-															"defaults": [
-																{
-																	"type": "parry",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															]
-														},
-														{
-															"id": "WXAF3DUq9n5sR78_D",
-															"sv": 1,
-															"damage": {
-																"type": "burn",
-																"base_leveled": "5d"
-															},
-															"usage": "Psychokinetic Lash",
-															"accuracy": "3",
-															"range": "10/100",
-															"defaults": [
-																{
-																	"type": "skill",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															],
-															"calc": {
-																"damage": "5d per level  burn"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 5,
-													"calc": {
-														"points": 24,
-														"current_level": 5
-													}
-												},
-												{
-													"id": "tKv-ZmGXBq6YewG3J",
-													"name": "Pyrokinetic Bolt",
-													"reference": "DF14:10",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": -1,
-													"points_per_level": 5,
-													"weapons": [
-														{
-															"id": "wsbbCTzFnLOIqKhx3",
-															"sv": 1,
-															"damage": {
-																"type": ""
-															},
-															"usage": "Psychokinetic Parry",
-															"parry": "6",
-															"defaults": [
-																{
-																	"type": "parry",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															]
-														},
-														{
-															"id": "WmynVWqUusTTS63ng",
-															"sv": 1,
-															"damage": {
-																"type": "burn",
-																"base_leveled": "6d"
-															},
-															"usage": "Psychokinetic Lash",
-															"accuracy": "3",
-															"range": "10/100",
-															"defaults": [
-																{
-																	"type": "skill",
-																	"name": "Innate Attack",
-																	"specialization": "Gaze"
-																}
-															],
-															"calc": {
-																"damage": "6d per level  burn"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 6,
-													"calc": {
-														"points": 29,
-														"current_level": 6
-													}
-												}
-											],
-											"calc": {
-												"points": 102
-											}
-										},
-										{
-											"id": "TlRjE2AE8fsyoYXYb",
-											"name": "Remote Viewing",
-											"reference": "DF14:10",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
-											"children": [
-												{
-													"id": "thZp3wqhHcZWAWqf7",
-													"name": "Remote Viewing",
-													"reference": "DF14:10",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															}
-														]
-													},
-													"base_points": 35,
-													"points_per_level": 5,
-													"can_level": true,
-													"levels": 1,
-													"calc": {
-														"points": 40,
-														"current_level": 1
-													}
-												},
-												{
-													"id": "t0SPfR-YU58qfwGlK",
-													"name": "Remote Viewing",
-													"reference": "DF14:10",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															}
-														]
-													},
-													"base_points": 35,
-													"points_per_level": 5,
-													"can_level": true,
-													"levels": 2,
-													"calc": {
-														"points": 45,
-														"current_level": 2
-													}
-												},
-												{
-													"id": "tsJnM1is7OW1QuRt6",
-													"name": "Remote Viewing",
-													"reference": "DF14:10",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psight"
-																}
-															}
-														]
-													},
-													"base_points": 35,
-													"points_per_level": 5,
-													"can_level": true,
-													"levels": 3,
-													"calc": {
-														"points": 50,
-														"current_level": 3
-													}
-												}
-											],
-											"calc": {
-												"points": 135
-											}
-										},
-										{
-											"id": "T8POlm8C5Q4673wk7",
-											"name": "Telekinesis",
-											"reference": "DF14:11",
-											"tags": [
-												"Advantage",
-												"Psionics"
-											],
-											"children": [
-												{
-													"id": "tODp99xpBPqzuDoAw",
 													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
+													"reference": "B92,P82,PSI17",
 													"tags": [
 														"Advantage",
 														"Exotic",
+														"Force",
 														"Mental",
-														"Psionics"
+														"Physical"
 													],
 													"prereqs": {
 														"type": "prereq_list",
 														"all": true,
 														"prereqs": [
 															{
+																"type": "script_prereq",
+																"script": "(self.level > Math.max(0,entity.traitLevel('Psi Talent')) + 10) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+															},
+															{
 																"type": "trait_prereq",
 																"has": true,
 																"name": {
 																	"compare": "is",
 																	"qualifier": "Unusual Background (Psionic)"
+																},
+																"level": {
+																	"compare": "at_least"
 																}
 															}
 														]
 													},
-													"base_points": 1,
-													"points_per_level": 3,
+													"replacements": {
+														"Disciplines of Faith or Major Vow": "Disciplines of Faith or Major Vow"
+													},
+													"modifiers": [
+														{
+															"id": "mhab8UaFJwukv1Qv_",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
+														},
+														{
+															"id": "mzCCa0e1am1fIoUqH",
+															"name": "Cannot Affect Self",
+															"reference": "PSI17",
+															"cost_adj": "-20%"
+														}
+													],
+													"points_per_level": 5,
+													"max_levels": "16",
 													"weapons": [
 														{
-															"id": "wONc-C54GzK_uixu6",
+															"id": "wh6FseepWwWsAlsmL",
 															"sv": 1,
 															"damage": {
 																"type": "cr",
-																"base_leveled": "1d-7"
+																"st": "tk_thr"
 															},
-															"usage": "Punch",
-															"reach": "C",
+															"usage": "Grab",
+															"reach": "C,1-10",
 															"defaults": [
 																{
 																	"type": "dx"
 																},
 																{
 																	"type": "skill",
-																	"name": "Boxing"
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "Judo"
+																	}
 																},
 																{
 																	"type": "skill",
-																	"name": "Brawling"
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "Sumo Wrestling"
+																	}
 																},
 																{
 																	"type": "skill",
-																	"name": "Karate"
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "Wrestling"
+																	}
 																}
 															],
 															"calc": {
-																"damage": "1d-7 per level  cr"
+																"damage": "telekinetic thr cr"
 															}
 														},
 														{
-															"id": "w3ZIHt89wjZmGDmrR",
+															"id": "wnR3fff1mgK9z2ek1",
 															"sv": 1,
 															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d-6"
+																"type": "cr",
+																"st": "tk_thr"
 															},
-															"usage": "Grapple",
-															"reach": "C",
+															"usage": "Shove",
+															"usage_notes": "No Damage, Double Knockback",
+															"reach": "C,1-10",
 															"defaults": [
 																{
 																	"type": "dx"
 																},
 																{
 																	"type": "skill",
-																	"name": "Judo"
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "Brawling"
+																	}
 																},
 																{
 																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "Sumo Wrestling"
+																	}
 																}
 															],
 															"calc": {
-																"damage": "1d-6 per level  ctrl"
+																"damage": "telekinetic thr cr"
 															}
+														},
+														{
+															"id": "wucv3KEOdQzw5b1Wc",
+															"sv": 1,
+															"damage": {
+																"type": "cr",
+																"st": "tk_thr"
+															},
+															"usage": "Strike",
+															"reach": "C,1-10",
+															"parry": "0",
+															"defaults": [
+																{
+																	"type": "dx"
+																},
+																{
+																	"type": "skill",
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "Boxing"
+																	}
+																},
+																{
+																	"type": "skill",
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "Brawling"
+																	}
+																},
+																{
+																	"type": "skill",
+																	"name": {
+																		"compare": "is",
+																		"qualifier": "Karate"
+																	}
+																}
+															],
+															"calc": {
+																"damage": "telekinetic thr cr"
+															}
+														}
+													],
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "Skill use of High Manual Dexterity as per B92+",
+															"amount": 4
 														}
 													],
 													"can_level": true,
@@ -5899,12 +2044,119 @@
 														"points": 4,
 														"current_level": 1
 													}
+												}
+											],
+											"calc": {
+												"points": 72
+											}
+										},
+										{
+											"id": "TtjBMIDDJ3F98y7l4",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "TLqsbmbz-2jgmCeAB"
+											},
+											"name": "Telepathy",
+											"children": [
+												{
+													"id": "tCf9ZgV8BrDhi6DIW",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "t-LpbpjqQoNZb1DAA"
+													},
+													"name": "Battlesense",
+													"reference": "DF14:5",
+													"local_notes": "Enhanced (Block, Dodge, Parry)",
+													"tags": [
+														"Advantage",
+														"Exotic",
+														"Mental",
+														"Psionics"
+													],
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "script_prereq",
+																"script": "((self.level*2) > entity.traitLevel('Psi Talent')) ? \"You do NOT have Enough Psi Talent!\" : \"\""
+															},
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Mind Reading"
+																}
+															}
+														]
+													},
+													"replacements": {
+														"Condition": "Not against the Mindless"
+													},
+													"modifiers": [
+														{
+															"id": "me7T_EG0VVizwVr9q",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
+														},
+														{
+															"id": "mkm9qcDjDIEk9Kus2",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+																"id": "m2IwCpU9KwYmjiSSA"
+															},
+															"name": "Accessibility (@Condition@)",
+															"reference": "B110,P99",
+															"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+															"cost_adj": "-1%",
+															"levels": 10,
+															"calc": {}
+														}
+													],
+													"points_per_level": 30,
+													"max_levels": "3",
+													"features": [
+														{
+															"type": "attribute_bonus",
+															"attribute": "dodge",
+															"amount": 1,
+															"per_level": true
+														},
+														{
+															"type": "attribute_bonus",
+															"attribute": "parry",
+															"amount": 1,
+															"per_level": true
+														},
+														{
+															"type": "attribute_bonus",
+															"attribute": "block",
+															"amount": 1,
+															"per_level": true
+														}
+													],
+													"can_level": true,
+													"levels": 1,
+													"calc": {
+														"points": 24,
+														"current_level": 1
+													}
 												},
 												{
-													"id": "tc3Vvn623ysADzx7A",
-													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
+													"id": "tpKz3v2jgNB4d_Y_S",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tZkafJWp7VeDD-Szf"
+													},
+													"name": "Empathy",
+													"reference": "DF14:6",
 													"tags": [
 														"Advantage",
 														"Exotic",
@@ -5925,82 +2177,95 @@
 															}
 														]
 													},
-													"base_points": 1,
-													"points_per_level": 3,
-													"weapons": [
+													"replacements": {
+														"Condition": "Not on Elder Things"
+													},
+													"modifiers": [
 														{
-															"id": "wPJkXf5qvXguf2uWd",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d-7"
-															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d-7 per level  cr"
-															}
+															"id": "mvRts3i9bytR5SAmq",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
 														},
 														{
-															"id": "wBnMKBMlxd2jDCyRW",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d-6"
+															"id": "mEwZDFt9tOCZwkDIS",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+																"id": "m2IwCpU9KwYmjiSSA"
 															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d-6 per level  ctrl"
-															}
+															"name": "Accessibility (@Condition@)",
+															"reference": "B110,P99",
+															"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+															"cost_adj": "-1%",
+															"levels": 5,
+															"calc": {}
 														}
 													],
-													"can_level": true,
-													"levels": 2,
+													"base_points": 15,
 													"calc": {
-														"points": 7,
-														"current_level": 2
+														"points": 13
 													}
 												},
 												{
-													"id": "tpE4sxxoJffeLRgyv",
-													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
+													"id": "tT1FiF42FgGyWxnI5",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tFovAJ3h8q_yyIrOW"
+													},
+													"name": "Fear",
+													"reference": "DF14:6",
+													"local_notes": "Terror",
+													"tags": [
+														"Advantage",
+														"Exotic",
+														"Mental",
+														"Psionics"
+													],
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Telesend"
+																}
+															}
+														]
+													},
+													"modifiers": [
+														{
+															"id": "mRpNqdzdfsdcAQsb2",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
+														},
+														{
+															"id": "m4dZkdnhcsQb-lwmT",
+															"name": "Active",
+															"reference": "P84"
+														}
+													],
+													"base_points": 30,
+													"calc": {
+														"points": 27
+													}
+												},
+												{
+													"id": "t5CY9_OhSUlDbmanq",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tePelkGSO0FP9l3Bz"
+													},
+													"name": "Intuition",
+													"reference": "DF14:6",
 													"tags": [
 														"Advantage",
 														"Exotic",
@@ -6021,82 +2286,822 @@
 															}
 														]
 													},
-													"base_points": 2,
-													"points_per_level": 3,
-													"weapons": [
+													"replacements": {
+														"Condition": "Not places that have never had sentient visitors or a past"
+													},
+													"modifiers": [
 														{
-															"id": "wGox-mjNiSNo1q86b",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d-6"
-															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d-6 per level  cr"
-															}
+															"id": "mMPtBsMLewW4uPdG4",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
 														},
 														{
-															"id": "wzDqfDe5xmV1_za4w",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d-5"
+															"id": "micqCYWCOUWv8X7ko",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+																"id": "m2IwCpU9KwYmjiSSA"
 															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d-5 per level  ctrl"
-															}
+															"name": "Accessibility (@Condition@)",
+															"reference": "B110,P99",
+															"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+															"cost_adj": "-1%",
+															"levels": 5,
+															"calc": {}
 														}
 													],
-													"can_level": true,
-													"levels": 3,
+													"base_points": 15,
 													"calc": {
-														"points": 11,
-														"current_level": 3
+														"points": 13
 													}
 												},
 												{
-													"id": "t8WUNnyl-2ebjhNjv",
-													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
+													"id": "TvccrovOY37PdEgaN",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "TzDmTA3w76H7Dn65y"
+													},
+													"name": "Madness",
+													"reference": "DF14:7",
+													"tags": [
+														"Advantage",
+														"Psionics"
+													],
+													"children": [
+														{
+															"id": "tpXLgBF-I7-i0q3ha",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tWa7S7frYk5HwZF5e"
+															},
+															"name": "Madness 1",
+															"reference": "DF14:7",
+															"local_notes": "Affliction (Hallucinating)",
+															"tags": [
+																"Advantage",
+																"Physical",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"replacements": {
+																"Different Attribute": "Will"
+															},
+															"modifiers": [
+																{
+																	"id": "mU8H9OM5UjKr-iGPZ",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "mtzqALYJFj6eQxSZ4",
+																	"name": "Hallucination",
+																	"reference": "B429",
+																	"cost_adj": "50%"
+																},
+																{
+																	"id": "mezRxMwYmE-0DXYXD",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mwYBuNRe3OO7f3KNJ"
+																	},
+																	"name": "Malediction",
+																	"reference": "B106,P103",
+																	"local_notes": "-1 per yard of range",
+																	"cost_adj": "100%"
+																},
+																{
+																	"id": "miIygmAgV60B1DUMz",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mlMAMv0A4zOUT52xH"
+																	},
+																	"name": "No Signature",
+																	"reference": "B106,P103",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "mNQV-DeklgtynvjDh",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm",
+																		"id": "mJ4fxQ_hJHsqPgccX"
+																	},
+																	"name": "Based on @Different Attribute@, Own Roll",
+																	"reference": "PU4:12",
+																	"cost_adj": "20%"
+																}
+															],
+															"base_points": 10,
+															"calc": {
+																"points": 28
+															}
+														},
+														{
+															"id": "tqPLC4DUYTuqrui4J",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tWjV7-qGxOzaLtKsW"
+															},
+															"name": "Madness 2",
+															"reference": "DF14:7",
+															"local_notes": "Affliction (Hallucinating)",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 2
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"replacements": {
+																"Different Attribute": "Will"
+															},
+															"modifiers": [
+																{
+																	"id": "mIhT3bMVhuR3bMU7i",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "ms-4cMd5V9gAPTOqz",
+																	"name": "Hallucination",
+																	"reference": "B429",
+																	"cost_adj": "50%"
+																},
+																{
+																	"id": "mPlXM5c6YteIavQ5t",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mgoMzmGtd5meGGC3u"
+																	},
+																	"name": "Malediction",
+																	"reference": "B106,P103",
+																	"local_notes": "Use SSRT range penalties",
+																	"cost_adj": "150%"
+																},
+																{
+																	"id": "mQD2uKlscI_qtO9Ta",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mlMAMv0A4zOUT52xH"
+																	},
+																	"name": "No Signature",
+																	"reference": "B106,P103",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "m8kSfK7kphjXxCHOl",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm",
+																		"id": "mJ4fxQ_hJHsqPgccX"
+																	},
+																	"name": "Based on @Different Attribute@, Own Roll",
+																	"reference": "PU4:12",
+																	"cost_adj": "20%"
+																}
+															],
+															"base_points": 10,
+															"calc": {
+																"points": 33
+															}
+														},
+														{
+															"id": "truRkciyOxc1XGYIh",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tMFO-pHZCnrweNQgO"
+															},
+															"name": "Madness 3",
+															"reference": "DF14:7",
+															"local_notes": "Affliction (Hallucinating)",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 4
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"replacements": {
+																"Different Attribute": "Will"
+															},
+															"modifiers": [
+																{
+																	"id": "m9J1EjYfzKtTZwzG0",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "mMCVWAsQskZwsdfyR",
+																	"name": "Hallucination",
+																	"reference": "B429",
+																	"cost_adj": "50%"
+																},
+																{
+																	"id": "mVtPB95MfsB5gEtDe",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mrQbJZqh8LqLTSlSm"
+																	},
+																	"name": "Malediction",
+																	"reference": "B106,P103",
+																	"local_notes": "Uses Long-Distance Modifiers",
+																	"cost_adj": "200%"
+																},
+																{
+																	"id": "m_SxXo4WMxnMGSyiC",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mlMAMv0A4zOUT52xH"
+																	},
+																	"name": "No Signature",
+																	"reference": "B106,P103",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "mvi3OLchYo_a0yd_G",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm",
+																		"id": "mJ4fxQ_hJHsqPgccX"
+																	},
+																	"name": "Based on @Different Attribute@, Own Roll",
+																	"reference": "PU4:12",
+																	"cost_adj": "20%"
+																}
+															],
+															"base_points": 10,
+															"calc": {
+																"points": 38
+															}
+														}
+													],
+													"calc": {
+														"points": 99
+													}
+												},
+												{
+													"id": "TOl0991A4kiLBLw_p",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "T8sVjMvLzDutBao_0"
+													},
+													"name": "Mind Blast",
+													"reference": "DF14:7",
+													"tags": [
+														"Advantage",
+														"Psionics"
+													],
+													"children": [
+														{
+															"id": "tDfLsrb8s-kb7bu8K",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tgRTvaXLKKq1SGf22"
+															},
+															"name": "Mind Blast 1",
+															"reference": "DF14:7",
+															"local_notes": "Affliction 1 (Stun)",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"replacements": {
+																"Different Attribute": "Will"
+															},
+															"modifiers": [
+																{
+																	"id": "madapnMNWSviNBV-d",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "m2oIom4O9U_144sF0",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm",
+																		"id": "mJ4fxQ_hJHsqPgccX"
+																	},
+																	"name": "Based on @Different Attribute@, Own Roll",
+																	"reference": "PU4:12",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "m_2jRyzvG02lPPuVO",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mibbcaZA6iq5s3ETp"
+																	},
+																	"name": "3x Duration",
+																	"reference": "B105",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "mxrlsDYp9m1Gan6cC",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mwYBuNRe3OO7f3KNJ"
+																	},
+																	"name": "Malediction",
+																	"reference": "B106,P103",
+																	"local_notes": "-1 per yard of range",
+																	"cost_adj": "100%"
+																},
+																{
+																	"id": "mnI6SHiIDdD3t7ZKo",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mlMAMv0A4zOUT52xH"
+																	},
+																	"name": "No Signature",
+																	"reference": "B106,P103",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "mOvNScZAwgdGPkwvg",
+																	"name": "Secondary Unconsciousness",
+																	"reference": "B429",
+																	"cost_adj": "40%"
+																}
+															],
+															"base_points": 10,
+															"calc": {
+																"points": 29
+															}
+														},
+														{
+															"id": "tx9rEsYOc7J3Nx7Yi",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "t8z7PHdzPL43IUN8h"
+															},
+															"name": "Mind Blast 2",
+															"reference": "DF14:7",
+															"local_notes": "Affliction 1 (Stun)",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 2
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"replacements": {
+																"Different Attribute": "Will"
+															},
+															"modifiers": [
+																{
+																	"id": "m4Tsrp6jL71ZyS-R4",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "mSguEzEAiLv8A_CGo",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm",
+																		"id": "mJ4fxQ_hJHsqPgccX"
+																	},
+																	"name": "Based on @Different Attribute@, Own Roll",
+																	"reference": "PU4:12",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "mZQiQ_7CI8mcY8mdO",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mibbcaZA6iq5s3ETp"
+																	},
+																	"name": "3x Duration",
+																	"reference": "B105",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "mflaMw0Qjs0hiKJdX",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mgoMzmGtd5meGGC3u"
+																	},
+																	"name": "Malediction",
+																	"reference": "B106,P103",
+																	"local_notes": "Use SSRT range penalties",
+																	"cost_adj": "150%"
+																},
+																{
+																	"id": "mWijNmAdy82B9czPc",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mlMAMv0A4zOUT52xH"
+																	},
+																	"name": "No Signature",
+																	"reference": "B106,P103",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "mYRA1t-JgWojEX8nq",
+																	"name": "Secondary Unconsciousness",
+																	"reference": "B429",
+																	"cost_adj": "40%"
+																}
+															],
+															"base_points": 10,
+															"calc": {
+																"points": 34
+															}
+														},
+														{
+															"id": "ttwwuccgtAsquoCOV",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tuFejhdLoZpFC8Vz8"
+															},
+															"name": "Mind Blast 3",
+															"reference": "DF14:7",
+															"local_notes": "Affliction 1 (Stun)",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 4
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Unusual Background (Psionic)"
+																		}
+																	}
+																]
+															},
+															"replacements": {
+																"Different Attribute": "Will"
+															},
+															"modifiers": [
+																{
+																	"id": "mGL0Jmx32N_6eEyEJ",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "mOwNC54eKm1Hfx4UC",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Power Ups/Power Ups 4 Enhancements Enhancement Modifiers.adm",
+																		"id": "mJ4fxQ_hJHsqPgccX"
+																	},
+																	"name": "Based on @Different Attribute@, Own Roll",
+																	"reference": "PU4:12",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "mKOCf_VDpJfn7WZhx",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mibbcaZA6iq5s3ETp"
+																	},
+																	"name": "3x Duration",
+																	"reference": "B105",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "mdmW6Xtvc2r1muC_d",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mrQbJZqh8LqLTSlSm"
+																	},
+																	"name": "Malediction",
+																	"reference": "B106,P103",
+																	"local_notes": "Uses Long-Distance Modifiers",
+																	"cost_adj": "200%"
+																},
+																{
+																	"id": "mMWfB6hTpd32YUjFa",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mlMAMv0A4zOUT52xH"
+																	},
+																	"name": "No Signature",
+																	"reference": "B106,P103",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "mCuYSuRKhb04G_1-B",
+																	"name": "Secondary Unconsciousness",
+																	"reference": "B429",
+																	"cost_adj": "40%"
+																}
+															],
+															"base_points": 10,
+															"calc": {
+																"points": 39
+															}
+														}
+													],
+													"calc": {
+														"points": 102
+													}
+												},
+												{
+													"id": "TH01apQxX80IWdWAU",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "Txm9zbmWD0B19TwvP"
+													},
+													"name": "Mind Control",
+													"reference": "DF14:7",
+													"tags": [
+														"Advantage",
+														"Psionics"
+													],
+													"children": [
+														{
+															"id": "tWXdEW9G2o1wQgzj_",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tGU3dd0dmu76Tt9KW"
+															},
+															"name": "Mind Control 1",
+															"reference": "DF14:7",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 2
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Telesend"
+																		}
+																	}
+																]
+															},
+															"modifiers": [
+																{
+																	"id": "msjVNQuftlLpiucqb",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "mM4ZzTV2qCXJUc-vm",
+																	"name": "Mind Tricks",
+																	"reference": "PSI15",
+																	"cost_adj": "-30%"
+																}
+															],
+															"base_points": 50,
+															"calc": {
+																"points": 30
+															}
+														},
+														{
+															"id": "t670QDFHCbSatpf9Z",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "t6wg73HkodIKMT7Om"
+															},
+															"name": "Mind Control 2",
+															"reference": "DF14:7",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 4
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Telesend"
+																		}
+																	}
+																]
+															},
+															"modifiers": [
+																{
+																	"id": "mGdrP2RX0kxzIgRth",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																}
+															],
+															"base_points": 50,
+															"calc": {
+																"points": 45
+															}
+														}
+													],
+													"calc": {
+														"points": 75
+													}
+												},
+												{
+													"id": "tU9ORJoOtt7_Z9yT_",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tNjl44OWEq8f7_z6X"
+													},
+													"name": "Mind Meld",
+													"reference": "DF14:8",
+													"local_notes": "**Mind Probe** , Feature: Can compel speech, but risk giving up secrets.",
 													"tags": [
 														"Advantage",
 														"Exotic",
@@ -6114,779 +3119,7 @@
 																	"compare": "is",
 																	"qualifier": "Unusual Background (Psionic)"
 																}
-															}
-														]
-													},
-													"base_points": 2,
-													"points_per_level": 3,
-													"weapons": [
-														{
-															"id": "w2RMOyLkKE2_LWF4F",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d-6"
 															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d-6 per level  cr"
-															}
-														},
-														{
-															"id": "wdwNhRaF1ki6m8sdB",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d-5"
-															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d-5 per level  ctrl"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 4,
-													"calc": {
-														"points": 14,
-														"current_level": 4
-													}
-												},
-												{
-													"id": "tT1rTEWUSZ2JXCTdP",
-													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 3,
-													"points_per_level": 3,
-													"weapons": [
-														{
-															"id": "wpvr9ObGmUkAMjwwo",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d-5"
-															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d-5 per level  cr"
-															}
-														},
-														{
-															"id": "wFRVyLsKjlFsxu7EI",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d-4"
-															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d-4 per level  ctrl"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 5,
-													"calc": {
-														"points": 18,
-														"current_level": 5
-													}
-												},
-												{
-													"id": "tCS9bgg779lYQfCtv",
-													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 3,
-													"points_per_level": 3,
-													"weapons": [
-														{
-															"id": "win-OzKyh_VGbbBJW",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d-5"
-															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d-5 per level  cr"
-															}
-														},
-														{
-															"id": "waBL1-NYyOwSAae8d",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d-4"
-															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d-4 per level  ctrl"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 6,
-													"calc": {
-														"points": 21,
-														"current_level": 6
-													}
-												},
-												{
-													"id": "t_mEcOMyLIpiCjrOJ",
-													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 4,
-													"points_per_level": 3,
-													"weapons": [
-														{
-															"id": "w3PglkJ9l_EFhyL1K",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d-4"
-															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d-4 per level  cr"
-															}
-														},
-														{
-															"id": "wOCPnbmrmqYpG4P42",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d-3"
-															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d-3 per level  ctrl"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 7,
-													"calc": {
-														"points": 25,
-														"current_level": 7
-													}
-												},
-												{
-													"id": "tN9tNOE6DTSCIUhiH",
-													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 4,
-													"points_per_level": 3,
-													"weapons": [
-														{
-															"id": "wu0awEpijDw6Gws2T",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d-2"
-															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d-2 per level  cr"
-															}
-														},
-														{
-															"id": "wtHVqp_QGDnpG4aGS",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d-1"
-															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d-1 per level  ctrl"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 9,
-													"calc": {
-														"points": 31,
-														"current_level": 9
-													}
-												},
-												{
-													"id": "trma9cQ97yNLjagMN",
-													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 4,
-													"points_per_level": 3,
-													"weapons": [
-														{
-															"id": "wicEQmpsYAdnSdInT",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d-4"
-															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d-4 per level  cr"
-															}
-														},
-														{
-															"id": "weAkRu_3wy-5SgC12",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d-3"
-															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d-3 per level  ctrl"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 8,
-													"calc": {
-														"points": 28,
-														"current_level": 8
-													}
-												},
-												{
-													"id": "toNp8M15PnsOsV8z-",
-													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 5,
-													"points_per_level": 3,
-													"weapons": [
-														{
-															"id": "woDirj_KWZ6fBsH1R",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d-1"
-															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d-1 per level  cr"
-															}
-														},
-														{
-															"id": "wVwRLeSCjzsXt-oHM",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d"
-															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d per level  ctrl"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 10,
-													"calc": {
-														"points": 35,
-														"current_level": 10
-													}
-												},
-												{
-													"id": "tx8uzFzqcXokC7Ccu",
-													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 1
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 6,
-													"points_per_level": 3,
-													"weapons": [
-														{
-															"id": "wdv3yD24BYWNxSlmi",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d"
-															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d per level  cr"
-															}
-														},
-														{
-															"id": "wJSvOAPvDggxFlglD",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d+1"
-															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d+1 per level  ctrl"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 11,
-													"calc": {
-														"points": 39,
-														"current_level": 11
-													}
-												},
-												{
-													"id": "txAbJ-7H7JlWiMe1w",
-													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
 															{
 																"type": "trait_prereq",
 																"has": true,
@@ -6898,93 +3131,44 @@
 																	"compare": "at_least",
 																	"qualifier": 2
 																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
 															}
 														]
 													},
-													"base_points": 6,
-													"points_per_level": 3,
-													"weapons": [
+													"modifiers": [
 														{
-															"id": "wAuY8kb4RvtbCMw_6",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d+2"
-															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d+2 per level  ctrl"
-															}
+															"id": "mZRjVCHk_JsfAaam5",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
 														},
 														{
-															"id": "wKiKBIvtB5yqCujoA",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d+1"
+															"id": "mhdKAfmIUuJdBEyNK",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Power Ups/Power Ups 8 Limitations Limitation Modifiers.adm",
+																"id": "mnXv6kra7QDSGy2f5"
 															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d+1 per level  cr"
-															}
+															"name": "Immediate Preparation Required",
+															"reference": "PU8:14",
+															"local_notes": "1 minute",
+															"cost_adj": "-30%"
 														}
 													],
-													"can_level": true,
-													"levels": 12,
+													"base_points": 20,
 													"calc": {
-														"points": 42,
-														"current_level": 12
+														"points": 12
 													}
 												},
 												{
-													"id": "tsHm-7Ft8Ou4OATFB",
-													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
+													"id": "tZMvSEdv7eXaNPL6n",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tSwvnXANtzmf-moeF"
+													},
+													"name": "Mind Reading",
+													"reference": "DF14:8",
 													"tags": [
 														"Advantage",
 														"Exotic",
@@ -7000,99 +3184,342 @@
 																"has": true,
 																"name": {
 																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 3
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
 																	"qualifier": "Unusual Background (Psionic)"
 																}
 															}
 														]
 													},
-													"base_points": 7,
-													"points_per_level": 3,
-													"weapons": [
+													"modifiers": [
 														{
-															"id": "wXei0Aiza8RZUySFX",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d"
-															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d per level  ctrl"
-															}
-														},
-														{
-															"id": "w6QnvsevESbOsHkpE",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d-1"
-															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d-1 per level  cr"
-															}
+															"id": "mN21SHupOjwO5etZd",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
 														}
 													],
-													"can_level": true,
-													"levels": 13,
+													"base_points": 30,
 													"calc": {
-														"points": 46,
-														"current_level": 13
+														"points": 27
 													}
 												},
 												{
-													"id": "tEHdCxvgIzndx9LDI",
-													"name": "Telekinesis",
+													"id": "TPtWsvesHkOa9jtsa",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "TvV3pDjC7pVG9V-St"
+													},
+													"name": "Mind Stab",
+													"reference": "DF14:9",
+													"tags": [
+														"Advantage",
+														"Psionics"
+													],
+													"children": [
+														{
+															"id": "tBbr3G4DuZ3F-jM2S",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tB0jeNW169PovpPXy"
+															},
+															"name": "Mind Stab 1",
+															"reference": "DF14:9",
+															"local_notes": "Innate Attack (Fatigue/Toxic)",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 2
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Telesend"
+																		}
+																	}
+																]
+															},
+															"replacements": {
+																"Condition": "No effect on Brainless; Damage cannot exceed margin of victory; Psychic Armor protects normally"
+															},
+															"modifiers": [
+																{
+																	"id": "mpLyP9mSbx45eMJ0Q",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "mcZcGgNnHLf_ehOas",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+																		"id": "m2IwCpU9KwYmjiSSA"
+																	},
+																	"name": "Accessibility (@Condition@)",
+																	"reference": "B110,P99",
+																	"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+																	"cost_adj": "-1%",
+																	"levels": 70,
+																	"calc": {}
+																},
+																{
+																	"id": "m06vgGOEFMs-stBsj",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mlMAMv0A4zOUT52xH"
+																	},
+																	"name": "No Signature",
+																	"reference": "B106,P103",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "mhySOoZE2xcb3R6-L",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mwYBuNRe3OO7f3KNJ"
+																	},
+																	"name": "Malediction",
+																	"reference": "B106,P103",
+																	"local_notes": "-1 per yard of range",
+																	"cost_adj": "100%"
+																}
+															],
+															"base_points": 32.5,
+															"calc": {
+																"points": 46
+															}
+														},
+														{
+															"id": "tf3qn7g7Y-cmbyDGV",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tyYA39PgVuzKONhgz"
+															},
+															"name": "Mind Stab 2",
+															"reference": "DF14:9",
+															"local_notes": "Innate Attack (Fatigue/Toxic)",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 4
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Telesend"
+																		}
+																	}
+																]
+															},
+															"replacements": {
+																"Condition": "No effect on Brainless; Damage cannot exceed margin of victory; Psychic Armor protects normally"
+															},
+															"modifiers": [
+																{
+																	"id": "mlvWvDgBT5a_37t-b",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "m9g4MKoO72aLsCMr1",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+																		"id": "m2IwCpU9KwYmjiSSA"
+																	},
+																	"name": "Accessibility (@Condition@)",
+																	"reference": "B110,P99",
+																	"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+																	"cost_adj": "-1%",
+																	"levels": 70,
+																	"calc": {}
+																},
+																{
+																	"id": "mZ2x3OzpE_Z9v3N2D",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mlMAMv0A4zOUT52xH"
+																	},
+																	"name": "No Signature",
+																	"reference": "B106,P103",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "mWs4LyS4AvHe4wgPX",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mgoMzmGtd5meGGC3u"
+																	},
+																	"name": "Malediction",
+																	"reference": "B106,P103",
+																	"local_notes": "Use SSRT range penalties",
+																	"cost_adj": "150%"
+																}
+															],
+															"base_points": 32.5,
+															"calc": {
+																"points": 62
+															}
+														},
+														{
+															"id": "t7bFSNlasvb2sIiOF",
+															"source": {
+																"library": "richardwilkes/gcs_master_library",
+																"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+																"id": "tky1yaFu610_AMAQ1"
+															},
+															"name": "Mind Stab 3",
+															"reference": "DF14:9",
+															"local_notes": "Innate Attack (Fatigue/Toxic)",
+															"tags": [
+																"Advantage",
+																"Exotic",
+																"Mental",
+																"Psionics"
+															],
+															"prereqs": {
+																"type": "prereq_list",
+																"all": true,
+																"prereqs": [
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Psi Talent"
+																		},
+																		"level": {
+																			"compare": "at_least",
+																			"qualifier": 6
+																		}
+																	},
+																	{
+																		"type": "trait_prereq",
+																		"has": true,
+																		"name": {
+																			"compare": "is",
+																			"qualifier": "Telesend"
+																		}
+																	}
+																]
+															},
+															"replacements": {
+																"Condition": "No effect on Brainless; Damage cannot exceed margin of victory; Psychic Armor protects normally"
+															},
+															"modifiers": [
+																{
+																	"id": "mZhbh9M6je20RnkZW",
+																	"name": "Psionic",
+																	"reference": "DF14:5",
+																	"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+																	"cost_adj": "-10%"
+																},
+																{
+																	"id": "m40zEhhzzA9rhBp0T",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Limitation Modifiers.adm",
+																		"id": "m2IwCpU9KwYmjiSSA"
+																	},
+																	"name": "Accessibility (@Condition@)",
+																	"reference": "B110,P99",
+																	"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
+																	"cost_adj": "-1%",
+																	"levels": 70,
+																	"calc": {}
+																},
+																{
+																	"id": "mVf-YNt91WmsvJO98",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mlMAMv0A4zOUT52xH"
+																	},
+																	"name": "No Signature",
+																	"reference": "B106,P103",
+																	"cost_adj": "20%"
+																},
+																{
+																	"id": "mUOu4U-qqE31O0C9w",
+																	"source": {
+																		"library": "richardwilkes/gcs_master_library",
+																		"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
+																		"id": "mrQbJZqh8LqLTSlSm"
+																	},
+																	"name": "Malediction",
+																	"reference": "B106,P103",
+																	"local_notes": "Uses Long-Distance Modifiers",
+																	"cost_adj": "200%"
+																}
+															],
+															"base_points": 32.5,
+															"calc": {
+																"points": 78
+															}
+														}
+													],
+													"calc": {
+														"points": 186
+													}
+												},
+												{
+													"id": "tYh0zf6rqgAvip8je",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tgFRGx8DCKK9Lxgjl"
+													},
+													"name": "Telesend",
 													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
+													"local_notes": "Telecommunication (Telesend)",
 													"tags": [
 														"Advantage",
 														"Exotic",
@@ -7108,385 +3535,52 @@
 																"has": true,
 																"name": {
 																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 4
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
 																	"qualifier": "Unusual Background (Psionic)"
 																}
 															}
 														]
 													},
-													"base_points": 7,
-													"points_per_level": 3,
-													"weapons": [
+													"modifiers": [
 														{
-															"id": "wef2x-NXbNb5e_2Ti",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d"
-															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d per level  ctrl"
-															}
-														},
-														{
-															"id": "waJU8yQqr7OSxI1of",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d-1"
-															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d-1 per level  cr"
-															}
+															"id": "m2Xm5NVNYWCd0Wbok",
+															"name": "Psionic",
+															"reference": "DF14:5",
+															"local_notes": "1 FP cost a use or per min, [Attracts Elder Things](DF14:37) on a 6 or less",
+															"cost_adj": "-10%"
 														}
 													],
-													"can_level": true,
-													"levels": 14,
+													"base_points": 30,
 													"calc": {
-														"points": 49,
-														"current_level": 14
-													}
-												},
-												{
-													"id": "tEGFHd28sBfKpE-dU",
-													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 5
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 8,
-													"points_per_level": 3,
-													"weapons": [
-														{
-															"id": "wSh7OB55kwvRm32s-",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d+1"
-															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d+1 per level  ctrl"
-															}
-														},
-														{
-															"id": "wFoTuJdSDIVghk33N",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d"
-															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d per level  cr"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 15,
-													"calc": {
-														"points": 53,
-														"current_level": 15
-													}
-												},
-												{
-													"id": "t6kis88Gln9qrfXmd",
-													"name": "Telekinesis",
-													"reference": "DF14:11",
-													"local_notes": "1 FP/min",
-													"tags": [
-														"Advantage",
-														"Exotic",
-														"Mental",
-														"Psionics"
-													],
-													"prereqs": {
-														"type": "prereq_list",
-														"all": true,
-														"prereqs": [
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Psi Talent"
-																},
-																"level": {
-																	"compare": "at_least",
-																	"qualifier": 6
-																}
-															},
-															{
-																"type": "trait_prereq",
-																"has": true,
-																"name": {
-																	"compare": "is",
-																	"qualifier": "Unusual Background (Psionic)"
-																}
-															}
-														]
-													},
-													"base_points": 8,
-													"points_per_level": 3,
-													"weapons": [
-														{
-															"id": "w7IJgk_F6E20tnOLG",
-															"sv": 1,
-															"damage": {
-																"type": "ctrl",
-																"base_leveled": "1d+1"
-															},
-															"usage": "Grapple",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Judo"
-																},
-																{
-																	"type": "skill",
-																	"name": "Sumo Wrestling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Wrestling"
-																}
-															],
-															"calc": {
-																"damage": "1d+1 per level  ctrl"
-															}
-														},
-														{
-															"id": "w-h15jrhalevtpRZX",
-															"sv": 1,
-															"damage": {
-																"type": "cr",
-																"base_leveled": "1d"
-															},
-															"usage": "Punch",
-															"reach": "C",
-															"defaults": [
-																{
-																	"type": "dx"
-																},
-																{
-																	"type": "skill",
-																	"name": "Boxing"
-																},
-																{
-																	"type": "skill",
-																	"name": "Brawling"
-																},
-																{
-																	"type": "skill",
-																	"name": "Karate"
-																}
-															],
-															"calc": {
-																"damage": "1d per level  cr"
-															}
-														}
-													],
-													"can_level": true,
-													"levels": 16,
-													"calc": {
-														"points": 56,
-														"current_level": 16
+														"points": 27
 													}
 												}
 											],
 											"calc": {
-												"points": 479
-											}
-										},
-										{
-											"id": "tqwcZCJUi4Kn8BruZ",
-											"name": "Telesend",
-											"reference": "DF14:11",
-											"local_notes": "1 FP/min",
-											"tags": [
-												"Advantage",
-												"Exotic",
-												"Mental",
-												"Psionics"
-											],
-											"prereqs": {
-												"type": "prereq_list",
-												"all": true,
-												"prereqs": [
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Unusual Background (Psionic)"
-														}
-													}
-												]
-											},
-											"base_points": 27,
-											"calc": {
-												"points": 27
-											}
-										},
-										{
-											"id": "tX1gsjAs6ewGIdkjJ",
-											"name": "Transdimensional Sight",
-											"reference": "DF14:11",
-											"tags": [
-												"Advantage",
-												"Exotic",
-												"Mental",
-												"Psionics"
-											],
-											"prereqs": {
-												"type": "prereq_list",
-												"all": true,
-												"prereqs": [
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Unusual Background (Psionic)"
-														}
-													}
-												]
-											},
-											"base_points": 13,
-											"calc": {
-												"points": 13
+												"points": 605
 											}
 										}
 									],
 									"calc": {
-										"points": 2546
+										"points": 1065
 									}
 								},
 								{
-									"id": "T0DB1Q5FEWOpXl0yu",
-									"name": "Psionic Power-Ups",
+									"id": "TpBhHKzNvtn1aOPFJ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "TGseI9IykAzbtB-fp"
+									},
+									"name": "Mentalist Power-Ups",
+									"reference": "DF14:19",
 									"children": [
 										{
-											"id": "tFR4Sit1p_FcbuqWS",
+											"id": "tUtxHqHp6DgW5I2bx",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tqpmMxemwbsfvbFXN"
+											},
 											"name": "Acute ESP",
 											"reference": "DF14:19",
 											"tags": [
@@ -7499,6 +3593,10 @@
 												"type": "prereq_list",
 												"all": false,
 												"prereqs": [
+													{
+														"type": "script_prereq",
+														"script": "(self.level > Math.max(0,entity.traitLevel('Psi Talent'))) ? \"You do NOT have enough Psi Talent\" : \"\""
+													},
 													{
 														"type": "trait_prereq",
 														"has": true,
@@ -7534,6 +3632,15 @@
 												]
 											},
 											"points_per_level": 2,
+											"max_levels": "6",
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "Perception rolled for information from (Psight, Psychic Sensitivity, or Transdimensional Sight) and Sense rolls during Remote Viewing.",
+													"amount": 1,
+													"per_level": true
+												}
+											],
 											"can_level": true,
 											"levels": 1,
 											"calc": {
@@ -7542,9 +3649,15 @@
 											}
 										},
 										{
-											"id": "t4aY4uVsnQFEloiwF",
+											"id": "tYwzRyI9kUx0iKn9a",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tBvXhgZfCtT0jghfW"
+											},
 											"name": "Blind Viewing",
 											"reference": "DF14:19",
+											"local_notes": "Technique",
 											"tags": [
 												"Advantage",
 												"Exotic",
@@ -7561,55 +3674,480 @@
 														"name": {
 															"compare": "is",
 															"qualifier": "Remote Viewing"
-														},
-														"level": {
-															"compare": "at_least",
-															"qualifier": 1
 														}
 													}
 												]
 											},
 											"base_points": 6,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "to counteract the penalty to use Remote Viewing to a place you can't see",
+													"amount": 5
+												}
+											],
 											"calc": {
 												"points": 6
 											}
 										},
 										{
-											"id": "tqbXoQ4Lzcuywhm8p",
+											"id": "TGyfFaqq8FC2HVFk7",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "Th2k3oGKa7-UkIe54"
+											},
 											"name": "Bonded Creature",
 											"reference": "DF14:20",
-											"tags": [
-												"Advantage",
-												"Exotic",
-												"Mental",
-												"Psionics"
-											],
-											"prereqs": {
-												"type": "prereq_list",
-												"all": true,
-												"prereqs": [
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Psi Talent"
+											"reference_highlight": "Bonded Creature",
+											"local_notes": "Like a [familiar](DF5:20) but the link is psionic instead of magical. This still requires obtaining a creature and caring for it for 1d weeks until the bond forms.",
+											"container_type": "meta_trait",
+											"children": [
+												{
+													"id": "tGXNODihdpjowFOBi",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "ttSv-XI59lXppUlRt"
+													},
+													"name": "Ally (@Who@)",
+													"reference": "B36,P41",
+													"local_notes": "<script>entity.exists ? `Ally Point Value: ${Math.floor(entity.points.total*.25)}` : \"\" </script>",
+													"tags": [
+														"Advantage",
+														"Social"
+													],
+													"modifiers": [
+														{
+															"id": "M6gxhWSDfDqN_EtFG",
+															"name": "Point Total",
+															"reference": "B37",
+															"children": [
+																{
+																	"id": "mtylqKhInNwsfqx4G",
+																	"name": "25% of your starting points",
+																	"reference": "B37",
+																	"cost_adj": "1"
+																},
+																{
+																	"id": "mlNBNj4ZcLbZo7XCh",
+																	"name": "50% of your starting points",
+																	"reference": "B37",
+																	"cost_adj": "2",
+																	"disabled": true
+																},
+																{
+																	"id": "mi9ue0ijyNuAosn4N",
+																	"name": "75% of your starting points",
+																	"reference": "B37",
+																	"cost_adj": "3",
+																	"disabled": true
+																},
+																{
+																	"id": "mECP31NUfLd3MY5L3",
+																	"name": "100% of your starting points",
+																	"reference": "B37",
+																	"cost_adj": "5",
+																	"disabled": true
+																},
+																{
+																	"id": "mYI_U066dyG2iYITf",
+																	"name": "150% of your starting points",
+																	"reference": "B37",
+																	"cost_adj": "10",
+																	"disabled": true
+																}
+															]
 														},
-														"level": {
-															"compare": "at_least",
-															"qualifier": 1
+														{
+															"id": "M6WxRPbm1iaYYYT0r",
+															"name": "Ally Group",
+															"reference": "B37",
+															"children": [
+																{
+																	"id": "mN2eGLS6-PHVEMmVy",
+																	"name": "Group of 6-10",
+																	"reference": "B37",
+																	"cost_adj": "x6",
+																	"disabled": true
+																},
+																{
+																	"id": "muHKgAT1WOvk8ddnl",
+																	"name": "Group of 11-20",
+																	"reference": "B37",
+																	"cost_adj": "x8",
+																	"disabled": true
+																},
+																{
+																	"id": "mdBvQeyja9yzRr9YJ",
+																	"name": "Group of 21-50",
+																	"reference": "B37",
+																	"cost_adj": "x10",
+																	"disabled": true
+																},
+																{
+																	"id": "mkhoSeKxGfNp_2XVr",
+																	"name": "Group of 51-100",
+																	"reference": "B37",
+																	"cost_adj": "x12",
+																	"disabled": true
+																},
+																{
+																	"id": "mXJEqTcpFzv1GJkoj",
+																	"name": "Group of 101-1000",
+																	"reference": "B37",
+																	"cost_adj": "x18",
+																	"disabled": true
+																},
+																{
+																	"id": "middT7k41zE7kdhdr",
+																	"name": "Group of 1001-10000",
+																	"reference": "B37",
+																	"cost_adj": "x24",
+																	"disabled": true
+																},
+																{
+																	"id": "mYuMpARmktBsjRWts",
+																	"name": "Group of 10001-100000",
+																	"reference": "B37",
+																	"cost_adj": "x30",
+																	"disabled": true
+																},
+																{
+																	"id": "mzu3_c0-5-39r4Enl",
+																	"name": "Group of 100001-1000000",
+																	"reference": "B37",
+																	"cost_adj": "x36",
+																	"disabled": true
+																}
+															]
+														},
+														{
+															"id": "MBIkNc5tUihQ5eHkV",
+															"name": "Frequency of Appearance",
+															"reference": "B37",
+															"children": [
+																{
+																	"id": "mhfBZdDjUqTVuqwvf",
+																	"name": "Appears quite rarely (6-)",
+																	"reference": "B36",
+																	"cost_adj": "x0.5",
+																	"disabled": true
+																},
+																{
+																	"id": "mqcUoXQBTYlmCUffg",
+																	"name": "Appears fairly often (9-)",
+																	"reference": "B36",
+																	"cost_adj": "x1",
+																	"disabled": true
+																},
+																{
+																	"id": "mozfJej8-BlXf5NyG",
+																	"name": "Appears quite often (12-)",
+																	"reference": "B36",
+																	"cost_adj": "x2",
+																	"disabled": true
+																},
+																{
+																	"id": "mOH_s55e6qf9HW71H",
+																	"name": "Appears almost all the time (15-)",
+																	"reference": "B36",
+																	"cost_adj": "x3",
+																	"disabled": true
+																},
+																{
+																	"id": "mKGr7la-Es0jkOmX2",
+																	"name": "Appears constantly",
+																	"reference": "B36",
+																	"cost_adj": "x4"
+																}
+															]
+														},
+														{
+															"id": "mY2SY6cpZ1K7ArVAc",
+															"name": "Minion",
+															"reference": "B38",
+															"local_notes": "IQ 0 or Slave Mentality",
+															"disabled": true
+														},
+														{
+															"id": "mwO8wFAYEfI5OTxnr",
+															"name": "Minion",
+															"reference": "B38",
+															"cost_adj": "50%",
+															"disabled": true
+														},
+														{
+															"id": "mWp2aVVpP-FTUxI99",
+															"name": "Special Abilities",
+															"reference": "B38",
+															"local_notes": "@Abilities@",
+															"cost_adj": "50%"
+														},
+														{
+															"id": "MaQMFmQkkYkpYSAQU",
+															"name": "Summonable",
+															"children": [
+																{
+																	"id": "mGT8lztdpXrf0pz2-",
+																	"name": "Summonable",
+																	"reference": "B38,P41",
+																	"cost_adj": "100%"
+																},
+																{
+																	"id": "mNKg4K_IGX9Q73eDu",
+																	"name": "Conjured",
+																	"reference": "DF9:4,P41",
+																	"cost_adj": "100%",
+																	"disabled": true
+																},
+																{
+																	"id": "myZDTqlO3m2mKmiyW",
+																	"name": "Harder Summoning 1",
+																	"reference": "DF9:4",
+																	"cost_adj": "-5%",
+																	"disabled": true
+																},
+																{
+																	"id": "mq6lwcmyxa0689TLg",
+																	"name": "Harder Summoning 2",
+																	"reference": "DF9:4",
+																	"cost_adj": "-10%",
+																	"disabled": true
+																},
+																{
+																	"id": "mK-Zd4hj_6V93HGUb",
+																	"name": "Harder Summoning 3",
+																	"reference": "DF9:4",
+																	"cost_adj": "-20%",
+																	"disabled": true
+																}
+															]
+														},
+														{
+															"id": "MS_kLwH90u_BBCKp2",
+															"name": "Sympathy",
+															"reference": "B38",
+															"children": [
+																{
+																	"id": "mIO5mmMksLC0ophtk",
+																	"name": "Sympathy",
+																	"reference": "B38",
+																	"local_notes": "Death of one party reduces the other to 0 HP",
+																	"cost_adj": "-25%"
+																},
+																{
+																	"id": "mw90hzx5BbkPG9Pk8",
+																	"name": "Sympathy",
+																	"reference": "B38",
+																	"local_notes": "Death of one party reduces the other to 0 HP and wounds affect ally but not you",
+																	"cost_adj": "-5%",
+																	"disabled": true
+																},
+																{
+																	"id": "mMS9Qy47xWmKIzfC-",
+																	"name": "Sympathy",
+																	"reference": "B38",
+																	"local_notes": "Death of one party kills the other",
+																	"cost_adj": "-50%",
+																	"disabled": true
+																},
+																{
+																	"id": "md8MXUFVSdRMyyNQi",
+																	"name": "Sympathy",
+																	"reference": "B38",
+																	"local_notes": "Death of one party kills the other and wounds affect ally but not you",
+																	"cost_adj": "-10%",
+																	"disabled": true
+																}
+															]
+														},
+														{
+															"id": "mMQG75mDuyATJ7rVM",
+															"name": "Unwilling",
+															"reference": "B38",
+															"cost_adj": "-50%",
+															"disabled": true
+														},
+														{
+															"id": "m9YwvW9Tkk73O0CWS",
+															"name": "Favor",
+															"reference": "B55",
+															"cost_adj": "x0.2",
+															"disabled": true
 														}
+													],
+													"calc": {
+														"points": 9
 													}
-												]
-											},
+												},
+												{
+													"id": "tKBEpV0lEUW1cyR8I",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Powers/Powers Traits.adq",
+														"id": "trTYPvJ5UMzNNlDpd"
+													},
+													"name": "Energy Reserve (@Source@)",
+													"reference": "P119",
+													"tags": [
+														"Advantage",
+														"Attribute",
+														"Exotic",
+														"Physical"
+													],
+													"replacements": {
+														"Source": "Psionic"
+													},
+													"modifiers": [
+														{
+															"id": "mcS8hugwqwsjddokm",
+															"name": "Abilities Only",
+															"reference": "P119",
+															"cost_adj": "-10%",
+															"disabled": true
+														},
+														{
+															"id": "mXiEpccYhHjZlTjlS",
+															"name": "One Power",
+															"reference": "P119",
+															"cost_adj": "-50%",
+															"disabled": true
+														},
+														{
+															"id": "m--zEseKTH9U_ql6G",
+															"name": "Slow Recharge",
+															"reference": "P119",
+															"local_notes": "1/hour",
+															"cost_adj": "-20%",
+															"disabled": true
+														},
+														{
+															"id": "mF6L7oNoaJXB_ZUQi",
+															"name": "Slow Recharge",
+															"reference": "P119",
+															"local_notes": "1/day",
+															"cost_adj": "-60%",
+															"disabled": true
+														},
+														{
+															"id": "mT10vvpiGIgMmVSRQ",
+															"name": "Special Recharge",
+															"reference": "P119",
+															"cost_adj": "-70%",
+															"disabled": true
+														},
+														{
+															"id": "mxIgl58l_iT9CTIKq",
+															"name": "Special Recharge",
+															"reference": "P119",
+															"local_notes": "1/s bleed",
+															"cost_adj": "-80%",
+															"disabled": true
+														},
+														{
+															"id": "mD89-j2JkTezjSVE8",
+															"name": "Stunts Only",
+															"reference": "P119",
+															"cost_adj": "-10%",
+															"disabled": true
+														},
+														{
+															"id": "meLdJepFW3AWG30uT",
+															"name": "Drains Familiar",
+															"cost_adj": "-50%"
+														}
+													],
+													"points_per_level": 3,
+													"can_level": true,
+													"levels": 6,
+													"calc": {
+														"points": 9,
+														"current_level": 6
+													}
+												},
+												{
+													"id": "tzMwCJ4dnxn_hO67o",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 5/Familiars.adq",
+														"id": "t0ZElGf8SsLX7AX24"
+													},
+													"name": "Special Rapport (Familiar)",
+													"reference": "B88",
+													"tags": [
+														"Advantage",
+														"Mental",
+														"Supernatural"
+													],
+													"modifiers": [
+														{
+															"id": "mZ4FePCXIgoCAf9_G",
+															"name": "One Way",
+															"reference": "P77",
+															"cost_adj": "20%",
+															"disabled": true
+														},
+														{
+															"id": "moooYZTwd1seHLzj9",
+															"name": "Transferable",
+															"reference": "P78",
+															"local_notes": "Own Race",
+															"cost_adj": "100%",
+															"disabled": true
+														},
+														{
+															"id": "mneTVtQBciA9RwOYO",
+															"name": "Transferable",
+															"reference": "P78",
+															"local_notes": "Living Being",
+															"cost_adj": "150%",
+															"disabled": true
+														},
+														{
+															"id": "mnWhsp8yUy-5Dbqsh",
+															"name": "Transferable",
+															"reference": "P78",
+															"local_notes": "Digital Minds",
+															"cost_adj": "150%",
+															"disabled": true
+														},
+														{
+															"id": "mcSefWHH6P9VtD_ke",
+															"name": "Transferable",
+															"reference": "P78",
+															"local_notes": "Any Sapient mind",
+															"cost_adj": "250%",
+															"disabled": true
+														},
+														{
+															"id": "mbjnN65o0UU7YlubM",
+															"name": "Must be Willing or Helpless",
+															"reference": "P78",
+															"cost_adj": "-50%",
+															"disabled": true
+														}
+													],
+													"base_points": 5,
+													"calc": {
+														"points": 5
+													}
+												}
+											],
 											"calc": {
-												"points": 0
+												"points": 23
 											}
 										},
 										{
-											"id": "t0CYJLXif0C34CKY6",
+											"id": "thR33DWe-0Ij3VlsY",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tTbrXtmW3JPV_TDeU"
+											},
 											"name": "Death Posession",
 											"reference": "DF15:20",
+											"local_notes": "Extra Life (Reincarnation, As defined in [Unkillable](B95), -20%)",
 											"tags": [
 												"Advantage",
 												"Exotic",
@@ -7621,16 +4159,8 @@
 												"all": true,
 												"prereqs": [
 													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Psi Talent"
-														},
-														"level": {
-															"compare": "at_least",
-															"qualifier": 1
-														}
+														"type": "script_prereq",
+														"script": "const msgtxt = []\nif (self.level > entity.traitLevel('Psi Talent')) { msgtxt.push(\"You do NOT have Enough Psi Talent!\"); } \nmsgtxt.join(\"\\n* \") "
 													}
 												]
 											},
@@ -7643,69 +4173,90 @@
 											}
 										},
 										{
-											"id": "tAhCrDhzJgMAl9evQ",
+											"id": "T0piQNym7waZkH6Mw",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "TrQFNeiMv9-j6g4Yq"
+											},
 											"name": "Defense Stunts",
 											"reference": "DF14:20",
-											"tags": [
-												"Advantage",
-												"Exotic",
-												"Mental",
-												"Psionics"
-											],
-											"prereqs": {
-												"type": "prereq_list",
-												"all": true,
-												"prereqs": [
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Ergokinetic Shield"
-														}
-													},
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Mind Shield"
-														}
-													},
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Psychic Armor"
-														}
-													}
-												]
-											},
-											"modifiers": [
+											"reference_highlight": "Defense Stunts",
+											"children": [
 												{
-													"id": "mQdHc2tF2PKZ9QdHH",
-													"name": "Extended Defense (@Ability@)",
+													"id": "tZBifPW_kgIWdhyqj",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tqyZyK5pFfR7kPuU7"
+													},
+													"name": "Extended Defense (@Ergokinetic Shield, Mind Shield, or Psychic Armor@)",
 													"reference": "DF14:21",
-													"cost_adj": "7",
-													"disabled": true
+													"reference_highlight": "Extended Defense",
+													"local_notes": "Whenever you extend your defense to protect others, ignore the -6 to the Will roll to do so.",
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "@Ergokinetic Shield, Mind Shield, or Psychic Armor@"
+																}
+															}
+														]
+													},
+													"base_points": 7,
+													"calc": {
+														"points": 7
+													}
 												},
 												{
-													"id": "mjXduARzTD0Ze5RZn",
-													"name": "Sudden Defense (@Ability@)",
+													"id": "tOBV57isFjLu1jIFM",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "t_BH08AicGTlwrSPa"
+													},
+													"name": "Sudden Defense (@Ergokinetic Shield, Mind Shield, or Psychic Armor@)",
 													"reference": "DF14:21",
-													"cost_adj": "5",
-													"disabled": true
+													"local_notes": "Ignore the -4 penalty to the WIll roll to raise your defense in response to an attack. The defense still can't be used if it's part of an Alternative Abilities set with another ability that's active.",
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "@Ergokinetic Shield, Mind Shield, or Psychic Armor@"
+																}
+															}
+														]
+													},
+													"base_points": 5,
+													"calc": {
+														"points": 5
+													}
 												}
 											],
 											"calc": {
-												"points": 0
+												"points": 12
 											}
 										},
 										{
-											"id": "tClJKGZeoo76I7bbe",
+											"id": "t2J2YFbdOlOV2_3tz",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "t9lejxxS0ZhvzT_ea"
+											},
 											"name": "Elder Lore",
 											"reference": "DF14:21",
+											"local_notes": "Detect (Elder Artifacts)",
 											"tags": [
 												"Advantage",
 												"Exotic",
@@ -7730,15 +4281,186 @@
 													}
 												]
 											},
-											"base_points": 8,
+											"modifiers": [
+												{
+													"id": "mkv4egHSdDrn9oJBP",
+													"name": "Analysis Only",
+													"reference": "PSI14",
+													"cost_adj": "-50%"
+												},
+												{
+													"id": "m-4xgjrj2gVeBwOWf",
+													"name": "Analyzing",
+													"reference": "P47",
+													"local_notes": "Immediate Preparation Required, 1hr, -75%  PU8:14",
+													"cost_adj": "+25%"
+												}
+											],
+											"base_points": 10,
 											"calc": {
 												"points": 8
 											}
 										},
 										{
-											"id": "t1h45Ox__xll8Osyd",
-											"name": "Mass Chaos (@Ability@)",
+											"id": "t0tx06zTXS1784Ita",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Powers/Powers Traits.adq",
+												"id": "trTYPvJ5UMzNNlDpd"
+											},
+											"name": "Energy Reserve (@Source@)",
+											"reference": "P119",
+											"tags": [
+												"Advantage",
+												"Attribute",
+												"Exotic",
+												"Physical"
+											],
+											"replacements": {
+												"Source": "Psionic"
+											},
+											"modifiers": [
+												{
+													"id": "mAD_5L1Q5e5UqS7P9",
+													"name": "Abilities Only",
+													"reference": "P119",
+													"cost_adj": "-10%",
+													"disabled": true
+												},
+												{
+													"id": "mS9ybYT-iwvz48mXH",
+													"name": "One Power",
+													"reference": "P119",
+													"cost_adj": "-50%",
+													"disabled": true
+												},
+												{
+													"id": "mH9yCBMdWF9AFLsLr",
+													"name": "Slow Recharge",
+													"reference": "P119",
+													"local_notes": "1/hour",
+													"cost_adj": "-20%",
+													"disabled": true
+												},
+												{
+													"id": "mPSQVcbVQXTqh6oyj",
+													"name": "Slow Recharge",
+													"reference": "P119",
+													"local_notes": "1/day",
+													"cost_adj": "-60%",
+													"disabled": true
+												},
+												{
+													"id": "mEnst7pQmU5qOnua9",
+													"name": "Special Recharge",
+													"reference": "P119",
+													"cost_adj": "-70%",
+													"disabled": true
+												},
+												{
+													"id": "m5unl0Ai2A7pcAtBX",
+													"name": "Special Recharge",
+													"reference": "P119",
+													"local_notes": "1/s bleed",
+													"cost_adj": "-80%",
+													"disabled": true
+												},
+												{
+													"id": "mO5xWvKgNkyE4vmex",
+													"name": "Stunts Only",
+													"reference": "P119",
+													"cost_adj": "-10%",
+													"disabled": true
+												}
+											],
+											"points_per_level": 3,
+											"can_level": true,
+											"levels": 1,
+											"calc": {
+												"points": 3,
+												"current_level": 1
+											}
+										},
+										{
+											"id": "tQKDOxGX-Z_tdcUT0",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tpqxCsRu8W1w0NZPS"
+											},
+											"name": "Extraordinary Luck",
+											"reference": "B66",
+											"local_notes": "Usable once per 30 minutes of play",
+											"tags": [
+												"Advantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mI_uD2eVfUGXlDDye",
+													"name": "Active",
+													"reference": "B66",
+													"cost_adj": "-40%",
+													"disabled": true
+												},
+												{
+													"id": "mtw3LavdVorCjudUS",
+													"name": "Aspected",
+													"reference": "B66",
+													"local_notes": "@Aspect@",
+													"cost_adj": "-20%",
+													"disabled": true
+												},
+												{
+													"id": "mdPGU5c1gX_akLeam",
+													"name": "Defensive",
+													"reference": "B66",
+													"cost_adj": "-20%",
+													"disabled": true
+												},
+												{
+													"id": "muH3SXIg38UkhC7kE",
+													"name": "Wishing",
+													"reference": "P59",
+													"cost_adj": "100%",
+													"disabled": true
+												},
+												{
+													"id": "ms3rEhUaYtW3h-_nq",
+													"name": "Game Time",
+													"reference": "P108",
+													"local_notes": "Uses per game day equal to its maximum possible uses per real hour",
+													"disabled": true
+												}
+											],
+											"base_points": 30,
+											"calc": {
+												"points": 30
+											}
+										},
+										{
+											"id": "tWdlShqZ-Rmtvtti_",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tNHRFdMy-9bwHStcI"
+											},
+											"name": "Feature: Will has a cap of 25 before racial modifiers",
+											"reference": "DF14:19",
+											"calc": {
+												"points": 0
+											}
+										},
+										{
+											"id": "toyofvmCn5QP0yfzt",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tBbMmeSmTJyAfIoSJ"
+											},
+											"name": "Mass Chaos (@Fear, Madness, Mind Blast@)",
 											"reference": "DF14:21",
+											"local_notes": "Adds Area of Effect 1 to @Fear, Madness, Mind Blast@ for an extra 2 FP cost",
 											"tags": [
 												"Advantage",
 												"Exotic",
@@ -7754,23 +4476,7 @@
 														"has": true,
 														"name": {
 															"compare": "is",
-															"qualifier": "Fear"
-														}
-													},
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Madness"
-														}
-													},
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Mind Blast"
+															"qualifier": "@Fear, Madness, Mind Blast@"
 														}
 													}
 												]
@@ -7781,37 +4487,196 @@
 											}
 										},
 										{
-											"id": "tE0IN-ps8_le1iN9z",
+											"id": "Ty2i2LJjGzMY-6pT6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "TMq1FvDBJ_JvGzqrm"
+											},
 											"name": "Mind-Reading Stunts",
 											"reference": "DF14:21",
-											"tags": [
-												"Advantage",
-												"Exotic",
-												"Mental",
-												"Psionics"
-											],
-											"modifiers": [
+											"reference_highlight": "Mind-Reading Stunts",
+											"children": [
 												{
-													"id": "mviLXw_jRkXz8QkXW",
-													"name": "Your Eyes Are My Eyes (@Ability@)",
+													"id": "tvDXsAf2rzN6A0Hle",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tx0nV3F_NtxpkaZzj"
+													},
+													"name": "Your Eyes Are My Eyes (Mind Reading)",
 													"reference": "DF14:21",
-													"cost_adj": "4",
-													"disabled": true
+													"reference_highlight": "Your Eyes Are My Eyes",
+													"local_notes": "You experience their senses as well as picking up surface thoughts. Costs an extra 2FP/minute to use.",
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Mind Reading"
+																}
+															},
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Psi Talent"
+																},
+																"level": {
+																	"compare": "at_least",
+																	"qualifier": 1
+																}
+															}
+														]
+													},
+													"base_points": 4,
+													"calc": {
+														"points": 4
+													}
 												},
 												{
-													"id": "myzoR462fYMz7_e9W",
-													"name": "Your Tongue Is My Tongue (@Ability@)",
+													"id": "tY-l_HujL-DLcVWdS",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tmvDFnmx9wPHw2Mv7"
+													},
+													"name": "Your Eyes Are My Eyes (Mind Meld)",
 													"reference": "DF14:21",
-													"cost_adj": "7",
-													"disabled": true
+													"reference_highlight": "Your Eyes Are My Eyes",
+													"local_notes": "You experience vivid replays of their senses as well as their thoughts. Costs an extra 2FP/minute to use.",
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Mind Meld"
+																}
+															},
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Psi Talent"
+																},
+																"level": {
+																	"compare": "at_least",
+																	"qualifier": 1
+																}
+															}
+														]
+													},
+													"base_points": 4,
+													"calc": {
+														"points": 4
+													}
+												},
+												{
+													"id": "tbFaeGB047uF-om1_",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tpbxjClBi6YskLI_5"
+													},
+													"name": "Your Tongue Is My Tongue (Mind Reading)",
+													"reference": "DF14:21",
+													"reference_highlight": "Your Tongue Is My Tongue",
+													"local_notes": "You can understand their thoughts without understanding their language. Even for Elder Things! Costs an extra 2FP/minute to use.",
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Mind Reading"
+																}
+															},
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Psi Talent"
+																},
+																"level": {
+																	"compare": "at_least",
+																	"qualifier": 2
+																}
+															}
+														]
+													},
+													"base_points": 7,
+													"calc": {
+														"points": 7
+													}
+												},
+												{
+													"id": "tJ2bdpgXktBlK0r9D",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tgw0MCzUXbV_EtQ9s"
+													},
+													"name": "Your Tongue Is My Tongue (Mind Meld)",
+													"reference": "DF14:21",
+													"reference_highlight": "Your Tongue Is My Tongue",
+													"local_notes": "You can understand their thoughts without understanding their language. Even for Elder Things! Costs an extra 2FP/minute to use.",
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Mind Meld"
+																}
+															},
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Psi Talent"
+																},
+																"level": {
+																	"compare": "at_least",
+																	"qualifier": 2
+																}
+															}
+														]
+													},
+													"base_points": 7,
+													"calc": {
+														"points": 7
+													}
 												}
 											],
 											"calc": {
-												"points": 0
+												"points": 22
 											}
 										},
 										{
-											"id": "t2n5LuyaDoeH-7O02",
+											"id": "tf1ptDPVBbBX4Z1Em",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tuEne7lERZ_MrZz3N"
+											},
 											"name": "Psientist",
 											"reference": "DF14:21",
 											"tags": [
@@ -7907,9 +4772,15 @@
 											}
 										},
 										{
-											"id": "tevuJEwFybzKNdrOz",
+											"id": "tx2lzbze8uN4wXguc",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tT4zYGXDC5Jgz7MiT"
+											},
 											"name": "Residue Sense",
 											"reference": "DF14:21",
+											"local_notes": "Psychic Sensitivity can detect psi activity in the past for an extra 2 FP cost",
 											"tags": [
 												"Advantage",
 												"Exotic",
@@ -7944,9 +4815,72 @@
 											}
 										},
 										{
-											"id": "tBIfqMmIrtKLy7m-D",
+											"id": "t5iEP9xCcXNJx0GFS",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tzcAVOHp3Wd0BY361"
+											},
+											"name": "Ridiculous Luck",
+											"reference": "B66",
+											"local_notes": "Usable once per 10 minutes of play",
+											"tags": [
+												"Advantage",
+												"Mental"
+											],
+											"modifiers": [
+												{
+													"id": "mI8_wJBkOJGR1Vzwz",
+													"name": "Active",
+													"reference": "B66",
+													"cost_adj": "-40%",
+													"disabled": true
+												},
+												{
+													"id": "mXHkMPd5U1IRoKDP8",
+													"name": "Aspected",
+													"reference": "B66",
+													"local_notes": "@Aspect@",
+													"cost_adj": "-20%",
+													"disabled": true
+												},
+												{
+													"id": "m2lUkotvngoluW2bc",
+													"name": "Defensive",
+													"reference": "B66",
+													"cost_adj": "-20%",
+													"disabled": true
+												},
+												{
+													"id": "mLVZ8AhXxKTM8WuDe",
+													"name": "Wishing",
+													"reference": "P59",
+													"cost_adj": "100%",
+													"disabled": true
+												},
+												{
+													"id": "mppcS-x2RBohU7uS0",
+													"name": "Game Time",
+													"reference": "P108",
+													"local_notes": "Uses per game day equal to its maximum possible uses per real hour",
+													"disabled": true
+												}
+											],
+											"base_points": 60,
+											"calc": {
+												"points": 60
+											}
+										},
+										{
+											"id": "tYjiDREdSUbulnZBO",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "t0avOzBlHoCiam5X4"
+											},
 											"name": "Second Nature",
 											"reference": "DF14:21",
+											"local_notes": "Comparmentalized Mind",
 											"tags": [
 												"Advantage",
 												"Exotic",
@@ -7958,20 +4892,19 @@
 												"all": true,
 												"prereqs": [
 													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Psi Talent"
-														},
-														"level": {
-															"compare": "at_least",
-															"qualifier": 5
-														}
+														"type": "script_prereq",
+														"script": "const msgtxt = []\nif (self.level > 2) { msgtxt.push(\"Maximum Trait Level is 2!\"); }\nif (self.level > Math.max(0,entity.traitLevel('Psi Talent')) - 4) { msgtxt.push(\"You do NOT have Enough Psi Talent!\"); } \nmsgtxt.join(\"\\n* \") "
 													}
 												]
 											},
-											"points_per_level": 45,
+											"modifiers": [
+												{
+													"id": "mG8zDrtMUy_VDinpm",
+													"name": "Limited (Psi)",
+													"cost_adj": "-10%"
+												}
+											],
+											"points_per_level": 50,
 											"can_level": true,
 											"levels": 1,
 											"calc": {
@@ -7980,45 +4913,59 @@
 											}
 										},
 										{
-											"id": "tPok0Ll9LIpvTUxlF",
-											"name": "Second Nature",
-											"reference": "DF14:21",
+											"id": "tEaDpN1UxenKeY7PG",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tkiJQ7nfyi9aAdGHK"
+											},
+											"name": "Serendipity",
+											"reference": "B83,P73",
 											"tags": [
 												"Advantage",
-												"Exotic",
-												"Mental",
-												"Psionics"
+												"Mental"
 											],
-											"prereqs": {
-												"type": "prereq_list",
-												"all": true,
-												"prereqs": [
-													{
-														"type": "trait_prereq",
-														"has": true,
-														"name": {
-															"compare": "is",
-															"qualifier": "Psi Talent"
-														},
-														"level": {
-															"compare": "at_least",
-															"qualifier": 6
-														}
-													}
-												]
-											},
-											"points_per_level": 45,
+											"modifiers": [
+												{
+													"id": "m7ojts4oUPu5FBTDi",
+													"name": "Wishing",
+													"reference": "P73",
+													"cost_adj": "100%",
+													"disabled": true
+												},
+												{
+													"id": "mKo6nmssUcKK--td7",
+													"name": "Wishing",
+													"reference": "P73",
+													"local_notes": "For others only",
+													"disabled": true
+												},
+												{
+													"id": "mbssM4jPqnTye2NHx",
+													"name": "Game Time",
+													"reference": "P108",
+													"local_notes": "Uses per game week equal to its maximum possible uses per session",
+													"disabled": true
+												}
+											],
+											"points_per_level": 15,
 											"can_level": true,
-											"levels": 2,
+											"levels": 1,
 											"calc": {
-												"points": 90,
-												"current_level": 2
+												"points": 15,
+												"current_level": 1
 											}
 										},
 										{
-											"id": "tpjW08TP3g5Oq9_gB",
+											"id": "tOQYSzUxMhIoqkgn1",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tsnFlxTlQC-C3sbFs"
+											},
 											"name": "Speed of Thought",
 											"reference": "DF14:22",
+											"local_notes": "Enhanced Time Sense",
 											"tags": [
 												"Advantage",
 												"Exotic",
@@ -8043,59 +4990,430 @@
 													}
 												]
 											},
-											"base_points": 36,
+											"modifiers": [
+												{
+													"id": "mTonJ9OXwexCl5LYy",
+													"name": "Psionics Only",
+													"cost_adj": "-20%"
+												}
+											],
+											"base_points": 45,
 											"calc": {
 												"points": 36
 											}
 										},
 										{
-											"id": "tCbmq5Oa-HJ6a-WnL",
-											"name": "Telesend Stunts",
-											"reference": "DF14:22",
+											"id": "tastmrL_4jWY-andk",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Traits.adq",
+												"id": "tQ3xiqvixTRB9d7zT"
+											},
+											"name": "Talent (Smooth Operator)",
+											"reference": "B90,PU3:15",
 											"tags": [
 												"Advantage",
-												"Exotic",
 												"Mental",
-												"Psionics"
+												"Talent"
 											],
 											"modifiers": [
 												{
-													"id": "mcmq9U_DX20xGGbhU",
-													"name": "Coordinator",
-													"reference": "DF14:22",
-													"cost_adj": "9",
+													"id": "mZPHCLDW613Z1sGD2",
+													"name": "Alternate Benefit",
+													"local_notes": "Bonus to resist covered skills",
 													"disabled": true
 												},
 												{
-													"id": "mR13sbQRKY8JOe64K",
-													"name": "Mr. Universe",
-													"reference": "DF14:22",
-													"cost_adj": "7",
-													"disabled": true
-												},
-												{
-													"id": "mYrWEHvGWOVR6yFLe",
-													"name": "Spotter 1",
-													"reference": "DF14:22",
-													"cost_adj": "6",
-													"disabled": true
-												},
-												{
-													"id": "miEvHA4bvDzd-f_4h",
-													"name": "Spotter 2",
-													"reference": "DF14:22",
-													"cost_adj": "10",
+													"id": "mFs1SfnChNEo3mmoK",
+													"name": "Alternative Cost",
+													"cost_adj": "-2",
+													"affects": "levels_only",
 													"disabled": true
 												}
 											],
+											"points_per_level": 15,
+											"features": [
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Acting"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Carousing"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Detect Lies"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Diplomacy"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Fast-Talk"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Intimidation"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Leadership"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Panhandling"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Politics"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Public Speaking"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Savoir-Faire"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Sex Appeal"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is",
+														"qualifier": "Streetwise"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "skill_bonus",
+													"selection_type": "skills_with_name",
+													"name": {
+														"compare": "is"
+													},
+													"amount": 1,
+													"per_level": true
+												},
+												{
+													"type": "reaction_bonus",
+													"situation": "from con artists, politicians, salesmen, etc. – but only if you aren’t trying to manipulate them.",
+													"amount": 1,
+													"per_level": true
+												}
+											],
+											"can_level": true,
+											"levels": 1,
 											"calc": {
-												"points": 0
+												"points": 15,
+												"current_level": 1
 											}
 										},
 										{
-											"id": "tng8-Rn-OUPxLYOB4",
+											"id": "TAhMq5pyCRxUdL6_I",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "TiOQiGTQ0lKePDWDT"
+											},
+											"name": "Telesend Stunts",
+											"reference": "DF14:22",
+											"reference_highlight": "Telesend Stunts",
+											"children": [
+												{
+													"id": "tJ97Tjm5DF-HBo0_9",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tvHIfKImVRVZxgXtK"
+													},
+													"name": "Coordinator",
+													"reference": "DF14:22",
+													"reference_highlight": "Coordinator",
+													"local_notes": "Send thoughts to as many people as you want, at the range penalty of the most-distant subject and an extra -4. Costs an extra 2 FP/minute.",
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Psi Talent"
+																},
+																"level": {
+																	"compare": "at_least",
+																	"qualifier": 3
+																}
+															},
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Telesend"
+																}
+															}
+														]
+													},
+													"base_points": 9,
+													"features": [
+														{
+															"type": "conditional_modifier",
+															"situation": "to coordinated ambushes, and Advice, Encouragement and Observation from [Onward to Victory!](DF2:11) when using Telesend (Coordinator)",
+															"amount": 4
+														}
+													],
+													"calc": {
+														"points": 9
+													}
+												},
+												{
+													"id": "tt1EyfirGKPzK0vPq",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tes3x4R1e1moc9gqA"
+													},
+													"name": "Mr. Universe",
+													"reference": "DF14:22",
+													"reference_highlight": "Mr. Universe",
+													"local_notes": "Thoughts sent are understood by any sapient, regardless of language. costs an extra 2 FP/minute.",
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Psi Talent"
+																},
+																"level": {
+																	"compare": "at_least",
+																	"qualifier": 2
+																}
+															},
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Telesend"
+																}
+															}
+														]
+													},
+													"base_points": 7,
+													"calc": {
+														"points": 7
+													}
+												},
+												{
+													"id": "tSAGOFNzyEBvcUvEk",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tioRylRSutTn6ZGbX"
+													},
+													"name": "Spotter 1",
+													"reference": "DF14:22",
+													"reference_highlight": "Spotter",
+													"local_notes": "Share your vision with the subject. Spellcasters can use your vision to cast spells as if they can see the target, range penalties are unaffected.",
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Telesend"
+																}
+															},
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Psi Talent"
+																},
+																"level": {
+																	"compare": "at_least",
+																	"qualifier": 2
+																}
+															}
+														]
+													},
+													"base_points": 6,
+													"calc": {
+														"points": 6
+													}
+												},
+												{
+													"id": "tA4iJy5V7LkIk0Q8W",
+													"source": {
+														"library": "richardwilkes/gcs_master_library",
+														"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+														"id": "tqwFsu_1D-uHBbzwu"
+													},
+													"name": "Spotter 2",
+													"reference": "DF14:22",
+													"reference_highlight": "Spotter",
+													"local_notes": "Share all of your senses with the subject. Spellcasters can use your vision to cast spells as if they can see the target, range penalties are unaffected.",
+													"prereqs": {
+														"type": "prereq_list",
+														"all": true,
+														"prereqs": [
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Telesend"
+																}
+															},
+															{
+																"type": "trait_prereq",
+																"has": true,
+																"name": {
+																	"compare": "is",
+																	"qualifier": "Psi Talent"
+																},
+																"level": {
+																	"compare": "at_least",
+																	"qualifier": 4
+																}
+															}
+														]
+													},
+													"base_points": 10,
+													"calc": {
+														"points": 10
+													}
+												}
+											],
+											"calc": {
+												"points": 32
+											}
+										},
+										{
+											"id": "tS_1kY-cZvQq3L48T",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tON-_y6aueHM7rkGk"
+											},
 											"name": "True Will",
 											"reference": "DF14:22",
+											"local_notes": "Protected Power (Psionics)",
 											"tags": [
 												"Advantage",
 												"Exotic",
@@ -8127,12 +5445,323 @@
 										}
 									],
 									"calc": {
-										"points": 231
+										"points": 353
+									}
+								},
+								{
+									"id": "TTl5AiDX1C-LfDMh6",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "T9sbajfExnpml3GMl"
+									},
+									"name": "Psi Perks",
+									"reference": "DF14:14",
+									"reference_highlight": "Psi Perks",
+									"local_notes": "to a maximum of one perk per 10 full points total in Psi Talent, Psionics abilities, and psi-related skills. For dedicated mentalists, this limit will rarely matter!",
+									"children": [
+										{
+											"id": "texDHDcGBZ46euOWI",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tcuO-BLXXd_imjqq1"
+											},
+											"name": "Perk (Focused Resistance)",
+											"reference": "DF14:14",
+											"reference_highlight": "Focused Resistance",
+											"local_notes": "**@resist one specific Psionics ability,spell, Enthrallment skill, or monster attack that targets IQ or Will@**<br>This is cumulative with other bonuses to resist.",
+											"tags": [
+												"Mental",
+												"Perk"
+											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Unusual Background (Psionic)"
+														}
+													}
+												]
+											},
+											"base_points": 1,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "to resist @resist one specific Psionics ability,spell, Enthrallment skill, or monster attack that targets IQ or Will@",
+													"amount": 3
+												}
+											],
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tiR7iAl4sQtBLx-TU",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tfpbL_5feCpNHXVyg"
+											},
+											"name": "Perk (Gazer)",
+											"reference": "DF14:14",
+											"reference_highlight": "Gazer",
+											"local_notes": "Replace regular Innate Attack (Gaze) with a Per-based one",
+											"tags": [
+												"Mental",
+												"Perk"
+											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Unusual Background (Psionic)"
+														}
+													}
+												]
+											},
+											"base_points": 1,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tLmFNbbogpi6WmyoK",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tyoMXlZdGiHssPk9a"
+											},
+											"name": "Perk (Hilfe!)",
+											"reference": "DF14:14",
+											"reference_highlight": "Hilfe!",
+											"local_notes": "When you're in danger you can send out a call for help detectable by any party member who's been on at least 2 adventures with you and passes a Perception +Psi Talent roll. But only to know that you're in trouble.",
+											"tags": [
+												"Mental",
+												"Perk"
+											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Unusual Background (Psionic)"
+														}
+													}
+												]
+											},
+											"base_points": 1,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tgGj8mGUfD5xvkkkf",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tPTedUv0DDrSy0ayj"
+											},
+											"name": "Perk (Psharp)",
+											"reference": "DF14:14",
+											"reference_highlight": "Psharp",
+											"local_notes": "Use Psight to cheat at [Gambling](DF2:4). Claim a +1 to +3 bonus to the skill roll but make a reaction roll at -1 to -3 respectively. On a [Bad](BX560) reaction you're caught cheating.",
+											"tags": [
+												"Mental",
+												"Perk"
+											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Unusual Background (Psionic)"
+														}
+													}
+												]
+											},
+											"base_points": 1,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "ts8uZEvn2yC34mcys",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tmrQgcoQi8yFJ_I5m"
+											},
+											"name": "Perk (Psychic Replica @Signature Gear@)",
+											"reference": "DF14:14",
+											"reference_highlight": "Psychic Replica",
+											"local_notes": "A designated piece of Signature Gear weighing up to BL appears with you when you project into another plane.",
+											"tags": [
+												"Equipment",
+												"Perk"
+											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Unusual Background (Psionic)"
+														}
+													}
+												]
+											},
+											"base_points": 1,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "t083AnNPdaxOeivSh",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "tE8FlntN5oDKW_d7k"
+											},
+											"name": "Perk (Psychic Terror)",
+											"reference": "DF14:14",
+											"reference_highlight": "Psychic Terror",
+											"local_notes": "If you do not have any form of Terror, failing to read your mind causes a Fright Check the first time it happens. If you _do_ have a form of Terror (including [Fear](DF14:6)), it instead activates for free even on a successful mind read.",
+											"tags": [
+												"Mental",
+												"Perk"
+											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Unusual Background (Psionic)"
+														}
+													}
+												]
+											},
+											"base_points": 1,
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tq_p6upIMg01CvYaa",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "t-5KfznFRvunEzZTM"
+											},
+											"name": "Perk (Telekinetic Tether @Signature Gear@)",
+											"reference": "DF14:14",
+											"reference_highlight": "Telekinetic Tether",
+											"local_notes": "A designated piece of Signature Gear weighing up to BL can be summoed to your hand from up to 2yds away if not restrained. If already in reach it's easier to fast-draw.",
+											"tags": [
+												"Equipment",
+												"Perk"
+											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Unusual Background (Psionic)"
+														}
+													}
+												]
+											},
+											"base_points": 1,
+											"features": [
+												{
+													"type": "conditional_modifier",
+													"situation": "to fast-draw @Signature Gear@",
+													"amount": 4
+												}
+											],
+											"calc": {
+												"points": 1
+											}
+										},
+										{
+											"id": "tQGbO6HlwuVJzSL75",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+												"id": "t9YufpTv3AxsWnWvx"
+											},
+											"name": "Perk (Weird Dreams CR@Self-control roll@)",
+											"reference": "DF14:14",
+											"reference_highlight": "Weird Dreams",
+											"local_notes": "Like [Nightmares](B144) you have unsettling dreams on a failed roll against @Self-control roll@, but they also include useful clues about today's activities. Lost FP can be paid from Energy Reserve (Psionic) or a psionic power item but won't recover without rest.",
+											"tags": [
+												"Mental",
+												"Perk"
+											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": false,
+														"name": {
+															"compare": "is",
+															"qualifier": "Nightmares"
+														}
+													},
+													{
+														"type": "trait_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Unusual Background (Psionic)"
+														}
+													}
+												]
+											},
+											"base_points": 1,
+											"calc": {
+												"points": 1
+											}
+										}
+									],
+									"calc": {
+										"points": 8
 									}
 								}
 							],
 							"calc": {
-								"points": 2777
+								"points": 1426
 							}
 						},
 						{
@@ -8140,206 +5769,28 @@
 							"name": "25 Points chosen from the above or:",
 							"children": [
 								{
-									"id": "tHVrmm1A9dXezuDjh",
-									"name": "Increased Strength",
-									"reference": "B14",
-									"tags": [
-										"Advantage",
-										"Attribute",
-										"Physical"
-									],
-									"modifiers": [
-										{
-											"id": "m42g2YTlgEfFc3_zZ",
-											"name": "No Fine Manipulators",
-											"reference": "B15",
-											"cost_adj": "-40%",
-											"disabled": true
-										},
-										{
-											"id": "mv0IT9_pu8X-T70id",
-											"name": "Size",
-											"reference": "B15",
-											"cost_adj": "-10%",
-											"levels": 1,
-											"disabled": true
-										},
-										{
-											"id": "m1bkAr3dmKaH8FyUR",
-											"name": "Super-Effort",
-											"reference": "SU24",
-											"cost_adj": "300%",
-											"disabled": true
-										}
-									],
-									"points_per_level": 10,
-									"features": [
-										{
-											"type": "attribute_bonus",
-											"attribute": "st",
-											"amount": 1,
-											"per_level": true
-										}
-									],
-									"can_level": true,
-									"levels": 1,
-									"calc": {
-										"points": 10,
-										"current_level": 1
-									}
-								},
-								{
-									"id": "tpiT7LSDJL8g7YPEN",
-									"name": "Increased Dexterity",
-									"reference": "B15",
-									"tags": [
-										"Advantage",
-										"Attribute",
-										"Physical"
-									],
-									"modifiers": [
-										{
-											"id": "mA_P6sIaaxaoL0pcz",
-											"name": "No Fine Manipulators",
-											"cost_adj": "-40%",
-											"disabled": true
-										}
-									],
-									"points_per_level": 20,
-									"features": [
-										{
-											"type": "attribute_bonus",
-											"attribute": "dx",
-											"amount": 1,
-											"per_level": true
-										}
-									],
-									"can_level": true,
-									"levels": 1,
-									"calc": {
-										"points": 20,
-										"current_level": 1
-									}
-								},
-								{
-									"id": "tGlXButeDdt5T3mvX",
-									"name": "Increased Intelligence",
-									"reference": "B15",
-									"tags": [
-										"Advantage",
-										"Attribute",
-										"Mental"
-									],
-									"points_per_level": 20,
-									"features": [
-										{
-											"type": "attribute_bonus",
-											"attribute": "iq",
-											"amount": 1,
-											"per_level": true
-										}
-									],
-									"can_level": true,
-									"levels": 1,
-									"calc": {
-										"points": 20,
-										"current_level": 1
-									}
-								},
-								{
-									"id": "tQJGdLeoTUOxnpT42",
-									"name": "Increased Will",
-									"reference": "B16",
-									"tags": [
-										"Advantage",
-										"Attribute",
-										"Mental"
-									],
-									"points_per_level": 5,
-									"features": [
-										{
-											"type": "attribute_bonus",
-											"attribute": "will",
-											"amount": 1,
-											"per_level": true
-										}
-									],
-									"can_level": true,
-									"levels": 1,
-									"calc": {
-										"points": 5,
-										"current_level": 1
-									}
-								},
-								{
-									"id": "tWq1PAl8VllGcR5NY",
-									"name": "Increased Perception",
-									"reference": "B16",
-									"tags": [
-										"Advantage",
-										"Attribute",
-										"Mental",
-										"Physical"
-									],
-									"points_per_level": 5,
-									"features": [
-										{
-											"type": "attribute_bonus",
-											"attribute": "per",
-											"amount": 1,
-											"per_level": true
-										}
-									],
-									"can_level": true,
-									"levels": 1,
-									"calc": {
-										"points": 5,
-										"current_level": 1
-									}
-								},
-								{
-									"id": "t7LT3JIyYkCwdEvDf",
-									"name": "Extra Fatigue Points",
-									"reference": "B16",
-									"tags": [
-										"Advantage",
-										"Attribute",
-										"Physical"
-									],
-									"points_per_level": 3,
-									"features": [
-										{
-											"type": "attribute_bonus",
-											"attribute": "fp",
-											"amount": 1,
-											"per_level": true
-										}
-									],
-									"can_level": true,
-									"levels": 1,
-									"calc": {
-										"points": 3,
-										"current_level": 1
-									}
-								},
-								{
-									"id": "tcDLbX-Ze-H4CpUyD",
+									"id": "t_9Yum-LuxR-fDM_I",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tZTGYpVyvbfhURaxn"
+									},
 									"name": "Animal Empathy",
-									"reference": "B40",
+									"reference": "B40,P48",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
 									"modifiers": [
 										{
-											"id": "mwV_EBQcBKQShecWK",
+											"id": "mQAowaTBDpVUKpdce",
 											"name": "Remote",
 											"reference": "P48",
 											"cost_adj": "50%",
 											"disabled": true
 										},
 										{
-											"id": "mUcY9QcH7RQULCMYA",
+											"id": "mboOqHxvVgR4voHwT",
 											"name": "Specialized",
 											"reference": "B87",
 											"local_notes": "All aquatic animals",
@@ -8347,7 +5798,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mJtuJwRcWRBUQ6Y_Q",
+											"id": "mJMWsoHifM7r_9uQ6",
 											"name": "Specialized",
 											"reference": "B87",
 											"local_notes": "All land animals",
@@ -8355,7 +5806,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mT5GiTnttcXwTHuOB",
+											"id": "mg4xZgYttebhPJprD",
 											"name": "Specialized",
 											"reference": "B87",
 											"local_notes": "@One class: Mammals, Birds, etc.@",
@@ -8363,7 +5814,7 @@
 											"disabled": true
 										},
 										{
-											"id": "m1TSi23tWekRQgQoL",
+											"id": "mlGNGOlRPpTLRu5O9",
 											"name": "Specialized",
 											"reference": "B87",
 											"local_notes": "@One family: Felines, Parrots, etc.@",
@@ -8371,7 +5822,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mUGJ3vfN3tgrFx_Ay",
+											"id": "mPVi1hTIqkXN-_nxF",
 											"name": "Specialized",
 											"reference": "B87",
 											"local_notes": "@One species: House Cats, Macaws, etc.@",
@@ -8385,7 +5836,12 @@
 									}
 								},
 								{
-									"id": "t9gLnLqlQ-modheIu",
+									"id": "tmLQiih9jPyOui-W4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tMMQWflrKUPOkyIF9"
+									},
 									"name": "Charisma",
 									"reference": "B41",
 									"tags": [
@@ -8455,9 +5911,14 @@
 									}
 								},
 								{
-									"id": "tRCQXVheO0iyRY0mW",
+									"id": "t2FvUwK7S7wzjZBeU",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tgjE-yMzESTjq695x"
+									},
 									"name": "Danger Sense",
-									"reference": "B47",
+									"reference": "B47,P46",
 									"tags": [
 										"Advantage",
 										"Mental"
@@ -8468,52 +5929,12 @@
 									}
 								},
 								{
-									"id": "t5pQW11HqBpfkX70K",
-									"name": "Luck",
-									"reference": "B66",
-									"local_notes": "Usable once per hour of play",
-									"tags": [
-										"Advantage",
-										"Mental"
-									],
-									"modifiers": [
-										{
-											"id": "mZieZU9ts7v_2PruO",
-											"name": "Active",
-											"reference": "B66",
-											"cost_adj": "-40%",
-											"disabled": true
-										},
-										{
-											"id": "m_DM8U5mZdm9ExiTW",
-											"name": "Aspected",
-											"reference": "B66",
-											"local_notes": "@Aspect@",
-											"cost_adj": "-20%",
-											"disabled": true
-										},
-										{
-											"id": "mUMCNKWpg-0wmCT2D",
-											"name": "Defensive",
-											"reference": "B66",
-											"cost_adj": "-20%",
-											"disabled": true
-										},
-										{
-											"id": "mD8FUHr8HTU1intak",
-											"name": "Wishing",
-											"reference": "P59",
-											"cost_adj": "100%",
-											"disabled": true
-										}
-									],
-									"base_points": 15,
-									"calc": {
-										"points": 15
-									}
-								},
-								{
-									"id": "tqgoIqHAn-UvELUxT",
+									"id": "tBF2CEhFjn_f1abxt",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tW-eAzIKBWa5Yc9cI"
+									},
 									"name": "Eidetic Memory",
 									"reference": "B51",
 									"tags": [
@@ -8522,7 +5943,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mpYijHkMO7zBnjP99",
+											"id": "mXE3JaK5XOWOiFabl",
 											"name": "Photographic",
 											"reference": "B51",
 											"cost_adj": "5",
@@ -8535,17 +5956,291 @@
 									}
 								},
 								{
-									"id": "tgFFTVtuFdWqSv4tW",
+									"id": "tVNlwJrDfCCfshuCC",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tsIfS0jZqdshsDFOM"
+									},
+									"name": "Extra Fatigue Points",
+									"reference": "B16",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Physical"
+									],
+									"points_per_level": 3,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "fp",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 3,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "ta9gRAsJ8xWfWQlW2",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tGWOSEE6SmBHACE6Y"
+									},
+									"name": "Increased Dexterity",
+									"reference": "B15",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "m7QUf2nC--5yzRRVG",
+											"name": "No Fine Manipulators",
+											"cost_adj": "-40%",
+											"disabled": true
+										}
+									],
+									"points_per_level": 20,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "dx",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 20,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tGCyLKjWWiyOYsJ7X",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t1w1RFcFceKR2T9_e"
+									},
+									"name": "Increased Intelligence",
+									"reference": "B15",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental"
+									],
+									"points_per_level": 20,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "iq",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 20,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tlwsIRJbv3n9GKx3c",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tmpxhXmSORakqvrbn"
+									},
+									"name": "Increased Perception",
+									"reference": "B16",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental",
+										"Physical"
+									],
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "per",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 5,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tqeFpUmRWNM8hPEp9",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tqha9GlDBU9P-Wg-6"
+									},
+									"name": "Increased Strength",
+									"reference": "B14",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Physical"
+									],
+									"modifiers": [
+										{
+											"id": "miv4HjoMvTyagf9k2",
+											"name": "No Fine Manipulators",
+											"reference": "B15",
+											"cost_adj": "-40%",
+											"disabled": true
+										},
+										{
+											"id": "maBNqBBiEAawo_7Iw",
+											"name": "Size",
+											"reference": "B15",
+											"cost_adj": "-10%",
+											"levels": 1,
+											"disabled": true
+										},
+										{
+											"id": "mzNnZ10eajo_ny46R",
+											"name": "Super-Effort",
+											"reference": "SU24",
+											"cost_adj": "300%",
+											"disabled": true
+										}
+									],
+									"points_per_level": 10,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "st",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 10,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tOEOFqS0UGZ528IQm",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tERWfEKV80M6toQn3"
+									},
+									"name": "Increased Will",
+									"reference": "B16",
+									"tags": [
+										"Advantage",
+										"Attribute",
+										"Mental"
+									],
+									"points_per_level": 5,
+									"features": [
+										{
+											"type": "attribute_bonus",
+											"attribute": "will",
+											"amount": 1,
+											"per_level": true
+										}
+									],
+									"can_level": true,
+									"levels": 1,
+									"calc": {
+										"points": 5,
+										"current_level": 1
+									}
+								},
+								{
+									"id": "tPgIEuRKfg6RN59Mj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tz-USDL9B_KrrVqDi"
+									},
+									"name": "Luck",
+									"reference": "B66,P59",
+									"local_notes": "Usable once per hour of play",
+									"tags": [
+										"Advantage",
+										"Mental"
+									],
+									"modifiers": [
+										{
+											"id": "mOtW73lDsEuICuCyo",
+											"name": "Active",
+											"reference": "B66",
+											"cost_adj": "-40%",
+											"disabled": true
+										},
+										{
+											"id": "mqelsHSW4UqQLeiqJ",
+											"name": "Aspected",
+											"reference": "B66",
+											"local_notes": "@Aspect@",
+											"cost_adj": "-20%",
+											"disabled": true
+										},
+										{
+											"id": "mDohj_aZ7hk8iI5r2",
+											"name": "Defensive",
+											"reference": "B66",
+											"cost_adj": "-20%",
+											"disabled": true
+										},
+										{
+											"id": "m_dwfQdcBvoBjChGy",
+											"name": "Wishing",
+											"reference": "P59",
+											"cost_adj": "100%",
+											"disabled": true
+										},
+										{
+											"id": "mk1WYTOVtm7F8vyuA",
+											"name": "Game Time",
+											"reference": "P108",
+											"local_notes": "Uses per game day equal to its maximum possible uses per real hour",
+											"disabled": true
+										}
+									],
+									"base_points": 15,
+									"calc": {
+										"points": 15
+									}
+								},
+								{
+									"id": "tWsYRYlAygBm2OdJD",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tvH8CndwPkEmF4Z6t"
+									},
 									"name": "Magic Resistance",
 									"reference": "B67",
-									"local_notes": "-1/level to skill for others to cast a spell on you. +1/level to resist spells.",
 									"tags": [
 										"Advantage",
 										"Physical"
 									],
 									"modifiers": [
 										{
-											"id": "mfdq6IY96MabdsDac",
+											"id": "mbSU0TmUnosbSp6xt",
 											"name": "Improved",
 											"reference": "B67",
 											"cost_adj": "150%",
@@ -8553,6 +6248,20 @@
 										}
 									],
 									"points_per_level": 2,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to resist spells",
+											"amount": 1,
+											"per_level": true
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to skill for others to cast a spell on you",
+											"amount": -1,
+											"per_level": true
+										}
+									],
 									"can_level": true,
 									"levels": 1,
 									"calc": {
@@ -8561,7 +6270,12 @@
 									}
 								},
 								{
-									"id": "tI4FDAjuE-h2ACRba",
+									"id": "tevKdQIXcsfBYHxqb",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "twYbceNKP5XRucfbL"
+									},
 									"name": "Psi Talent",
 									"reference": "DF14:4",
 									"tags": [
@@ -8571,39 +6285,31 @@
 										"Psionics"
 									],
 									"points_per_level": 5,
+									"max_levels": "6",
 									"features": [
 										{
-											"type": "skill_bonus",
-											"selection_type": "skills_with_name",
-											"tags": {
-												"compare": "is",
-												"qualifier": "Psionics"
-											},
+											"type": "conditional_modifier",
+											"situation": "to ALL rolls involving Psionic Abilities",
 											"amount": 1,
 											"per_level": true
-										},
-										{
-											"type": "skill_bonus",
-											"selection_type": "weapons_with_name",
-											"name": {
-												"compare": "is",
-												"qualifier": "Psychokinetic Lash"
-											},
-											"amount": 1
 										}
 									],
 									"can_level": true,
-									"levels": 4,
+									"levels": 1,
 									"calc": {
-										"points": 20,
-										"current_level": 4
+										"points": 5,
+										"current_level": 1
 									}
 								},
 								{
-									"id": "tGEIddSLPZtokuKls",
-									"name": "Resistance to Psionics",
-									"reference": "B81",
-									"local_notes": "-1/level to skill for others to use psionics on you. +1/level to resist psionic abilities.",
+									"id": "tq35HvHeIZZ_rNZGZ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq",
+										"id": "tfHo4a0U7i7qDw6K7"
+									},
+									"name": "Resistant to Psionics",
+									"reference": "DF14:14, B81",
 									"tags": [
 										"Advantage",
 										"Exotic",
@@ -8611,6 +6317,15 @@
 										"Physical"
 									],
 									"points_per_level": 2,
+									"max_levels": "6",
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to all resistance rolls against psi",
+											"amount": 1,
+											"per_level": true
+										}
+									],
 									"can_level": true,
 									"levels": 1,
 									"calc": {
@@ -8619,26 +6334,38 @@
 									}
 								},
 								{
-									"id": "tBdSePSP_PS7FHilR",
+									"id": "t3R9P0gQod9iPyDoq",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tkiJQ7nfyi9aAdGHK"
+									},
 									"name": "Serendipity",
-									"reference": "B83",
+									"reference": "B83,P73",
 									"tags": [
 										"Advantage",
 										"Mental"
 									],
 									"modifiers": [
 										{
-											"id": "mqEotWhhKH1ggNmgE",
+											"id": "mrwpz774Plu3aBvkP",
 											"name": "Wishing",
 											"reference": "P73",
 											"cost_adj": "100%",
 											"disabled": true
 										},
 										{
-											"id": "m7fRLjjphsRW_lnZZ",
+											"id": "m3MhQz1yGzCfDXDUW",
 											"name": "Wishing",
 											"reference": "P73",
 											"local_notes": "For others only",
+											"disabled": true
+										},
+										{
+											"id": "mDeLCo1p0yEuL3S7s",
+											"name": "Game Time",
+											"reference": "P108",
+											"local_notes": "Uses per game week equal to its maximum possible uses per session",
 											"disabled": true
 										}
 									],
@@ -8651,7 +6378,12 @@
 									}
 								},
 								{
-									"id": "tRSjpbmTPG9w5I3x4",
+									"id": "tDhzSHyhq2mT0S6Ts",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "thKwCUUe961nSwzVi"
+									},
 									"name": "Signature Gear",
 									"reference": "B85",
 									"local_notes": "For equipment normally bought with money, each point gives goods worth up to 50% of the average campaign starting wealth (but never cash).",
@@ -8668,13 +6400,33 @@
 									}
 								},
 								{
-									"id": "tQawyhdbhr6YTTlAT",
-									"name": "Smooth Operator",
+									"id": "tfCMHTZrhpjiddfmj",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tQ3xiqvixTRB9d7zT"
+									},
+									"name": "Talent (Smooth Operator)",
 									"reference": "B90,PU3:15",
 									"tags": [
 										"Advantage",
 										"Mental",
 										"Talent"
+									],
+									"modifiers": [
+										{
+											"id": "m-q4i2Ttp2tF7EXhC",
+											"name": "Alternate Benefit",
+											"local_notes": "Bonus to resist covered skills",
+											"disabled": true
+										},
+										{
+											"id": "mLRZUf0PqK-P2CfIE",
+											"name": "Alternative Cost",
+											"cost_adj": "-2",
+											"affects": "levels_only",
+											"disabled": true
+										}
 									],
 									"points_per_level": 15,
 									"features": [
@@ -8859,9 +6611,14 @@
 									}
 								},
 								{
-									"id": "tJUpg8eBGs-KCIbvV",
+									"id": "tFpvnb4bzFs5OP6Ww",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tLhvHsIW2tjWozsBy"
+									},
 									"name": "Spirit Empathy",
-									"reference": "B88",
+									"reference": "B88,P48",
 									"tags": [
 										"Advantage",
 										"Mental",
@@ -8869,7 +6626,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mS-4GBCktHgXXqYqV",
+											"id": "m-uKpnMKz7sGucDnb",
 											"name": "Specialized",
 											"reference": "B87",
 											"local_notes": "@Type: Angels, Demons, Elementals, Faerie, Ghosts, etc.@",
@@ -8877,7 +6634,7 @@
 											"disabled": true
 										},
 										{
-											"id": "mqpKyyD1NpociFbzh",
+											"id": "mdeBGDiMXXt4OPVIW",
 											"name": "Remote",
 											"reference": "P48",
 											"cost_adj": "50%",
@@ -8890,7 +6647,12 @@
 									}
 								},
 								{
-									"id": "tgD1yt7-nG0P4v3le",
+									"id": "t-YGxMQQXdle6tD6m",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "trClz3uZE-XIfFJKI"
+									},
 									"name": "Unfazeable",
 									"reference": "B95",
 									"local_notes": "Exempt from fright checks. Reaction modifiers do not affect you.",
@@ -8900,7 +6662,7 @@
 									],
 									"modifiers": [
 										{
-											"id": "mtEBEPHPS1ucja0yR",
+											"id": "mDIdPIhcfgWwnvVZ3",
 											"name": "Familiar Horrors",
 											"reference": "H20",
 											"cost_adj": "-50%",
@@ -8913,7 +6675,12 @@
 									}
 								},
 								{
-									"id": "t4-_2rfNuhX_pbhki",
+									"id": "t6vgnJA2i3xldytwt",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t2vba3l0J2mCZM50M"
+									},
 									"name": "Voice",
 									"reference": "B97",
 									"tags": [
@@ -9005,9 +6772,14 @@
 									}
 								},
 								{
-									"id": "tnsMo1EFAq9Z2VgDV",
+									"id": "tfN9vYuhKUNM6VPlo",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tg6F-Wf29f6BFE1oD"
+									},
 									"name": "Wild Talent",
-									"reference": "B99",
+									"reference": "B99,P89,MA49",
 									"tags": [
 										"Advantage",
 										"Mental",
@@ -9015,21 +6787,21 @@
 									],
 									"modifiers": [
 										{
-											"id": "md0AJ7dW-ylGdRYJ8",
+											"id": "mHiNia9LJLjr4SSYY",
 											"name": "Retention",
 											"reference": "B99",
 											"cost_adj": "25%",
 											"disabled": true
 										},
 										{
-											"id": "mKPHgnjmUEwJND_-U",
+											"id": "mlM1DrCWc3IzkOqfB",
 											"name": "Emergencies Only",
 											"reference": "B100",
 											"cost_adj": "-30%",
 											"disabled": true
 										},
 										{
-											"id": "mxN5DYVHQ-facH7B0",
+											"id": "mH9BNHU3iK0IFu3xO",
 											"name": "Focused",
 											"reference": "B99",
 											"local_notes": "@Type: Mental, Physical, Magical or Chi@",
@@ -9037,17 +6809,31 @@
 											"disabled": true
 										},
 										{
-											"id": "mceHXn00t3bjyLeSX",
+											"id": "mZyefI_b4DOUE2oiu",
 											"name": "Wild Ability",
 											"reference": "P90",
 											"cost_adj": "50%",
 											"disabled": true
 										},
 										{
-											"id": "m5ocSIWPj65kmkil3",
+											"id": "mjUkl0ONX-XObNnMh",
 											"name": "External",
 											"reference": "P90",
 											"cost_adj": "-20%",
+											"disabled": true
+										},
+										{
+											"id": "mtuHUop-16j_OaNCZ",
+											"name": "No Advantage Requirements",
+											"reference": "DF4:8",
+											"cost_adj": "50%",
+											"disabled": true
+										},
+										{
+											"id": "m9pZxVIYBl3hiW0-L",
+											"name": "Game Time",
+											"reference": "P108",
+											"local_notes": "Uses per game week equal to its maximum possible uses per session",
 											"disabled": true
 										}
 									],
@@ -9061,12 +6847,12 @@
 								}
 							],
 							"calc": {
-								"points": 218
+								"points": 203
 							}
 						}
 					],
 					"calc": {
-						"points": 3020
+						"points": 1654
 					}
 				},
 				{
@@ -9078,22 +6864,12 @@
 							"name": "-15 Points chosen from:",
 							"children": [
 								{
-									"id": "t6szOCFk7snt_zV2i",
-									"name": "Curious",
-									"reference": "B129",
-									"local_notes": "Make a self-control roll when presented with an interesting item or situation",
-									"tags": [
-										"Disadvantage",
-										"Mental"
-									],
-									"cr": 12,
-									"base_points": -5,
-									"calc": {
-										"points": -5
-									}
-								},
-								{
-									"id": "tgnal-c8QUdo0I8n_",
+									"id": "t45r-NpnMdSgJaHTo",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tnrtPQ0mWF4k75plo"
+									},
 									"name": "Bad Temper",
 									"reference": "B124",
 									"tags": [
@@ -9107,7 +6883,12 @@
 									}
 								},
 								{
-									"id": "tsd5_c7nOY9Y7DiaX",
+									"id": "tGYIC9w9ofQ7f-rk_",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "trdRnHewvO9QjUZDJ"
+									},
 									"name": "Combat Paralysis",
 									"reference": "B127",
 									"local_notes": "In any situation in which personal harm seems imminent, make a HT roll. Do not roll until the instant you need to fight, run, pull the trigger, or whatever. Any roll over 13 is a failure, even if you have HT 14+. On a success, you can act normally. On a failure, you are mentally stunned. ",
@@ -9142,7 +6923,122 @@
 									}
 								},
 								{
-									"id": "tQpPDKmFjaVWf14qe",
+									"id": "taan-g-jK41IXl4Fg",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t2O8gMxbRPpAWLej9"
+									},
+									"name": "Curious",
+									"reference": "B129",
+									"local_notes": "Make a self-control roll when presented with an interesting item or situation",
+									"tags": [
+										"Disadvantage",
+										"Mental"
+									],
+									"cr": 12,
+									"base_points": -5,
+									"calc": {
+										"points": -5
+									}
+								},
+								{
+									"id": "tuJ0qOu1sx0RJ81R7",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tw71iZfV_lekRjlBO"
+									},
+									"name": "Dead Broke",
+									"reference": "B25, L8, DFA67, DW33",
+									"local_notes": "Starting wealth is 0",
+									"tags": [
+										"Disadvantage",
+										"Social",
+										"Wealth"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Average Wealth"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Poor"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Struggling"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Comfortable Wealth"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Wealthy"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Very Wealthy"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Filthy Rich"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Multimillionaire"
+												}
+											}
+										]
+									},
+									"base_points": -25,
+									"calc": {
+										"points": -25
+									}
+								},
+								{
+									"id": "tzcSMhevhEePv53ft",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tNNZgqAtiUMQ_dZs6"
+									},
 									"name": "Jealousy",
 									"reference": "B140",
 									"tags": [
@@ -9162,7 +7058,12 @@
 									}
 								},
 								{
-									"id": "tkfrj3RlznbIuWMae",
+									"id": "tloRg-OTFCKdU-ZO_",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tnD52D6dhwXRMkPs5"
+									},
 									"name": "Loner",
 									"reference": "B142",
 									"local_notes": "Make a self-control roll whenever anyone lingers nearby, watches over your shoulder, etc. If you fail, you lash out at that person just as if you had Bad Temper.",
@@ -9170,6 +7071,7 @@
 										"Disadvantage",
 										"Mental"
 									],
+									"cr_adj": "reaction_penalty",
 									"cr": 12,
 									"base_points": -5,
 									"calc": {
@@ -9177,10 +7079,15 @@
 									}
 								},
 								{
-									"id": "tZe75XBqagF1aAMfe",
+									"id": "tLlC--PhNjo2IuwYw",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tQsgCJSqiGP4g4fkG"
+									},
 									"name": "Low Pain Threshold",
 									"reference": "B142",
-									"local_notes": "Double the shock from any injury. You roll at -4 to resist knockdown, stunning, and physical torture. Whenever you take a wound that does more than 1 HP of damage, you must make a Will roll to avoid crying out.",
+									"local_notes": "Double the shock from any injury. Whenever you take a wound that does more than 1 HP of damage, you must make a Will roll to avoid crying out.",
 									"tags": [
 										"Disadvantage",
 										"Physical"
@@ -9200,17 +7107,34 @@
 										]
 									},
 									"base_points": -10,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from \"macho\" individuals",
+											"amount": -1
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to resist knockdown, stunning, and physical torture",
+											"amount": -4
+										}
+									],
 									"calc": {
 										"points": -10
 									}
 								},
 								{
-									"id": "tF0EBn2SwvklgZ0nd",
+									"id": "tUXTWAnMRPJjctJBm",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tAFhfFoZosiPCFUhy"
+									},
 									"name": "No Sense of Humor",
 									"reference": "B146",
 									"tags": [
 										"Disadvantage",
-										"Physical"
+										"Mental"
 									],
 									"base_points": -10,
 									"features": [
@@ -9225,7 +7149,12 @@
 									}
 								},
 								{
-									"id": "to3dCtf-J9yxhr1bz",
+									"id": "tfQK_dTCjGM1tpb5o",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t49qcxpm53kg-OdPj"
+									},
 									"name": "Odious Personal Habit",
 									"reference": "B22",
 									"local_notes": "@Habit@",
@@ -9235,21 +7164,21 @@
 									],
 									"modifiers": [
 										{
-											"id": "muHXhswhOLiW2diok",
+											"id": "mj4kVoUnFmTx9GKlA",
 											"name": "-1 Reaction",
 											"reference": "B22",
 											"cost_adj": "-5",
 											"disabled": true
 										},
 										{
-											"id": "mzm7hyH1Aa4C8yOFs",
+											"id": "mhE5pj7bqrSWZvKUn",
 											"name": "-2 Reaction",
 											"reference": "B22",
 											"cost_adj": "-10",
 											"disabled": true
 										},
 										{
-											"id": "mamY5YJj8g8UzuuSN",
+											"id": "mhEsWp90GS95lw2Q0",
 											"name": "-3 Reaction",
 											"reference": "B22",
 											"cost_adj": "-15",
@@ -9261,7 +7190,12 @@
 									}
 								},
 								{
-									"id": "tAsemmOs1k5dlPPdh",
+									"id": "tv_C4McshtjRvhdNE",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tPbL1_rekOzkM86wz"
+									},
 									"name": "Overconfidence",
 									"reference": "B148",
 									"local_notes": "You must make a self-control roll any time the GM feels you show an unreasonable degree of caution. If you fail, you must go ahead as though you were able to handle the situation!",
@@ -9288,7 +7222,12 @@
 									}
 								},
 								{
-									"id": "tf8EUlbwxzFI-t-D6",
+									"id": "tW1pk0Ejq8PnjwNQQ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tYWjKdrALVt_raSxk"
+									},
 									"name": "Paranoia",
 									"reference": "B148",
 									"tags": [
@@ -9313,7 +7252,102 @@
 									}
 								},
 								{
-									"id": "tSdWcXJrmepxS-5B5",
+									"id": "taJo0POk3MKvite_f",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t-X2ObErkLG1c_UzW"
+									},
+									"name": "Poor",
+									"reference": "B25, L8, DFA67, DW33",
+									"local_notes": "Starting wealth is 1/5 normal",
+									"tags": [
+										"Disadvantage",
+										"Social",
+										"Wealth"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Average Wealth"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Dead Broke"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Struggling"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Comfortable Wealth"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Wealthy"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Very Wealthy"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Filthy Rich"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Multimillionaire"
+												}
+											}
+										]
+									},
+									"base_points": -15,
+									"calc": {
+										"points": -15
+									}
+								},
+								{
+									"id": "tGXfVt8zawLAqfGj6",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tcLpFfSmbHHdHy5Yd"
+									},
 									"name": "Post-Combat Shakes",
 									"reference": "B150",
 									"local_notes": "Make a self-control roll at the end of any battle. If you fail, roll 3d, add the amount by which you failed your self-control roll, and look up the result on the Fright Check Table.",
@@ -9328,7 +7362,12 @@
 									}
 								},
 								{
-									"id": "t9wUW_b7dutYWjgZh",
+									"id": "tTlcSMAIFWtgmID6g",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tFfzQ6ETSImJHHvkX"
+									},
 									"name": "Pyromania",
 									"reference": "B150",
 									"local_notes": "Make a self-control roll whenever you have an opportunity to set a fire",
@@ -9365,54 +7404,26 @@
 									}
 								},
 								{
-									"id": "tgR8B0C0Pc_apBhf2",
-									"name": "Sense of Duty",
+									"id": "tSDAITzIGZiEaFj_O",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tYdqy1uPSGI8VqvLV"
+									},
+									"name": "Selfish",
 									"reference": "B153",
+									"local_notes": "Make a self-control roll whenever you experience a clear social slight or “snub.” On a failure, you lash out at the offending party just as if you had Bad Temper.",
 									"tags": [
 										"Disadvantage",
 										"Mental"
 									],
-									"modifiers": [
+									"cr": 12,
+									"base_points": -5,
+									"features": [
 										{
-											"id": "mYyDTAWadi_XamSrK",
-											"name": "Adventuring Companions",
-											"reference": "B153",
-											"cost_adj": "-5"
-										},
-										{
-											"id": "mLA_pLjwRp9JM29y9",
-											"name": "@Small Group@",
-											"reference": "B153",
-											"cost_adj": "-5",
-											"disabled": true
-										},
-										{
-											"id": "mbP39IrlCLF3pMwpj",
-											"name": "@Individual@",
-											"reference": "B153",
-											"cost_adj": "-2",
-											"disabled": true
-										},
-										{
-											"id": "mA2N-TsZSLjWX68k5",
-											"name": "@Large Group@",
-											"reference": "B153",
-											"cost_adj": "-10",
-											"disabled": true
-										},
-										{
-											"id": "mPEemBtFETqrCCLL0",
-											"name": "@Entire Race@",
-											"reference": "B153",
-											"cost_adj": "-15",
-											"disabled": true
-										},
-										{
-											"id": "m2aSEjAHA0cSxFxKp",
-											"name": "Every Living Being",
-											"reference": "B153",
-											"cost_adj": "-20",
-											"disabled": true
+											"type": "reaction_bonus",
+											"situation": "from others when your Selfishness surfaces",
+											"amount": -3
 										}
 									],
 									"calc": {
@@ -9420,10 +7431,14 @@
 									}
 								},
 								{
-									"id": "tbB33FMdQkZoi47mC",
+									"id": "tUcQK9KQLA1vHkuwy",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "taEdO2Q-RgdH-CiHq"
+									},
 									"name": "Skinny",
 									"reference": "B18",
-									"local_notes": "-2 ST vs. knockback",
 									"tags": [
 										"Disadvantage",
 										"Physical"
@@ -9462,6 +7477,11 @@
 												"qualifier": "shadowing"
 											},
 											"amount": -2
+										},
+										{
+											"type": "conditional_modifier",
+											"situation": "to ST vs. knockback",
+											"amount": -2
 										}
 									],
 									"calc": {
@@ -9469,7 +7489,102 @@
 									}
 								},
 								{
-									"id": "tVMNMrlxyD1Lpkafh",
+									"id": "tAOXEdu_q1NcoFjEV",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "trgleL6LZZ7FUDMEB"
+									},
+									"name": "Struggling",
+									"reference": "B25, L8, DFA67, DW33",
+									"local_notes": "Starting wealth is ½ normal",
+									"tags": [
+										"Disadvantage",
+										"Social",
+										"Wealth"
+									],
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Average Wealth"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Dead Broke"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Poor"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Comfortable Wealth"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Wealthy"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Very Wealthy"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Filthy Rich"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": false,
+												"name": {
+													"compare": "is",
+													"qualifier": "Multimillionaire"
+												}
+											}
+										]
+									},
+									"base_points": -10,
+									"calc": {
+										"points": -10
+									}
+								},
+								{
+									"id": "tqRG4iIMB8lwN1lTt",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "t4gqkFmqABx7dLjkS"
+									},
 									"name": "Stubbornness",
 									"reference": "B157",
 									"tags": [
@@ -9489,62 +7604,29 @@
 									}
 								},
 								{
-									"id": "trBLJZ4yY6mtKqh-8",
+									"id": "t6p_RIbQpxuUmE40Z",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tItKCGaV9UN_W1pVs"
+									},
 									"name": "Unfit",
 									"reference": "B160",
-									"local_notes": "-1 to all HT rolls to remain conscious, avoid death, resist disease or poison, etc. As well, you lose FP at twice the normal rate.",
+									"local_notes": "You lose FP at twice the normal rate",
 									"tags": [
 										"Disadvantage",
 										"Physical"
 									],
 									"base_points": -5,
+									"features": [
+										{
+											"type": "conditional_modifier",
+											"situation": "to all HT rolls to remain conscious, avoid death, resist disease or poison, etc",
+											"amount": -1
+										}
+									],
 									"calc": {
 										"points": -5
-									}
-								},
-								{
-									"id": "tEjA0GxcK8dqVmvmi",
-									"name": "Struggling",
-									"reference": "B25",
-									"local_notes": "Starting wealth is ½ normal",
-									"tags": [
-										"Disadvantage",
-										"Social",
-										"Wealth"
-									],
-									"base_points": -10,
-									"calc": {
-										"points": -10
-									}
-								},
-								{
-									"id": "tsibJA7ACJH7CRkCG",
-									"name": "Poor",
-									"reference": "B25",
-									"local_notes": "Starting wealth is 1/5 normal",
-									"tags": [
-										"Disadvantage",
-										"Social",
-										"Wealth"
-									],
-									"base_points": -15,
-									"calc": {
-										"points": -15
-									}
-								},
-								{
-									"id": "tAgCIdRH54FSBKViu",
-									"name": "Dead Broke",
-									"reference": "B25",
-									"local_notes": "Starting wealth is 0",
-									"tags": [
-										"Disadvantage",
-										"Social",
-										"Wealth"
-									],
-									"base_points": -25,
-									"calc": {
-										"points": -25
 									}
 								}
 							],
@@ -9557,29 +7639,37 @@
 							"name": "-25 Points chosen from the above or:",
 							"children": [
 								{
-									"id": "tXE8Ty5qLmvN6sObX",
-									"name": "Delusion (Elder Things are my friends!)",
+									"id": "tPtfaMJvUwx_ayPVR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tLx7cgxRuxXHqkcb5"
+									},
+									"name": "Delusion (@Belief@)",
 									"reference": "B130",
 									"tags": [
 										"Disadvantage",
 										"Mental"
 									],
+									"replacements": {
+										"Belief": "Elder Things are my friends!"
+									},
 									"modifiers": [
 										{
-											"id": "mqw3kgvGGQTLzxIO2",
+											"id": "mD0IDkcBHvdM6gfL9",
 											"name": "Minor",
 											"reference": "B130",
 											"cost_adj": "-5"
 										},
 										{
-											"id": "me5-1CYInxCN3xZ-q",
+											"id": "mBUHkuPgGuos764yf",
 											"name": "Major",
 											"reference": "B130",
 											"cost_adj": "-10",
 											"disabled": true
 										},
 										{
-											"id": "mKt-wlrg2p_yYAuIk",
+											"id": "mfFW1cPQA-eVBUjq-",
 											"name": "Severe",
 											"reference": "B130",
 											"cost_adj": "-15",
@@ -9591,7 +7681,12 @@
 									}
 								},
 								{
-									"id": "t8baOKhcB6qQ5G8qJ",
+									"id": "tZ9MlJo05yxNH5zXp",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tIwv4VeJHsrnAQG0T"
+									},
 									"name": "Frightens Animals",
 									"reference": "B137",
 									"tags": [
@@ -9605,36 +7700,44 @@
 									}
 								},
 								{
-									"id": "tv6Eyn0RG8J2Jsafk",
-									"name": "Intolerance (Stupid People - IQ 10 or less)",
+									"id": "tgX16RXX8ZG_RyZJL",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "ttHkLI9zwzfeOIEZc"
+									},
+									"name": "Intolerance (@Class, Ethnicity, Nationality, Religion, Sex, or Species@)",
 									"reference": "B140",
 									"tags": [
 										"Disadvantage",
 										"Mental"
 									],
+									"replacements": {
+										"Class, Ethnicity, Nationality, Religion, Sex, or Species": "Stupid People - IQ 10 or less"
+									},
 									"modifiers": [
 										{
-											"id": "m_lsum1GJutctudFw",
+											"id": "mVCaNPHQ58dvxsPda",
 											"name": "Scope: Common",
 											"reference": "B140",
 											"cost_adj": "-5"
 										},
 										{
-											"id": "mVVxj0f6Yn-maurFN",
+											"id": "mJCnDBZaMQ4rFol_d",
 											"name": "Scope: Occasional",
 											"reference": "B140",
 											"cost_adj": "-2",
 											"disabled": true
 										},
 										{
-											"id": "me-u4eF5xFygu5NGU",
+											"id": "m8mg1ThR4epqM7vbE",
 											"name": "Scope: Rare",
 											"reference": "B140",
 											"cost_adj": "-1",
 											"disabled": true
 										},
 										{
-											"id": "me1F5T-Q7d57IzR3E",
+											"id": "m2p_Tl-D4LkAL-e7O",
 											"name": "Scope: Anyone unlike you",
 											"reference": "B140",
 											"cost_adj": "-10",
@@ -9653,24 +7756,32 @@
 									}
 								},
 								{
-									"id": "tAfnKNNgsQ6MaZdWn",
+									"id": "tmrP7dxRwizyLModM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tuBvIPa1ygEAxIiQ2"
+									},
 									"name": "Obsession",
 									"reference": "B146",
-									"local_notes": "Become a world-class psi at any cost; Make a self-control roll whenever it would be wise to deviate from your goal. If you fail, you continue to pursue your Obsession, regardless of the consequences.",
+									"local_notes": "@Goal@; Make a self-control roll whenever it would be wise to deviate from your goal. If you fail, you continue to pursue your Obsession, regardless of the consequences.",
 									"tags": [
 										"Disadvantage",
 										"Mental"
 									],
+									"replacements": {
+										"Goal": "Become a world-class psi at any cost"
+									},
 									"modifiers": [
 										{
-											"id": "mnFanzaKfxuq8fzZh",
+											"id": "m9CRiHL3ZzmURCG6T",
 											"name": "Short term",
 											"reference": "B146",
 											"cost_adj": "-5",
 											"disabled": true
 										},
 										{
-											"id": "msweCH2m2IbtkFHMQ",
+											"id": "m74S1gLv9IfzS-B78",
 											"name": "Long term",
 											"reference": "B146",
 											"cost_adj": "-10"
@@ -9678,27 +7789,36 @@
 									],
 									"cr": 12,
 									"calc": {
-										"points": -10
+										"points": -10,
+										"resolved_notes": "Become a world-class psi at any cost; Make a self-control roll whenever it would be wise to deviate from your goal. If you fail, you continue to pursue your Obsession, regardless of the consequences."
 									}
 								},
 								{
-									"id": "tQc8vBLQKBqrHL9EI",
+									"id": "t30lKRDBz2u-tiNvv",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tuBvIPa1ygEAxIiQ2"
+									},
 									"name": "Obsession",
 									"reference": "B146",
-									"local_notes": "Learn something dangerous involving Elder Things; Make a self-control roll whenever it would be wise to deviate from your goal. If you fail, you continue to pursue your Obsession, regardless of the consequences.",
+									"local_notes": "@Goal@; Make a self-control roll whenever it would be wise to deviate from your goal. If you fail, you continue to pursue your Obsession, regardless of the consequences.",
 									"tags": [
 										"Disadvantage",
 										"Mental"
 									],
+									"replacements": {
+										"Goal": "Learn something dangerous involving Elder Things"
+									},
 									"modifiers": [
 										{
-											"id": "mErxUl5Yh6MVv8gd3",
+											"id": "mxImRayGycF806vDm",
 											"name": "Short term",
 											"reference": "B146",
 											"cost_adj": "-5"
 										},
 										{
-											"id": "mDQUZvcok2k3yTuWl",
+											"id": "m_elOH8nXDsL3yJl6",
 											"name": "Long term",
 											"reference": "B146",
 											"cost_adj": "-10",
@@ -9707,11 +7827,17 @@
 									],
 									"cr": 12,
 									"calc": {
-										"points": -5
+										"points": -5,
+										"resolved_notes": "Learn something dangerous involving Elder Things; Make a self-control roll whenever it would be wise to deviate from your goal. If you fail, you continue to pursue your Obsession, regardless of the consequences."
 									}
 								},
 								{
-									"id": "tWw_9ytBmz9rlEkqi",
+									"id": "tTTUTZSsjXCb6NVOf",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tt5ULbbh-fi4t-UMm"
+									},
 									"name": "Weirdness Magnet",
 									"reference": "B161",
 									"tags": [
@@ -9721,25 +7847,38 @@
 									],
 									"modifiers": [
 										{
-											"id": "manvw9ZWRd_cE7mot",
+											"id": "mF1enQg9DEGxOrU_F",
 											"name": "Origins Magnet",
 											"reference": "SU32",
 											"disabled": true
 										}
 									],
 									"base_points": -15,
+									"features": [
+										{
+											"type": "reaction_bonus",
+											"situation": "from others who realize you are a weirdness magnet (except parapsychologists, cultists, conspiracy theorists, thrill-seekers)",
+											"amount": -2
+										}
+									],
 									"calc": {
 										"points": -15
 									}
 								},
 								{
-									"id": "tFOc8xaFbTOAxSJvb",
+									"id": "txZXpzY1m6WaXOrvi",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Traits.adq",
+										"id": "tX9XXLPFBvyQSpA4k"
+									},
 									"name": "Xenophilia",
 									"reference": "B162",
 									"tags": [
 										"Disadvantage",
 										"Mental"
 									],
+									"cr_adj": "fright_check_bonus",
 									"cr": 12,
 									"base_points": -10,
 									"calc": {
@@ -9755,10 +7894,116 @@
 					"calc": {
 						"points": -225
 					}
+				},
+				{
+					"id": "tbCBNnNtCRilszmhc",
+					"source": {
+						"library": "richardwilkes/gcs_master_library",
+						"path": "Basic Set/Basic Set Traits.adq",
+						"id": "tw1Ad0oSMw2ATM4X1"
+					},
+					"name": "Language: @Language@",
+					"reference": "B24",
+					"tags": [
+						"Advantage",
+						"Language",
+						"Mental"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Language Talent"
+								},
+								"level": {
+									"compare": "at_least"
+								}
+							}
+						]
+					},
+					"replacements": {
+						"Language": "Common"
+					},
+					"modifiers": [
+						{
+							"id": "m1qTiuBgcgod5MdhE",
+							"name": "Native",
+							"reference": "B23",
+							"cost_adj": "-6"
+						},
+						{
+							"id": "mJyCeAFSnfaZQtkFM",
+							"name": "Spoken",
+							"reference": "B24",
+							"local_notes": "None",
+							"disabled": true
+						},
+						{
+							"id": "m8-0rSAWRASVbZTo2",
+							"name": "Spoken",
+							"reference": "B24",
+							"local_notes": "Broken",
+							"cost_adj": "1",
+							"disabled": true
+						},
+						{
+							"id": "mNPy6cC0GSB8S72Ci",
+							"name": "Spoken",
+							"reference": "B24",
+							"local_notes": "Accented",
+							"cost_adj": "2",
+							"disabled": true
+						},
+						{
+							"id": "m-yQXo-MzarXyO57y",
+							"name": "Spoken",
+							"reference": "B24",
+							"local_notes": "Native",
+							"cost_adj": "3"
+						},
+						{
+							"id": "mGBh7N_EBdiRzuh7I",
+							"name": "Written",
+							"reference": "B24",
+							"local_notes": "None",
+							"disabled": true
+						},
+						{
+							"id": "mjmKMJLH4KxPzglBL",
+							"name": "Written",
+							"reference": "B24",
+							"local_notes": "Broken",
+							"cost_adj": "1",
+							"disabled": true
+						},
+						{
+							"id": "mYOfYyDeIyaoPnHgk",
+							"name": "Written",
+							"reference": "B24",
+							"local_notes": "Accented",
+							"cost_adj": "2",
+							"disabled": true
+						},
+						{
+							"id": "mu3XB6kG_cL4OZAId",
+							"name": "Written",
+							"reference": "B24",
+							"local_notes": "Native",
+							"cost_adj": "3"
+						}
+					],
+					"calc": {
+						"points": 0
+					}
 				}
 			],
 			"calc": {
-				"points": 2944
+				"points": 1578
 			}
 		}
 	],
@@ -9769,563 +8014,1324 @@
 			"children": [
 				{
 					"id": "S17baqDw4z29R2G6I",
-					"name": "Mandatory",
+					"name": "Primary Skills",
 					"children": [
 						{
-							"id": "sUUjw5rsd_39Xjw5-",
+							"id": "sW1vOywsw_KjPhA9q",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sIGnp4W_M8XBodpEH"
+							},
 							"name": "Hidden Lore",
-							"reference": "B199",
+							"reference": "B199,MA57",
 							"tags": [
 								"Knowledge"
 							],
-							"specialization": "Psi",
+							"replacements": {
+								"Subject": "Psi"
+							},
+							"specialization": "@Subject@",
 							"difficulty": "iq/a",
 							"points": 4
 						}
 					]
 				},
 				{
-					"id": "SnEfjCLisq1WNZWLS",
-					"name": "Melee Skill - Choose 1:",
+					"id": "ScFLlIaK6uAUOjPLU",
+					"name": "Secondary Skills",
 					"children": [
 						{
-							"id": "sdindnv_ens734sCh",
-							"name": "Rapier",
-							"reference": "B208",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Broadsword",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Main-Gauche",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Saber",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Smallsword",
-									"modifier": -3
+							"id": "S1_P_ugHWePX3SZgm",
+							"name": "Choose 4, or 2 points to raise one of those skills by a level",
+							"template_picker": {
+								"type": "points",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": 8
 								}
-							],
-							"points": 4
+							},
+							"children": [
+								{
+									"id": "sPNAHjxKMKfyp5aMx",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sgrwYPufk77pZC0Mu"
+									},
+									"name": "Aerobatics",
+									"reference": "B174",
+									"tags": [
+										"Athletic"
+									],
+									"difficulty": "dx/h",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -6
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Acrobatics"
+											},
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Aquabatics"
+											},
+											"modifier": -4
+										}
+									],
+									"points": 2
+								},
+								{
+									"id": "sGd67qkPZgJ42Wfsb",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sIegIM7jx4oMnRMm2"
+									},
+									"name": "Detect Lies",
+									"reference": "B187",
+									"tags": [
+										"Police",
+										"Social",
+										"Spy"
+									],
+									"difficulty": "per/h",
+									"defaults": [
+										{
+											"type": "per",
+											"modifier": -6
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Body Language"
+											},
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Psychology"
+											},
+											"modifier": -4
+										}
+									],
+									"points": 2
+								},
+								{
+									"id": "soloO_Zl0VHQg_QuM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s7zUqAO5PEC5JKk_W"
+									},
+									"name": "Fast-Talk",
+									"reference": "B195",
+									"tags": [
+										"Criminal",
+										"Social",
+										"Spy",
+										"Street"
+									],
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Acting"
+											},
+											"modifier": -5
+										}
+									],
+									"points": 2
+								},
+								{
+									"id": "s0q9RSxmc2eX7tBI1",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sWB9ypJAq43MF3O0n"
+									},
+									"name": "Gambling",
+									"reference": "B197",
+									"tags": [
+										"Criminal",
+										"Social",
+										"Street"
+									],
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Mathematics"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Statistics"
+											},
+											"modifier": -5
+										}
+									],
+									"points": 2
+								},
+								{
+									"id": "sYPoF2FD9ANJP38V6",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sIGnp4W_M8XBodpEH"
+									},
+									"name": "Hidden Lore",
+									"reference": "B199,MA57",
+									"tags": [
+										"Knowledge"
+									],
+									"replacements": {
+										"Subject": "Elder Things"
+									},
+									"specialization": "@Subject@",
+									"difficulty": "iq/a",
+									"points": 2
+								},
+								{
+									"id": "sH8yQun0TNC3_aAdQ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sm-zCRgqY_1QXowLd"
+									},
+									"name": "Hypnotism",
+									"reference": "B201",
+									"tags": [
+										"Medical"
+									],
+									"difficulty": "iq/h",
+									"points": 2
+								},
+								{
+									"id": "sOyb5BO5bMOCCk9OH",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sfB-d4kTee0C-BZv0"
+									},
+									"name": "Interrogation",
+									"reference": "B202",
+									"tags": [
+										"Military",
+										"Police",
+										"Spy"
+									],
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Intimidation"
+											},
+											"modifier": -3
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Psychology"
+											},
+											"modifier": -4
+										}
+									],
+									"points": 2
+								},
+								{
+									"id": "saIyvJDH04KEw7EhM",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s9Ea1OCpoHkrNdjwf"
+									},
+									"name": "Meditation",
+									"reference": "B207",
+									"tags": [
+										"Esoteric"
+									],
+									"difficulty": "will/h",
+									"defaults": [
+										{
+											"type": "will",
+											"modifier": -6
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Autohypnosis"
+											},
+											"modifier": -4
+										}
+									],
+									"points": 2
+								},
+								{
+									"id": "sB2sh-vwDb1I6svG5",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sxDgiqntG5jIWBGld"
+									},
+									"name": "Mental Strength",
+									"reference": "B209",
+									"tags": [
+										"Esoteric"
+									],
+									"difficulty": "will/e",
+									"prereqs": {
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"notes": {
+													"compare": "contains",
+													"qualifier": "Permits Mental Strength"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Unusual Background (Psionic)"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Magery"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "starts_with",
+													"qualifier": "weapon master"
+												}
+											},
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "trained by a master"
+												}
+											}
+										]
+									},
+									"points": 2
+								},
+								{
+									"id": "ss6ttSECfnsXOJqTq",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s_6AWhlyx4j6tK_OF"
+									},
+									"name": "Mind Block",
+									"reference": "B210",
+									"tags": [
+										"Esoteric"
+									],
+									"difficulty": "will/a",
+									"defaults": [
+										{
+											"type": "will",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Meditation"
+											},
+											"modifier": -5
+										}
+									],
+									"points": 2
+								},
+								{
+									"id": "seoSjDGCB6vc1Al-w",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sa4xUKRmFe81nvpnd"
+									},
+									"name": "Occultism",
+									"reference": "B212",
+									"tags": [
+										"Magical",
+										"Occult"
+									],
+									"difficulty": "iq/a",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -5
+										}
+									],
+									"points": 2
+								},
+								{
+									"id": "sAt9rwal2duTcsQnd",
+									"name": "Psychology",
+									"reference": "B216",
+									"tags": [
+										"Humanities",
+										"Social Sciences"
+									],
+									"specialization": "@Specialty@",
+									"difficulty": "iq/h",
+									"defaults": [
+										{
+											"type": "iq",
+											"modifier": -6
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Sociology"
+											},
+											"modifier": -4
+										}
+									],
+									"points": 2
+								}
+							]
 						},
 						{
-							"id": "sU3FYSSlGFrXVct0R",
-							"name": "Saber",
-							"reference": "B208",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
+							"id": "SnEfjCLisq1WNZWLS",
+							"name": "Melee Weapon Skill",
+							"local_notes": "Choose 1",
+							"template_picker": {
+								"type": "count",
+								"qualifier": {
+									"compare": "is",
+									"qualifier": 1
+								}
+							},
+							"children": [
 								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Broadsword",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Shortsword",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Main-Gauche",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
+									"id": "spWeB-gARsSbnKYdQ",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s-y06a7Fcnd6VGLQ-"
+									},
 									"name": "Rapier",
-									"modifier": -3
+									"reference": "B208",
+									"tags": [
+										"Combat",
+										"Melee Combat",
+										"Weapon"
+									],
+									"difficulty": "dx/a",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Broadsword"
+											},
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Main-Gauche"
+											},
+											"modifier": -3
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Saber"
+											},
+											"modifier": -3
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Smallsword"
+											},
+											"modifier": -3
+										}
+									],
+									"points": 4
 								},
 								{
-									"type": "skill",
-									"name": "Smallsword",
-									"modifier": -3
-								}
-							],
-							"points": 4
-						},
-						{
-							"id": "s5GuYRmZKJaaawQX5",
-							"name": "Shortsword",
-							"reference": "B209",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "skill",
-									"name": "Broadsword",
-									"modifier": -2
-								},
-								{
-									"type": "skill",
-									"name": "Force Sword",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Jitte/Sai",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Knife",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
+									"id": "ss6h8lHZ-fSPfO9PO",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sm4SB8y1Te_UbDPpu"
+									},
 									"name": "Saber",
-									"modifier": -4
+									"reference": "B208",
+									"tags": [
+										"Combat",
+										"Melee Combat",
+										"Weapon"
+									],
+									"difficulty": "dx/a",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Broadsword"
+											},
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Shortsword"
+											},
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Main-Gauche"
+											},
+											"modifier": -3
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Rapier"
+											},
+											"modifier": -3
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Smallsword"
+											},
+											"modifier": -3
+										}
+									],
+									"points": 4
 								},
 								{
-									"type": "skill",
-									"name": "Smallsword",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Tonfa",
-									"modifier": -3
-								},
-								{
-									"type": "dx",
-									"modifier": -5
-								}
-							],
-							"points": 4
-						},
-						{
-							"id": "suvLfULOGRbn_nCsS",
-							"name": "Smallsword",
-							"reference": "B208",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
+									"id": "sWAmrcsYzUA7-7R2V",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s-DdOtFsU7dX4Ttfz"
+									},
 									"name": "Shortsword",
-									"modifier": -4
+									"reference": "B209",
+									"tags": [
+										"Combat",
+										"Melee Combat",
+										"Weapon"
+									],
+									"difficulty": "dx/a",
+									"defaults": [
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Broadsword"
+											},
+											"modifier": -2
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Force Sword"
+											},
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Jitte/Sai"
+											},
+											"modifier": -3
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Knife"
+											},
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Saber"
+											},
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Smallsword"
+											},
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Tonfa"
+											},
+											"modifier": -3
+										},
+										{
+											"type": "dx",
+											"modifier": -5
+										}
+									],
+									"points": 4
 								},
 								{
-									"type": "skill",
-									"name": "Main-Gauche",
-									"modifier": -3
+									"id": "suCx9J_HNlhhFdBQ4",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sS4hZ6hj6EE25ergR"
+									},
+									"name": "Smallsword",
+									"reference": "B208",
+									"tags": [
+										"Combat",
+										"Melee Combat",
+										"Weapon"
+									],
+									"difficulty": "dx/a",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Shortsword"
+											},
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Main-Gauche"
+											},
+											"modifier": -3
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Rapier"
+											},
+											"modifier": -3
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Saber"
+											},
+											"modifier": -3
+										}
+									],
+									"points": 4
 								},
 								{
-									"type": "skill",
-									"name": "Rapier",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Saber",
-									"modifier": -3
+									"id": "shMoWpxm_dBd6yNSo",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sZnijHP17_9lk1OPG"
+									},
+									"name": "Staff",
+									"reference": "B208",
+									"tags": [
+										"Combat",
+										"Melee Combat",
+										"Weapon"
+									],
+									"difficulty": "dx/a",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Polearm"
+											},
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Spear"
+											},
+											"modifier": -2
+										}
+									],
+									"points": 4
 								}
-							],
-							"points": 4
+							]
 						},
 						{
-							"id": "soTt0yn9RITSpIDra",
-							"name": "Staff",
-							"reference": "B208",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Polearm",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Spear",
-									"modifier": -2
+							"id": "SLnIOHOesNlOjDBcq",
+							"name": "Secondary Weapon Skills",
+							"local_notes": "Choose 2, or raise Melee Weapon Skill by 1 and Choose another from this list:",
+							"template_picker": {
+								"type": "count",
+								"qualifier": {
+									"compare": "at_most",
+									"qualifier": 2
 								}
-							],
-							"points": 4
-						}
-					]
-				},
-				{
-					"id": "SLnIOHOesNlOjDBcq",
-					"name": "Choose 2, or raise Melee Weapon Skill by 1:",
-					"children": [
-						{
-							"id": "sFtky3LPRTJDuI_Ol",
-							"name": "Innate Attack",
-							"reference": "B201",
-							"tags": [
-								"Combat",
-								"Ranged Combat",
-								"Weapon"
-							],
-							"specialization": "Gaze",
-							"difficulty": "dx/e",
-							"defaults": [
+							},
+							"children": [
 								{
-									"type": "dx",
-									"modifier": -4
+									"id": "spIko2Uahg6uWx3Vc",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "swTrkA4PO0rSq8mHe"
+									},
+									"name": "Cloak",
+									"reference": "B184",
+									"tags": [
+										"Combat",
+										"Melee Combat",
+										"Weapon"
+									],
+									"difficulty": "dx/a",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -5
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Net"
+											},
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Shield"
+											},
+											"modifier": -4
+										}
+									],
+									"points": 4
 								},
 								{
-									"type": "skill",
-									"name": "Innate Attack",
-									"modifier": -2
-								}
-							],
-							"points": 4
-						},
-						{
-							"id": "szinb9Xj5Yz5BDkYD",
-							"name": "Shield",
-							"reference": "B220",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"specialization": "Shield",
-							"difficulty": "dx/e",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -4
-								}
-							],
-							"points": 4
-						},
-						{
-							"id": "shFfo9RbxyT916jEg",
-							"name": "Shield",
-							"reference": "B220",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"specialization": "Buckler",
-							"difficulty": "dx/e",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -4
+									"id": "SnaawRxJUgTk7LBlK",
+									"name": "Innate Attack (Gaze)",
+									"local_notes": "Choose the top one if you don't have the Gazer perk, and the bottom one if you *do* have the Gazer perk",
+									"template_picker": {
+										"type": "count",
+										"qualifier": {
+											"compare": "is",
+											"qualifier": 1
+										}
+									},
+									"children": [
+										{
+											"id": "shuRYV5Dfal0iR3O6",
+											"source": {
+												"library": "richardwilkes/gcs_master_library",
+												"path": "Basic Set/Basic Set Skills.skl",
+												"id": "srCc5hZzKUhInxl3K"
+											},
+											"name": "Innate Attack",
+											"reference": "B201",
+											"tags": [
+												"Combat",
+												"Ranged Combat",
+												"Weapon"
+											],
+											"specialization": "Gaze",
+											"difficulty": "dx/e",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -4
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Innate Attack"
+													},
+													"modifier": -2
+												}
+											],
+											"points": 4
+										},
+										{
+											"id": "sYZd5vqi6l_IArS_F",
+											"name": "Innate Attack",
+											"reference": "B201",
+											"tags": [
+												"Combat",
+												"Ranged Combat",
+												"Weapon"
+											],
+											"specialization": "Gaze",
+											"difficulty": "per/e",
+											"defaults": [
+												{
+													"type": "dx",
+													"modifier": -4
+												},
+												{
+													"type": "skill",
+													"name": {
+														"compare": "is",
+														"qualifier": "Innate Attack"
+													},
+													"modifier": -2
+												}
+											],
+											"prereqs": {
+												"type": "prereq_list",
+												"all": true,
+												"prereqs": [
+													{
+														"type": "trait_prereq",
+														"has": true,
+														"name": {
+															"compare": "is",
+															"qualifier": "Perk (Gazer)"
+														},
+														"level": {
+															"compare": "at_least"
+														}
+													}
+												]
+											},
+											"points": 4
+										}
+									]
 								},
 								{
-									"type": "skill",
+									"id": "sfRmogp_KFd8c2dch",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sxg-_yrzuGL19d-m8"
+									},
 									"name": "Shield",
-									"specialization": "Force",
-									"modifier": -2
-								}
-							],
-							"points": 4
-						},
-						{
-							"id": "sepjF19AB4fhriWbj",
-							"name": "Thrown Weapon",
-							"reference": "B226",
-							"tags": [
-								"Combat",
-								"Ranged Combat",
-								"Weapon"
-							],
-							"specialization": "@Specialty@",
-							"difficulty": "dx/e",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -4
-								}
-							],
-							"points": 4
-						},
-						{
-							"id": "s8mFRPiiLNeMrEXoj",
-							"name": "Thrown Weapon",
-							"reference": "B226",
-							"tags": [
-								"Combat",
-								"Ranged Combat",
-								"Weapon"
-							],
-							"specialization": "Axe/Mace",
-							"difficulty": "dx/e",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -4
-								}
-							],
-							"points": 4
-						},
-						{
-							"id": "ssHniJ-Yq6IbcJeiG",
-							"name": "Thrown Weapon",
-							"reference": "B226",
-							"tags": [
-								"Combat",
-								"Ranged Combat",
-								"Weapon"
-							],
-							"specialization": "Dart",
-							"difficulty": "dx/e",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -4
+									"reference": "B220",
+									"tags": [
+										"Combat",
+										"Melee Combat",
+										"Weapon"
+									],
+									"specialization": "Buckler",
+									"difficulty": "dx/e",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Shield"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Force"
+											},
+											"modifier": -2
+										}
+									],
+									"points": 4
 								},
 								{
-									"type": "skill",
+									"id": "siR4z8Kfp7Qmo2Z9j",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sHxw81LQLjwvQNyP9"
+									},
+									"name": "Shield",
+									"reference": "B220",
+									"tags": [
+										"Combat",
+										"Melee Combat",
+										"Weapon"
+									],
+									"specialization": "Shield",
+									"difficulty": "dx/e",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -4
+										}
+									],
+									"points": 4
+								},
+								{
+									"id": "s7cAn9_gQmpD-ZYCB",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s64oJ-8i-8xecRu4a"
+									},
 									"name": "Throwing",
-									"modifier": -2
-								}
-							],
-							"points": 4
-						},
-						{
-							"id": "sa9o4REv9qg4NysBR",
-							"name": "Thrown Weapon",
-							"reference": "B226",
-							"tags": [
-								"Combat",
-								"Ranged Combat",
-								"Weapon"
-							],
-							"specialization": "Harpoon",
-							"difficulty": "dx/e",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -4
+									"reference": "B226",
+									"tags": [
+										"Athletic",
+										"Combat",
+										"Ranged Combat",
+										"Weapon"
+									],
+									"difficulty": "dx/a",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -3
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Dropping"
+											},
+											"modifier": -4
+										}
+									],
+									"points": 4
 								},
 								{
-									"type": "skill",
+									"id": "svyaoyY6L9d3_3OLY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "shz-_Gg3cmjxmRxx2"
+									},
 									"name": "Thrown Weapon",
-									"specialization": "Spear",
-									"modifier": -2
-								}
-							],
-							"points": 4
-						},
-						{
-							"id": "sJoqLZ9ejOLeYdVhY",
-							"name": "Thrown Weapon",
-							"reference": "B226",
-							"tags": [
-								"Combat",
-								"Ranged Combat",
-								"Weapon"
-							],
-							"specialization": "Knife",
-							"difficulty": "dx/e",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -4
-								}
-							],
-							"points": 4
-						},
-						{
-							"id": "sasGCUJA7kr5ldBqL",
-							"name": "Thrown Weapon",
-							"reference": "B226",
-							"tags": [
-								"Combat",
-								"Ranged Combat",
-								"Weapon"
-							],
-							"specialization": "Shuriken",
-							"difficulty": "dx/e",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -4
+									"reference": "B226",
+									"tags": [
+										"Combat",
+										"Ranged Combat",
+										"Weapon"
+									],
+									"specialization": "@Specialty@",
+									"difficulty": "dx/e",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -4
+										}
+									],
+									"points": 4
 								},
 								{
-									"type": "skill",
-									"name": "Throwing",
-									"modifier": -2
-								}
-							],
-							"points": 4
-						},
-						{
-							"id": "s-vDSgaZTuxOgs82q",
-							"name": "Thrown Weapon",
-							"reference": "B226",
-							"tags": [
-								"Combat",
-								"Ranged Combat",
-								"Weapon"
-							],
-							"specialization": "Spear",
-							"difficulty": "dx/e",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Spear Thrower",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
+									"id": "s_A6kPspfbvKa44yR",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sQ93W8oPsTVYtDkZ9"
+									},
 									"name": "Thrown Weapon",
+									"reference": "B226",
+									"tags": [
+										"Combat",
+										"Ranged Combat",
+										"Weapon"
+									],
+									"specialization": "Axe/Mace",
+									"difficulty": "dx/e",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -4
+										}
+									],
+									"points": 4
+								},
+								{
+									"id": "s3095WVx9WLKnmwEY",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sb93Iknas4MWw8-l_"
+									},
+									"name": "Thrown Weapon",
+									"reference": "B226",
+									"tags": [
+										"Combat",
+										"Ranged Combat",
+										"Weapon"
+									],
+									"specialization": "Dart",
+									"difficulty": "dx/e",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Throwing"
+											},
+											"modifier": -2
+										}
+									],
+									"points": 4
+								},
+								{
+									"id": "sWfCqf-d5BSSA6eeF",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "shzjSxy2W5Q2LWFIp"
+									},
+									"name": "Thrown Weapon",
+									"reference": "B226",
+									"tags": [
+										"Combat",
+										"Ranged Combat",
+										"Weapon"
+									],
 									"specialization": "Harpoon",
-									"modifier": -2
-								}
-							],
-							"points": 4
-						},
-						{
-							"id": "sA2nUc7GJ8sT4qbIQ",
-							"name": "Thrown Weapon",
-							"reference": "B226",
-							"tags": [
-								"Combat",
-								"Ranged Combat",
-								"Weapon"
-							],
-							"specialization": "Stick",
-							"difficulty": "dx/e",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -4
-								}
-							],
-							"points": 4
-						},
-						{
-							"id": "sFOVZ-ss3TgaALF1g",
-							"name": "Cloak",
-							"reference": "B184",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -5
+									"difficulty": "dx/e",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Thrown Weapon"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Spear"
+											},
+											"modifier": -2
+										}
+									],
+									"points": 4
 								},
 								{
-									"type": "skill",
-									"name": "Net",
-									"modifier": -4
+									"id": "sfqwDCib4ONtpy4A3",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s3KM8dub0Xn5_9oPI"
+									},
+									"name": "Thrown Weapon",
+									"reference": "B226",
+									"tags": [
+										"Combat",
+										"Ranged Combat",
+										"Weapon"
+									],
+									"specialization": "Knife",
+									"difficulty": "dx/e",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -4
+										}
+									],
+									"points": 4
 								},
 								{
-									"type": "skill",
-									"name": "Shield",
-									"modifier": -4
-								}
-							],
-							"points": 4
-						},
-						{
-							"id": "sCywv_Uk5eQNKg6YT",
-							"name": "Throwing",
-							"reference": "B226",
-							"tags": [
-								"Athletic",
-								"Combat",
-								"Ranged Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -3
+									"id": "sRDQE_1h0D52ae4XS",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s6sHR8eiTIhFZvXjf"
+									},
+									"name": "Thrown Weapon",
+									"reference": "B226",
+									"tags": [
+										"Combat",
+										"Ranged Combat",
+										"Weapon"
+									],
+									"specialization": "Shuriken",
+									"difficulty": "dx/e",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Throwing"
+											},
+											"modifier": -2
+										}
+									],
+									"points": 4
 								},
 								{
-									"type": "skill",
-									"name": "Dropping",
-									"modifier": -4
+									"id": "s-lQ_1DQYjJipVD2R",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "sJnzh1OaoKVZdj02_"
+									},
+									"name": "Thrown Weapon",
+									"reference": "B226",
+									"tags": [
+										"Combat",
+										"Ranged Combat",
+										"Weapon"
+									],
+									"specialization": "Spear",
+									"difficulty": "dx/e",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Spear Thrower"
+											},
+											"modifier": -4
+										},
+										{
+											"type": "skill",
+											"name": {
+												"compare": "is",
+												"qualifier": "Thrown Weapon"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Harpoon"
+											},
+											"modifier": -2
+										}
+									],
+									"points": 4
+								},
+								{
+									"id": "sPO1swfDdU4ut3bhc",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "ssbVfpHEFYJxuxnZl"
+									},
+									"name": "Thrown Weapon",
+									"reference": "B226",
+									"tags": [
+										"Combat",
+										"Ranged Combat",
+										"Weapon"
+									],
+									"specialization": "Stick",
+									"difficulty": "dx/e",
+									"defaults": [
+										{
+											"type": "dx",
+											"modifier": -4
+										}
+									],
+									"points": 4
+								},
+								{
+									"id": "sAHrDAbLrTR4wY3Tc",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Basic Set/Basic Set Skills.skl",
+										"id": "s8parl7zgbXys0OF2"
+									},
+									"name": "Wrestling",
+									"reference": "B228,MA61",
+									"tags": [
+										"Combat",
+										"Melee Combat",
+										"Weapon"
+									],
+									"difficulty": "dx/a",
+									"points": 4
 								}
-							],
-							"points": 4
-						},
-						{
-							"id": "syPo9BQHx0rBfTbtI",
-							"name": "Wrestling",
-							"reference": "B228",
-							"tags": [
-								"Combat",
-								"Melee Combat",
-								"Weapon"
-							],
-							"difficulty": "dx/a",
-							"points": 4
+							]
 						}
 					]
 				},
 				{
 					"id": "S5wfwc2hVNle4sB8R",
-					"name": "Choose 7 or 1 point to buy anything from the above category:",
+					"name": "Background Skills",
+					"local_notes": "Choose 7 or 1 point to buy anything from the above category:",
+					"template_picker": {
+						"type": "count",
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": 7
+						}
+					},
 					"children": [
 						{
-							"id": "scvVNaXL6vlJgl8iC",
-							"name": "Fast-Draw",
-							"reference": "B194",
+							"id": "s-_TkRsieWambjIxX",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sQ7hn7pW3tIPfsU8Z"
+							},
+							"name": "Acting",
+							"reference": "B174",
 							"tags": [
-								"Combat",
-								"Ranged Combat",
-								"Weapon"
+								"Social",
+								"Spy"
 							],
-							"specialization": "@Item@",
-							"difficulty": "dx/e",
+							"difficulty": "iq/a",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Performance"
+									},
+									"modifier": -2
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Public Speaking"
+									},
+									"modifier": -5
+								}
+							],
 							"points": 1
 						},
 						{
-							"id": "sXzdf-gXRj74BDtbC",
+							"id": "siWwen554JzGNSEAn",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sOp4wssAMtUc1ukJI"
+							},
+							"name": "Body Language",
+							"reference": "B181",
+							"tags": [
+								"Police",
+								"Social",
+								"Spy"
+							],
+							"difficulty": "per/a",
+							"defaults": [
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Detect Lies"
+									},
+									"modifier": -4
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Psychology"
+									},
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "s-vHlb85juXTPOP3s",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sENfGTCKokQN0N4PF"
+							},
 							"name": "Climbing",
 							"reference": "B183",
 							"tags": [
@@ -10346,31 +9352,61 @@
 							"points": 1
 						},
 						{
-							"id": "s-NLndxJMkgwn24tg",
-							"name": "Stealth",
-							"reference": "B222",
+							"id": "siCSNV6YzHPwMMpxy",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s8j6tcaNxXkF89Xbt"
+							},
+							"name": "Diplomacy",
+							"reference": "B187",
 							"tags": [
-								"Criminal",
+								"Business",
 								"Police",
-								"Spy",
-								"Street"
+								"Social"
 							],
-							"difficulty": "dx/a",
-							"encumbrance_penalty_multiplier": 1,
+							"difficulty": "iq/h",
 							"defaults": [
 								{
 									"type": "iq",
-									"modifier": -5
+									"modifier": -6
 								},
 								{
-									"type": "dx",
-									"modifier": -5
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Politics"
+									},
+									"modifier": -6
 								}
 							],
 							"points": 1
 						},
 						{
-							"id": "s6eFNeg4-QtYkgljv",
+							"id": "sHYfZbTb4cyhRcMHp",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s5xh6bANmCGbYersa"
+							},
+							"name": "Fast-Draw",
+							"reference": "B194,MA56",
+							"tags": [
+								"Combat",
+								"Ranged Combat",
+								"Weapon"
+							],
+							"specialization": "@Specialization@",
+							"difficulty": "dx/e",
+							"points": 1
+						},
+						{
+							"id": "sCnm0SY2rFw1Pa8Sj",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s9mV--3lpIfXO7N6Z"
+							},
 							"name": "First Aid",
 							"reference": "B195",
 							"tags": [
@@ -10385,22 +9421,37 @@
 								},
 								{
 									"type": "skill",
-									"name": "Esoteric Medicine"
+									"name": {
+										"compare": "is",
+										"qualifier": "Esoteric Medicine"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Physician"
+									"name": {
+										"compare": "is",
+										"qualifier": "Physician"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Veterinary",
+									"name": {
+										"compare": "is",
+										"qualifier": "Veterinary"
+									},
 									"modifier": -4
 								}
 							],
+							"tech_level": "",
 							"points": 1
 						},
 						{
-							"id": "sB7ZFV-rR0NXrXjEV",
+							"id": "sI6JrlA4a2UxtjP4Z",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sGz21GskAlJXL1hYP"
+							},
 							"name": "Gesture",
 							"reference": "B198",
 							"tags": [
@@ -10416,34 +9467,121 @@
 							"points": 1
 						},
 						{
-							"id": "s8FtkgTniagumHqGk",
-							"name": "Acting",
-							"reference": "B174",
+							"id": "si5kUSQArUPyIDsng",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s9b5e-6c-ljOeUtt5"
+							},
+							"name": "Hiking",
+							"reference": "B200",
 							"tags": [
-								"Social",
-								"Spy"
+								"Athletic",
+								"Exploration",
+								"Outdoor"
 							],
-							"difficulty": "iq/a",
+							"difficulty": "ht/a",
 							"defaults": [
 								{
-									"type": "iq",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Performance",
-									"modifier": -2
-								},
-								{
-									"type": "skill",
-									"name": "Public Speaking",
+									"type": "ht",
 									"modifier": -5
 								}
 							],
 							"points": 1
 						},
 						{
-							"id": "sdlQlhlR6pQg1qiW-",
+							"id": "slCwsKqN9CsflGohp",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "shun-iitiwyWbrGcF"
+							},
+							"name": "Intimidation",
+							"reference": "B202",
+							"tags": [
+								"Criminal",
+								"Police",
+								"Social",
+								"Street"
+							],
+							"difficulty": "will/a",
+							"defaults": [
+								{
+									"type": "will",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Acting"
+									},
+									"modifier": -3
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "s7uyq6uZPEh1u_tfD",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sdl9m7gHE7hlMX0AX"
+							},
+							"name": "Lip Reading",
+							"reference": "B205",
+							"tags": [
+								"Spy"
+							],
+							"difficulty": "per/a",
+							"defaults": [
+								{
+									"type": "per",
+									"modifier": -10
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sL4qccd76LTieFLmU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s6Yn2IClGb4i4LgOQ"
+							},
+							"name": "Observation",
+							"reference": "B211",
+							"tags": [
+								"Criminal",
+								"Military",
+								"Police",
+								"Spy",
+								"Street"
+							],
+							"difficulty": "per/a",
+							"defaults": [
+								{
+									"type": "per",
+									"modifier": -5
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Shadowing"
+									},
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sXNEVrNk4JyQ7qnjE",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "spGG-fpOy0g88rFDO"
+							},
 							"name": "Public Speaking",
 							"reference": "B216",
 							"tags": [
@@ -10454,29 +9592,51 @@
 							"difficulty": "iq/a",
 							"defaults": [
 								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Public Speaking"
+									},
+									"modifier": -2
+								},
+								{
 									"type": "iq",
 									"modifier": -5
 								},
 								{
 									"type": "skill",
-									"name": "Acting",
+									"name": {
+										"compare": "is",
+										"qualifier": "Acting"
+									},
 									"modifier": -5
 								},
 								{
 									"type": "skill",
-									"name": "Performance",
+									"name": {
+										"compare": "is",
+										"qualifier": "Performance"
+									},
 									"modifier": -2
 								},
 								{
 									"type": "skill",
-									"name": "Politics",
+									"name": {
+										"compare": "is",
+										"qualifier": "Politics"
+									},
 									"modifier": -5
 								}
 							],
 							"points": 1
 						},
 						{
-							"id": "s3Nl5om_SOTHuefKb",
+							"id": "sNrdJGjXJWeKZqJcu",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "stFawUEv8gxldDoiC"
+							},
 							"name": "Research",
 							"reference": "B217",
 							"tags": [
@@ -10491,7 +9651,10 @@
 								},
 								{
 									"type": "skill",
-									"name": "Writing",
+									"name": {
+										"compare": "is",
+										"qualifier": "Writing"
+									},
 									"modifier": -3
 								}
 							],
@@ -10565,123 +9728,16 @@
 									}
 								]
 							},
+							"tech_level": "",
 							"points": 1
 						},
 						{
-							"id": "sE52OfjfFleRkp49H",
-							"name": "Teaching",
-							"reference": "B224",
-							"tags": [
-								"Scholarly",
-								"Social"
-							],
-							"difficulty": "iq/a",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "s9ftBjQ1lVAEmEMKg",
-							"name": "Diplomacy",
-							"reference": "B187",
-							"tags": [
-								"Business",
-								"Police",
-								"Social"
-							],
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Politics",
-									"modifier": -6
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sTRg2eBXSnMox-EcP",
-							"name": "Strategy",
-							"reference": "B222",
-							"tags": [
-								"Military"
-							],
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Intelligence Analysis",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Tactics",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Strategy",
-									"modifier": -4
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sAR7wfNdP11O44JQ7",
-							"name": "Hiking",
-							"reference": "B200",
-							"tags": [
-								"Athletic",
-								"Exploration",
-								"Outdoor"
-							],
-							"difficulty": "ht/a",
-							"defaults": [
-								{
-									"type": "ht",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "s9sNn7n8sUYZLYTUo",
-							"name": "Intimidation",
-							"reference": "B202",
-							"tags": [
-								"Criminal",
-								"Police",
-								"Social",
-								"Street"
-							],
-							"difficulty": "will/a",
-							"defaults": [
-								{
-									"type": "will",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Acting",
-									"modifier": -3
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "s9IEVVDCjDd9HeYCd",
+							"id": "s8K8qfCvEKA0D8IM-",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sQ2Nj_TqMYKV7skUF"
+							},
 							"name": "Scrounging",
 							"reference": "B218",
 							"tags": [
@@ -10698,72 +9754,12 @@
 							"points": 1
 						},
 						{
-							"id": "sT2lfBB0-ZaV7SH0O",
-							"name": "Body Language",
-							"reference": "B181",
-							"tags": [
-								"Police",
-								"Social",
-								"Spy"
-							],
-							"difficulty": "per/a",
-							"defaults": [
-								{
-									"type": "skill",
-									"name": "Detect Lies",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Psychology",
-									"modifier": -4
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "soqUAvfIQcCl9wbX3",
-							"name": "Lip Reading",
-							"reference": "B205",
-							"tags": [
-								"Spy"
-							],
-							"difficulty": "per/a",
-							"defaults": [
-								{
-									"type": "per",
-									"modifier": -10
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "sAnJT497v1Ju9U6ZR",
-							"name": "Observation",
-							"reference": "B211",
-							"tags": [
-								"Criminal",
-								"Military",
-								"Police",
-								"Spy",
-								"Street"
-							],
-							"difficulty": "per/a",
-							"defaults": [
-								{
-									"type": "per",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Shadowing",
-									"modifier": -5
-								}
-							],
-							"points": 1
-						},
-						{
-							"id": "st2KqzAZtVUBaqhcB",
+							"id": "sXYKAEBHboh-ChUe1",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sW_dr_6QZxz1zrODT"
+							},
 							"name": "Search",
 							"reference": "B219",
 							"tags": [
@@ -10778,14 +9774,119 @@
 								},
 								{
 									"type": "skill",
-									"name": "Criminology",
+									"name": {
+										"compare": "is",
+										"qualifier": "Criminology"
+									},
 									"modifier": -5
 								}
 							],
 							"points": 1
 						},
 						{
-							"id": "sG27FyNps42TQx9-J",
+							"id": "sxqUOvHRSKIewuieU",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "svEm7OyeCu_9wJ8Kk"
+							},
+							"name": "Stealth",
+							"reference": "B222",
+							"tags": [
+								"Criminal",
+								"Police",
+								"Spy",
+								"Street"
+							],
+							"difficulty": "dx/a",
+							"encumbrance_penalty_multiplier": 1,
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -5
+								},
+								{
+									"type": "dx",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sBewhjlssYhUcuGQs",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sTzZdkEt9palkx6X8"
+							},
+							"name": "Strategy",
+							"reference": "B222",
+							"tags": [
+								"Military"
+							],
+							"specialization": "Land",
+							"difficulty": "iq/h",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Intelligence Analysis"
+									},
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Tactics"
+									},
+									"modifier": -6
+								},
+								{
+									"type": "skill",
+									"name": {
+										"compare": "is",
+										"qualifier": "Strategy"
+									},
+									"modifier": -4
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "sULahD349fUFoN3cE",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "sHJ4snJkuJRXIT85e"
+							},
+							"name": "Teaching",
+							"reference": "B224",
+							"tags": [
+								"Scholarly",
+								"Social"
+							],
+							"difficulty": "iq/a",
+							"defaults": [
+								{
+									"type": "iq",
+									"modifier": -5
+								}
+							],
+							"points": 1
+						},
+						{
+							"id": "s4PepOYCJTq06inVv",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Basic Set/Basic Set Skills.skl",
+								"id": "s3rs5bVG0nxQSZEGS"
+							},
 							"name": "Tracking",
 							"reference": "B226",
 							"tags": [
@@ -10800,282 +9901,14 @@
 								},
 								{
 									"type": "skill",
-									"name": "Naturalist",
+									"name": {
+										"compare": "is",
+										"qualifier": "Naturalist"
+									},
 									"modifier": -5
 								}
 							],
 							"points": 1
-						}
-					]
-				},
-				{
-					"id": "ScFLlIaK6uAUOjPLU",
-					"name": "Choose 4, or 2 points to raise one of those skills by a level",
-					"children": [
-						{
-							"id": "skiOt3UKDzDCPvLp9",
-							"name": "Aerobatics",
-							"reference": "B174",
-							"tags": [
-								"Athletic"
-							],
-							"difficulty": "dx/h",
-							"defaults": [
-								{
-									"type": "dx",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Acrobatics",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Aquabatics",
-									"modifier": -4
-								}
-							],
-							"points": 2
-						},
-						{
-							"id": "sQ9nwf0XaMvn7QP1q",
-							"name": "Fast-Talk",
-							"reference": "B195",
-							"tags": [
-								"Criminal",
-								"Social",
-								"Spy",
-								"Street"
-							],
-							"difficulty": "iq/a",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Acting",
-									"modifier": -5
-								}
-							],
-							"points": 2
-						},
-						{
-							"id": "sm4H28UEMKaZhwTPO",
-							"name": "Gambling",
-							"reference": "B197",
-							"tags": [
-								"Criminal",
-								"Social",
-								"Street"
-							],
-							"difficulty": "iq/a",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Mathematics",
-									"specialization": "Statistics",
-									"modifier": -5
-								}
-							],
-							"points": 2
-						},
-						{
-							"id": "sxqXCH9I1PUsVx3he",
-							"name": "Hidden Lore",
-							"reference": "B199",
-							"tags": [
-								"Knowledge"
-							],
-							"specialization": "Elder Things",
-							"difficulty": "iq/a",
-							"points": 2
-						},
-						{
-							"id": "srf-D3J5ytamXNsBA",
-							"name": "Interrogation",
-							"reference": "B202",
-							"tags": [
-								"Military",
-								"Police",
-								"Spy"
-							],
-							"difficulty": "iq/a",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Intimidation",
-									"modifier": -3
-								},
-								{
-									"type": "skill",
-									"name": "Psychology",
-									"modifier": -4
-								}
-							],
-							"points": 2
-						},
-						{
-							"id": "sGS5JJR1W-F13y31H",
-							"name": "Occultism",
-							"reference": "B212",
-							"tags": [
-								"Magical",
-								"Occult"
-							],
-							"difficulty": "iq/a",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -5
-								}
-							],
-							"points": 2
-						},
-						{
-							"id": "szoCaujClhHiPfFWP",
-							"name": "Hypnotism",
-							"reference": "B201",
-							"tags": [
-								"Medical"
-							],
-							"difficulty": "iq/h",
-							"points": 2
-						},
-						{
-							"id": "sAt9rwal2duTcsQnd",
-							"name": "Psychology",
-							"reference": "B216",
-							"tags": [
-								"Humanities",
-								"Social Sciences"
-							],
-							"specialization": "@Specialty@",
-							"difficulty": "iq/h",
-							"defaults": [
-								{
-									"type": "iq",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Sociology",
-									"modifier": -4
-								}
-							],
-							"points": 2
-						},
-						{
-							"id": "slutaKRftpuiw3WwH",
-							"name": "Mental Strength",
-							"reference": "B209",
-							"tags": [
-								"Esoteric"
-							],
-							"difficulty": "will/e",
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "starts_with",
-											"qualifier": "weapon master"
-										}
-									},
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "trained by a master"
-										}
-									}
-								]
-							},
-							"points": 2
-						},
-						{
-							"id": "shAuqQEV9XU9gxSAd",
-							"name": "Mind Block",
-							"reference": "B210",
-							"tags": [
-								"Esoteric"
-							],
-							"difficulty": "will/a",
-							"defaults": [
-								{
-									"type": "will",
-									"modifier": -5
-								},
-								{
-									"type": "skill",
-									"name": "Meditation",
-									"modifier": -5
-								}
-							],
-							"points": 2
-						},
-						{
-							"id": "sMMgMDN4IaW4eRHn9",
-							"name": "Meditation",
-							"reference": "B207",
-							"tags": [
-								"Esoteric"
-							],
-							"difficulty": "will/h",
-							"defaults": [
-								{
-									"type": "will",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Autohypnosis",
-									"modifier": -4
-								}
-							],
-							"points": 2
-						},
-						{
-							"id": "sRFhXlnMO6dsDv8oL",
-							"name": "Detect Lies",
-							"reference": "B187",
-							"tags": [
-								"Police",
-								"Social",
-								"Spy"
-							],
-							"difficulty": "per/h",
-							"defaults": [
-								{
-									"type": "per",
-									"modifier": -6
-								},
-								{
-									"type": "skill",
-									"name": "Body Language",
-									"modifier": -4
-								},
-								{
-									"type": "skill",
-									"name": "Psychology",
-									"modifier": -4
-								}
-							],
-							"points": 2
 						}
 					]
 				}


### PR DESCRIPTION
This pull request is mostly work from Savar on the GCS Discord to improve the Mentalist template and add the Mentalist lens.

I have also done some tinkering to make more of the skills, traits and modifiers in the templates have source library data - partly by adding the Psionic power modifier to a "Dungeon Fantasy 14 Trait Modifiers" file, and adding the psionic abilities, perks and power-ups to the Dungeon Fantasy 14 Traits file.

Please note that this also includes some traits' maximum levels, which is a feature newer than v5.44.0.
It also has a commit in common from #561, to make the Accessibility modifier's notes take up less when attached to a trait.