### PR TITLE
Fix DFRPG expert backstabbing

### DIFF
--- a/Library/Dungeon Fantasy RPG/Classes/Thief.gct
+++ b/Library/Dungeon Fantasy RPG/Classes/Thief.gct
@@ -605,7 +605,12 @@
 								},
 								{
 									"id": "tNR6WXBZPsaTF8CpI",
-									"name": "Expert Backstabing",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
+										"id": "tJsPuir5lZ4uW35vl"
+									},
+									"name": "Expert Backstabbing",
 									"reference": "DFA39",
 									"tags": [
 										"Advantage",

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -3768,7 +3768,7 @@
 		},
 		{
 			"id": "tJsPuir5lZ4uW35vl",
-			"name": "Expert Backstabing",
+			"name": "Expert Backstabbing",
 			"reference": "DFA39",
 			"tags": [
 				"Advantage",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Rogue 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Rogue 2.gct
@@ -474,7 +474,12 @@
 						},
 						{
 							"id": "tNR6WXBZPsaTF8CpI",
-							"name": "Expert Backstabing",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
+								"id": "tJsPuir5lZ4uW35vl"
+							},
+							"name": "Expert Backstabbing",
 							"reference": "DFA39",
 							"tags": [
 								"Advantage",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Rogue 3.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Rogue 3.gct
@@ -474,7 +474,12 @@
 						},
 						{
 							"id": "tNR6WXBZPsaTF8CpI",
-							"name": "Expert Backstabing",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
+								"id": "tJsPuir5lZ4uW35vl"
+							},
+							"name": "Expert Backstabbing",
 							"reference": "DFA39",
 							"tags": [
 								"Advantage",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Rogue.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Rogue.gct
@@ -441,7 +441,12 @@
 						},
 						{
 							"id": "tNR6WXBZPsaTF8CpI",
-							"name": "Expert Backstabing",
+							"source": {
+								"library": "richardwilkes/gcs_master_library",
+								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
+								"id": "tJsPuir5lZ4uW35vl"
+							},
+							"name": "Expert Backstabbing",
 							"reference": "DFA39",
 							"tags": [
 								"Advantage",


### PR DESCRIPTION
ArchBeth on the gcs discord pointed out there was a typo in the trait's name (Expert Backsta*b*ing).

This fixes that in the DFRPG Traits list, and in the templates that use Expert Backstabbing.