### PR TITLE
DFRPG Traits: sort the list alphabetically

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -40,6 +40,44 @@
 			}
 		},
 		{
+			"id": "tpqSHJrZERB3bRKz5",
+			"name": "@Mental Quirk@",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tEl07swnu7iN4snM9",
+			"name": "@Physical Quirk@",
+			"reference": "DFA68",
+			"tags": [
+				"Physical",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tJmB4zQaqf3-cVshy",
+			"name": "@Quirk@",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tXJH1POGzeky7LdsW",
 			"name": "Absent-Mindedness",
 			"reference": "DFA56",
@@ -199,6 +237,20 @@
 			}
 		},
 		{
+			"id": "tD5y-MMRYGgB-6oXS",
+			"name": "Admiration (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tLANxwsLF0L_sJo9F",
 			"name": "Aerial",
 			"reference": "DFM12",
@@ -226,189 +278,6 @@
 			"calc": {
 				"points": 100,
 				"current_level": 1
-			}
-		},
-		{
-			"id": "tJmB4zQaqf3-cVshy",
-			"name": "@Quirk@",
-			"reference": "DFA68",
-			"tags": [
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tanu5CGlA3VxZ-ISK",
-			"name": "Hobby (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tpqSHJrZERB3bRKz5",
-			"name": "@Mental Quirk@",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tEl07swnu7iN4snM9",
-			"name": "@Physical Quirk@",
-			"reference": "DFA68",
-			"tags": [
-				"Physical",
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "ticN0Q6sg54QKqL53",
-			"name": "Like (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk",
-				"Social"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "toPfyMD2mDr7lfk1Q",
-			"name": "Dislike (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tnM-jTSQy5XYt2a3u",
-			"name": "Habit (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tD5y-MMRYGgB-6oXS",
-			"name": "Admiration (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk",
-				"Social"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tGU6pQdbTEtWypJx7",
-			"name": "Speech Mannerism (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk",
-				"Social"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "toZ-5zAkPSLxZCTiF",
-			"name": "Dress Code (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk",
-				"Social"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tIVsKXnkj0R0szX0r",
-			"name": "Odd Belief (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk",
-				"Social"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tioXfuuD-pM6hbg-D",
-			"name": "Weak Disadvantage (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tWMeHPNmSscqzc_-C",
-			"name": "Trivial Disadvantage (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tyJBUUUWtc1jgubqj",
-			"name": "Embellishment to Disadvantage (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
 			}
 		},
 		{
@@ -3074,6 +2943,19 @@
 			}
 		},
 		{
+			"id": "toPfyMD2mDr7lfk1Q",
+			"name": "Dislike (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "td1Yo0h6MN10NsrLW",
 			"name": "Disturbing Voice",
 			"reference": "DFM13",
@@ -3322,6 +3204,20 @@
 			}
 		},
 		{
+			"id": "toZ-5zAkPSLxZCTiF",
+			"name": "Dress Code (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "TpmhxbrWpe_wJe-Jx",
 			"name": "Druidic Abilities",
 			"reference": "DFA23",
@@ -3468,6 +3364,18 @@
 			"base_points": 1,
 			"calc": {
 				"points": 1
+			}
+		},
+		{
+			"id": "tyJBUUUWtc1jgubqj",
+			"name": "Embellishment to Disadvantage (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -4250,139 +4158,6 @@
 			}
 		},
 		{
-			"id": "t9qZw2_vMennojjML",
-			"source": {
-				"library": "richardwilkes/gcs_master_library",
-				"path": "Power Ups/Power Ups Traits.adq",
-				"id": "tmcxLSlmTsms7d0wG"
-			},
-			"name": "Talent (Forest Guardian)",
-			"reference": "PU3:10, DF3:7, DFA44, FFE18",
-			"tags": [
-				"Advantage",
-				"Exotic",
-				"Mental",
-				"Supernatural",
-				"Talent"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": true,
-						"name": {
-							"compare": "ends_with",
-							"qualifier": "Elf"
-						}
-					}
-				]
-			},
-			"modifiers": [
-				{
-					"id": "M0XR8wemEmtx74MYj",
-					"name": "Benefits",
-					"children": [
-						{
-							"id": "musFB6-GcdlC50c0A",
-							"name": "Reaction Bonus",
-							"use_level_from_trait": true,
-							"features": [
-								{
-									"type": "reaction_bonus",
-									"situation": "From druids, Faeries, and bunnies.",
-									"amount": 1,
-									"per_level": true
-								}
-							]
-						},
-						{
-							"id": "msUXD-uX-YMOF6Hxh",
-							"name": "Alternative Benefit",
-							"use_level_from_trait": true,
-							"features": [
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to notice intruders, etc in woodland where you've lived from 6-level months.",
-									"amount": 1,
-									"per_level": true
-								}
-							],
-							"disabled": true
-						}
-					]
-				}
-			],
-			"points_per_level": 5,
-			"features": [
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Bow"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Camouflage"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Fast-Draw"
-					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "Arrow"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Stealth"
-					},
-					"amount": 1,
-					"per_level": true
-				},
-				{
-					"type": "skill_bonus",
-					"selection_type": "skills_with_name",
-					"name": {
-						"compare": "is",
-						"qualifier": "Survival"
-					},
-					"specialization": {
-						"compare": "is",
-						"qualifier": "Woodlands"
-					},
-					"amount": 1,
-					"per_level": true
-				}
-			],
-			"can_level": true,
-			"levels": 1,
-			"calc": {
-				"points": 5,
-				"current_level": 1
-			}
-		},
-		{
 			"id": "tWd5S9FMtk5ZlJ7Iv",
 			"name": "Frightens Animals",
 			"reference": "DFA60",
@@ -4593,6 +4368,19 @@
 			],
 			"calc": {
 				"points": -10
+			}
+		},
+		{
+			"id": "tnM-jTSQy5XYt2a3u",
+			"name": "Habit (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -5245,6 +5033,19 @@
 			"calc": {
 				"points": 5,
 				"current_level": 1
+			}
+		},
+		{
+			"id": "tanu5CGlA3VxZ-ISK",
+			"name": "Hobby (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -6211,6 +6012,20 @@
 			}
 		},
 		{
+			"id": "ticN0Q6sg54QKqL53",
+			"name": "Like (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tcy01B-6HK2nOZuRV",
 			"name": "Limited Camouflage",
 			"reference": "DFM11",
@@ -6791,6 +6606,20 @@
 			],
 			"calc": {
 				"points": 0
+			}
+		},
+		{
+			"id": "tIVsKXnkj0R0szX0r",
+			"name": "Odd Belief (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -8097,6 +7926,48 @@
 			}
 		},
 		{
+			"id": "tcai2fZI6YXeRMpgJ",
+			"name": "Sharp Teeth",
+			"reference": "DFA43",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 1,
+			"weapons": [
+				{
+					"id": "w_K7saFqgMJYszIL7",
+					"sv": 1,
+					"damage": {
+						"type": "cut",
+						"st": "thr",
+						"base": "-1"
+					},
+					"usage": "Bite",
+					"reach": "C",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
+						},
+						{
+							"type": "dx"
+						}
+					],
+					"calc": {
+						"damage": "thr-1 cut"
+					}
+				}
+			],
+			"calc": {
+				"points": 1
+			}
+		},
+		{
 			"id": "tm9auvdYXJZ0BUS9x",
 			"name": "Shield Mastery",
 			"reference": "DFA29",
@@ -8591,6 +8462,20 @@
 			}
 		},
 		{
+			"id": "tGU6pQdbTEtWypJx7",
+			"name": "Speech Mannerism (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tYPeYkkWBwFf693nb",
 			"name": "Spider-Climb",
 			"reference": "DFM12",
@@ -8782,45 +8667,136 @@
 			}
 		},
 		{
-			"id": "tcai2fZI6YXeRMpgJ",
-			"name": "Sharp Teeth",
-			"reference": "DFA43",
+			"id": "t9qZw2_vMennojjML",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Power Ups/Power Ups Traits.adq",
+				"id": "tmcxLSlmTsms7d0wG"
+			},
+			"name": "Talent (Forest Guardian)",
+			"reference": "PU3:10, DF3:7, DFA44, FFE18",
 			"tags": [
 				"Advantage",
 				"Exotic",
-				"Physical"
+				"Mental",
+				"Supernatural",
+				"Talent"
 			],
-			"base_points": 1,
-			"weapons": [
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "trait_prereq",
+						"has": true,
+						"name": {
+							"compare": "ends_with",
+							"qualifier": "Elf"
+						}
+					}
+				]
+			},
+			"modifiers": [
 				{
-					"id": "w_K7saFqgMJYszIL7",
-					"sv": 1,
-					"damage": {
-						"type": "cut",
-						"st": "thr",
-						"base": "-1"
-					},
-					"usage": "Bite",
-					"reach": "C",
-					"defaults": [
+					"id": "M0XR8wemEmtx74MYj",
+					"name": "Benefits",
+					"children": [
 						{
-							"type": "skill",
-							"name": {
-								"compare": "is",
-								"qualifier": "Brawling"
-							}
+							"id": "musFB6-GcdlC50c0A",
+							"name": "Reaction Bonus",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "reaction_bonus",
+									"situation": "From druids, Faeries, and bunnies.",
+									"amount": 1,
+									"per_level": true
+								}
+							]
 						},
 						{
-							"type": "dx"
+							"id": "msUXD-uX-YMOF6Hxh",
+							"name": "Alternative Benefit",
+							"use_level_from_trait": true,
+							"features": [
+								{
+									"type": "conditional_modifier",
+									"situation": "Bonus to notice intruders, etc in woodland where you've lived from 6-level months.",
+									"amount": 1,
+									"per_level": true
+								}
+							],
+							"disabled": true
 						}
-					],
-					"calc": {
-						"damage": "thr-1 cut"
-					}
+					]
 				}
 			],
+			"points_per_level": 5,
+			"features": [
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Bow"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Camouflage"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Fast-Draw"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Arrow"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Stealth"
+					},
+					"amount": 1,
+					"per_level": true
+				},
+				{
+					"type": "skill_bonus",
+					"selection_type": "skills_with_name",
+					"name": {
+						"compare": "is",
+						"qualifier": "Survival"
+					},
+					"specialization": {
+						"compare": "is",
+						"qualifier": "Woodlands"
+					},
+					"amount": 1,
+					"per_level": true
+				}
+			],
+			"can_level": true,
+			"levels": 1,
 			"calc": {
-				"points": 1
+				"points": 5,
+				"current_level": 1
 			}
 		},
 		{
@@ -9124,6 +9100,18 @@
 			"base_points": -15,
 			"calc": {
 				"points": -15
+			}
+		},
+		{
+			"id": "tWMeHPNmSscqzc_-C",
+			"name": "Trivial Disadvantage (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -9633,6 +9621,18 @@
 			}
 		},
 		{
+			"id": "tioXfuuD-pM6hbg-D",
+			"name": "Weak Disadvantage (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tglHg7wtR66XmqvY7",
 			"name": "Weakness",
 			"reference": "DFM14",
@@ -9714,333 +9714,6 @@
 			"id": "TUclVy7o2l531jLdA",
 			"name": "Wealth",
 			"children": [
-				{
-					"id": "tfHmfo2ucusu8hxpm",
-					"name": "Dead Broke",
-					"reference": "DFA67",
-					"local_notes": "Starting wealth is $0, you sell at 0%",
-					"tags": [
-						"Disadvantage",
-						"Social",
-						"Wealth"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Rich Beyond Measure"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Far Too Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Crazy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Stinking Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Average Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Poor"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Struggling"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Comfortable Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Very Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Filthy Rich"
-								}
-							}
-						]
-					},
-					"base_points": -25,
-					"calc": {
-						"points": -25
-					}
-				},
-				{
-					"id": "toDaCYi95LgGppaB9",
-					"name": "Poor",
-					"reference": "DFA67",
-					"local_notes": "Starting wealth is $200, you sell at 10%",
-					"tags": [
-						"Disadvantage",
-						"Social",
-						"Wealth"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Rich Beyond Measure"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Far Too Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Crazy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Stinking Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Average Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Dead Broke"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Struggling"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Comfortable Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Very Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Filthy Rich"
-								}
-							}
-						]
-					},
-					"base_points": -15,
-					"calc": {
-						"points": -15
-					}
-				},
-				{
-					"id": "tizD8SFRiMTJgERVx",
-					"name": "Struggling",
-					"reference": "DFA67",
-					"local_notes": "Starting wealth is $500, you sell at 20%",
-					"tags": [
-						"Disadvantage",
-						"Social",
-						"Wealth"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Rich Beyond Measure"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Far Too RIch"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Crazy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Stinking Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Average Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Dead Broke"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Poor"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Comfortable Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Very Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Filthy Rich"
-								}
-							}
-						]
-					},
-					"base_points": -10,
-					"calc": {
-						"points": -10
-					}
-				},
 				{
 					"id": "tv-hkvdKJkBvQnNst",
 					"name": "Average Wealth",
@@ -10261,456 +9934,6 @@
 					}
 				},
 				{
-					"id": "tC2zAZVbmELpUUQJ5",
-					"name": "Wealthy",
-					"reference": "DFA54",
-					"local_notes": "Starting wealth is $5000, you sell at 80%",
-					"tags": [
-						"Advantage",
-						"Social",
-						"Wealth"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Rich Beyond Measure"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Far Too Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Crazy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Stinking Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Average Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Dead Broke"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Poor"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Struggling"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Comfortable Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Very Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Filthy Rich"
-								}
-							}
-						]
-					},
-					"base_points": 20,
-					"calc": {
-						"points": 20
-					}
-				},
-				{
-					"id": "tw62wN9PSUOsPvkM-",
-					"name": "Very Wealthy",
-					"reference": "DFA54",
-					"local_notes": "Starting wealth is $20,000, you sell at 100%",
-					"tags": [
-						"Advantage",
-						"Social",
-						"Wealth"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Rich Beyond Measure"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Far Too Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Crazy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Stinking Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Average Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Dead Broke"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Poor"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Struggling"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Comfortable Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Filthy Rich"
-								}
-							}
-						]
-					},
-					"base_points": 30,
-					"calc": {
-						"points": 30
-					}
-				},
-				{
-					"id": "tE-1d7ORxYf-GQmFN",
-					"name": "Filthy Rich",
-					"reference": "DFRC2:49",
-					"local_notes": "Starting wealth is $100,000, you sell at 100%",
-					"tags": [
-						"Advantage",
-						"Social",
-						"Wealth"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Rich Beyond Measure"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Far Too Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Crazy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Stinking Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Average Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Dead Broke"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Poor"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Struggling"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Comfortable Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Very Wealthy"
-								}
-							}
-						]
-					},
-					"base_points": 50,
-					"features": [
-						{
-							"type": "conditional_modifier",
-							"situation": "to any roll within your realm that money and title could influence",
-							"amount": 1
-						}
-					],
-					"calc": {
-						"points": 50
-					}
-				},
-				{
-					"id": "t4lRx3OCYfWndN0DB",
-					"name": "Stinking Rich",
-					"reference": "DFRC2:49",
-					"local_notes": "Starting wealth is $1,000,000, you sell at 100%",
-					"tags": [
-						"Advantage",
-						"Social",
-						"Wealth"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Rich Beyond Measure"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Far Too Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Crazy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Filthy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Average Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Dead Broke"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Poor"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Struggling"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Comfortable Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Very Wealthy"
-								}
-							}
-						]
-					},
-					"base_points": 75,
-					"features": [
-						{
-							"type": "conditional_modifier",
-							"situation": "to any roll within your realm that money and title could influence",
-							"amount": 2
-						}
-					],
-					"calc": {
-						"points": 75
-					}
-				},
-				{
 					"id": "tMAhrEI2tvSpv4eFi",
 					"name": "Crazy Rich",
 					"reference": "DFRC2:49",
@@ -10824,6 +10047,115 @@
 					],
 					"calc": {
 						"points": 100
+					}
+				},
+				{
+					"id": "tfHmfo2ucusu8hxpm",
+					"name": "Dead Broke",
+					"reference": "DFA67",
+					"local_notes": "Starting wealth is $0, you sell at 0%",
+					"tags": [
+						"Disadvantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": -25,
+					"calc": {
+						"points": -25
 					}
 				},
 				{
@@ -10943,6 +10275,231 @@
 					}
 				},
 				{
+					"id": "tE-1d7ORxYf-GQmFN",
+					"name": "Filthy Rich",
+					"reference": "DFRC2:49",
+					"local_notes": "Starting wealth is $100,000, you sell at 100%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							}
+						]
+					},
+					"base_points": 50,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to any roll within your realm that money and title could influence",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 50
+					}
+				},
+				{
+					"id": "toDaCYi95LgGppaB9",
+					"name": "Poor",
+					"reference": "DFA67",
+					"local_notes": "Starting wealth is $200, you sell at 10%",
+					"tags": [
+						"Disadvantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": -15,
+					"calc": {
+						"points": -15
+					}
+				},
+				{
 					"id": "ttD2aYm7pqgj-jeYe",
 					"name": "Rich Beyond Measure",
 					"reference": "DFRC2:49",
@@ -11056,6 +10613,449 @@
 					],
 					"calc": {
 						"points": 150
+					}
+				},
+				{
+					"id": "t4lRx3OCYfWndN0DB",
+					"name": "Stinking Rich",
+					"reference": "DFRC2:49",
+					"local_notes": "Starting wealth is $1,000,000, you sell at 100%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							}
+						]
+					},
+					"base_points": 75,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to any roll within your realm that money and title could influence",
+							"amount": 2
+						}
+					],
+					"calc": {
+						"points": 75
+					}
+				},
+				{
+					"id": "tizD8SFRiMTJgERVx",
+					"name": "Struggling",
+					"reference": "DFA67",
+					"local_notes": "Starting wealth is $500, you sell at 20%",
+					"tags": [
+						"Disadvantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too RIch"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": -10,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "tw62wN9PSUOsPvkM-",
+					"name": "Very Wealthy",
+					"reference": "DFA54",
+					"local_notes": "Starting wealth is $20,000, you sell at 100%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": 30,
+					"calc": {
+						"points": 30
+					}
+				},
+				{
+					"id": "tC2zAZVbmELpUUQJ5",
+					"name": "Wealthy",
+					"reference": "DFA54",
+					"local_notes": "Starting wealth is $5000, you sell at 80%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": 20,
+					"calc": {
+						"points": 20
 					}
 				}
 			],

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -9711,1347 +9711,1356 @@
 			}
 		},
 		{
-			"id": "tfHmfo2ucusu8hxpm",
-			"name": "Dead Broke",
-			"reference": "DFA67",
-			"local_notes": "Starting wealth is $0, you sell at 0%",
-			"tags": [
-				"Disadvantage",
-				"Social",
-				"Wealth"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Rich Beyond Measure"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Far Too Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Crazy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Stinking Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Average Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Poor"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Struggling"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Comfortable Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Very Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Filthy Rich"
-						}
-					}
-				]
-			},
-			"base_points": -25,
-			"calc": {
-				"points": -25
-			}
-		},
-		{
-			"id": "toDaCYi95LgGppaB9",
-			"name": "Poor",
-			"reference": "DFA67",
-			"local_notes": "Starting wealth is $200, you sell at 10%",
-			"tags": [
-				"Disadvantage",
-				"Social",
-				"Wealth"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Rich Beyond Measure"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Far Too Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Crazy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Stinking Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Average Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Dead Broke"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Struggling"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Comfortable Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Very Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Filthy Rich"
-						}
-					}
-				]
-			},
-			"base_points": -15,
-			"calc": {
-				"points": -15
-			}
-		},
-		{
-			"id": "tizD8SFRiMTJgERVx",
-			"name": "Struggling",
-			"reference": "DFA67",
-			"local_notes": "Starting wealth is $500, you sell at 20%",
-			"tags": [
-				"Disadvantage",
-				"Social",
-				"Wealth"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Rich Beyond Measure"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Far Too RIch"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Crazy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Stinking Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Average Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Dead Broke"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Poor"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Comfortable Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Very Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Filthy Rich"
-						}
-					}
-				]
-			},
-			"base_points": -10,
-			"calc": {
-				"points": -10
-			}
-		},
-		{
-			"id": "tv-hkvdKJkBvQnNst",
-			"name": "Average Wealth",
-			"reference": "DFA54",
-			"reference_highlight": "Average",
-			"local_notes": "Starting wealth is $1000, you sell at 40%",
-			"tags": [
-				"Advantage",
-				"Social",
-				"Wealth"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Rich Beyond Measure"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Far Too Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Crazy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Stinking Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Comfortable Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Dead Broke"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Poor"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Struggling"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Very Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Filthy Rich"
-						}
-					}
-				]
-			},
-			"calc": {
-				"points": 0
-			}
-		},
-		{
-			"id": "tB2OkJgHurcPtkScL",
-			"name": "Comfortable Wealth",
-			"reference": "DFA54",
-			"reference_highlight": "Comfortable",
-			"local_notes": "Starting wealth is $2000, you sell at 60%",
-			"tags": [
-				"Advantage",
-				"Social",
-				"Wealth"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Rich Beyond Measure"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Far Too Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Crazy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Stinking Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Average Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Dead Broke"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Poor"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Struggling"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Very Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Filthy Rich"
-						}
-					}
-				]
-			},
-			"base_points": 10,
-			"calc": {
-				"points": 10
-			}
-		},
-		{
-			"id": "tC2zAZVbmELpUUQJ5",
-			"name": "Wealthy",
-			"reference": "DFA54",
-			"local_notes": "Starting wealth is $5000, you sell at 80%",
-			"tags": [
-				"Advantage",
-				"Social",
-				"Wealth"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Rich Beyond Measure"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Far Too Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Crazy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Stinking Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Average Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Dead Broke"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Poor"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Struggling"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Comfortable Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Very Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Filthy Rich"
-						}
-					}
-				]
-			},
-			"base_points": 20,
-			"calc": {
-				"points": 20
-			}
-		},
-		{
-			"id": "tw62wN9PSUOsPvkM-",
-			"name": "Very Wealthy",
-			"reference": "DFA54",
-			"local_notes": "Starting wealth is $20,000, you sell at 100%",
-			"tags": [
-				"Advantage",
-				"Social",
-				"Wealth"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Rich Beyond Measure"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Far Too Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Crazy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Stinking Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Average Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Dead Broke"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Poor"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Struggling"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Comfortable Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Filthy Rich"
-						}
-					}
-				]
-			},
-			"base_points": 30,
-			"calc": {
-				"points": 30
-			}
-		},
-		{
-			"id": "tE-1d7ORxYf-GQmFN",
-			"name": "Filthy Rich",
-			"reference": "DFRC2:49",
-			"local_notes": "Starting wealth is $100,000, you sell at 100%",
-			"tags": [
-				"Advantage",
-				"Social",
-				"Wealth"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Rich Beyond Measure"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Far Too Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Crazy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Stinking Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Average Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Dead Broke"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Poor"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Struggling"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Comfortable Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Very Wealthy"
-						}
-					}
-				]
-			},
-			"base_points": 50,
-			"features": [
+			"id": "TUclVy7o2l531jLdA",
+			"name": "Wealth",
+			"children": [
 				{
-					"type": "conditional_modifier",
-					"situation": "to any roll within your realm that money and title could influence",
-					"amount": 1
+					"id": "tfHmfo2ucusu8hxpm",
+					"name": "Dead Broke",
+					"reference": "DFA67",
+					"local_notes": "Starting wealth is $0, you sell at 0%",
+					"tags": [
+						"Disadvantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": -25,
+					"calc": {
+						"points": -25
+					}
+				},
+				{
+					"id": "toDaCYi95LgGppaB9",
+					"name": "Poor",
+					"reference": "DFA67",
+					"local_notes": "Starting wealth is $200, you sell at 10%",
+					"tags": [
+						"Disadvantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": -15,
+					"calc": {
+						"points": -15
+					}
+				},
+				{
+					"id": "tizD8SFRiMTJgERVx",
+					"name": "Struggling",
+					"reference": "DFA67",
+					"local_notes": "Starting wealth is $500, you sell at 20%",
+					"tags": [
+						"Disadvantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too RIch"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": -10,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "tv-hkvdKJkBvQnNst",
+					"name": "Average Wealth",
+					"reference": "DFA54",
+					"reference_highlight": "Average",
+					"local_notes": "Starting wealth is $1000, you sell at 40%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"calc": {
+						"points": 0
+					}
+				},
+				{
+					"id": "tB2OkJgHurcPtkScL",
+					"name": "Comfortable Wealth",
+					"reference": "DFA54",
+					"reference_highlight": "Comfortable",
+					"local_notes": "Starting wealth is $2000, you sell at 60%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": 10,
+					"calc": {
+						"points": 10
+					}
+				},
+				{
+					"id": "tC2zAZVbmELpUUQJ5",
+					"name": "Wealthy",
+					"reference": "DFA54",
+					"local_notes": "Starting wealth is $5000, you sell at 80%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": 20,
+					"calc": {
+						"points": 20
+					}
+				},
+				{
+					"id": "tw62wN9PSUOsPvkM-",
+					"name": "Very Wealthy",
+					"reference": "DFA54",
+					"local_notes": "Starting wealth is $20,000, you sell at 100%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": 30,
+					"calc": {
+						"points": 30
+					}
+				},
+				{
+					"id": "tE-1d7ORxYf-GQmFN",
+					"name": "Filthy Rich",
+					"reference": "DFRC2:49",
+					"local_notes": "Starting wealth is $100,000, you sell at 100%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							}
+						]
+					},
+					"base_points": 50,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to any roll within your realm that money and title could influence",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 50
+					}
+				},
+				{
+					"id": "t4lRx3OCYfWndN0DB",
+					"name": "Stinking Rich",
+					"reference": "DFRC2:49",
+					"local_notes": "Starting wealth is $1,000,000, you sell at 100%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							}
+						]
+					},
+					"base_points": 75,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to any roll within your realm that money and title could influence",
+							"amount": 2
+						}
+					],
+					"calc": {
+						"points": 75
+					}
+				},
+				{
+					"id": "tMAhrEI2tvSpv4eFi",
+					"name": "Crazy Rich",
+					"reference": "DFRC2:49",
+					"local_notes": "Starting wealth is $10,000,000, you sell at 100%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							}
+						]
+					},
+					"base_points": 100,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to any roll within your realm that money and title could influence",
+							"amount": 3
+						}
+					],
+					"calc": {
+						"points": 100
+					}
+				},
+				{
+					"id": "tNoRaAgr1cInqHyFa",
+					"name": "Far Too Rich",
+					"reference": "DFRC2:49",
+					"local_notes": "Starting wealth is $100,000,000, you sell at 100%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							}
+						]
+					},
+					"base_points": 125,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to any roll within your realm that money and title could influence",
+							"amount": 4
+						}
+					],
+					"calc": {
+						"points": 125
+					}
+				},
+				{
+					"id": "ttD2aYm7pqgj-jeYe",
+					"name": "Rich Beyond Measure",
+					"reference": "DFRC2:49",
+					"local_notes": "Starting wealth is $1,000,000,000, you sell at 100%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							}
+						]
+					},
+					"base_points": 150,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to any roll within your realm that money and title could influence",
+							"amount": 5
+						}
+					],
+					"calc": {
+						"points": 150
+					}
 				}
 			],
 			"calc": {
-				"points": 50
-			}
-		},
-		{
-			"id": "t4lRx3OCYfWndN0DB",
-			"name": "Stinking Rich",
-			"reference": "DFRC2:49",
-			"local_notes": "Starting wealth is $1,000,000, you sell at 100%",
-			"tags": [
-				"Advantage",
-				"Social",
-				"Wealth"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Rich Beyond Measure"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Far Too Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Crazy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Filthy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Average Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Dead Broke"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Poor"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Struggling"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Comfortable Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Very Wealthy"
-						}
-					}
-				]
-			},
-			"base_points": 75,
-			"features": [
-				{
-					"type": "conditional_modifier",
-					"situation": "to any roll within your realm that money and title could influence",
-					"amount": 2
-				}
-			],
-			"calc": {
-				"points": 75
-			}
-		},
-		{
-			"id": "tMAhrEI2tvSpv4eFi",
-			"name": "Crazy Rich",
-			"reference": "DFRC2:49",
-			"local_notes": "Starting wealth is $10,000,000, you sell at 100%",
-			"tags": [
-				"Advantage",
-				"Social",
-				"Wealth"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Rich Beyond Measure"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Far Too Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Stinking Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Filthy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Average Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Dead Broke"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Poor"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Struggling"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Comfortable Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Very Wealthy"
-						}
-					}
-				]
-			},
-			"base_points": 100,
-			"features": [
-				{
-					"type": "conditional_modifier",
-					"situation": "to any roll within your realm that money and title could influence",
-					"amount": 3
-				}
-			],
-			"calc": {
-				"points": 100
-			}
-		},
-		{
-			"id": "tNoRaAgr1cInqHyFa",
-			"name": "Far Too Rich",
-			"reference": "DFRC2:49",
-			"local_notes": "Starting wealth is $100,000,000, you sell at 100%",
-			"tags": [
-				"Advantage",
-				"Social",
-				"Wealth"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Rich Beyond Measure"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Crazy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Stinking Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Filthy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Average Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Dead Broke"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Poor"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Struggling"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Comfortable Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Very Wealthy"
-						}
-					}
-				]
-			},
-			"base_points": 125,
-			"features": [
-				{
-					"type": "conditional_modifier",
-					"situation": "to any roll within your realm that money and title could influence",
-					"amount": 4
-				}
-			],
-			"calc": {
-				"points": 125
-			}
-		},
-		{
-			"id": "ttD2aYm7pqgj-jeYe",
-			"name": "Rich Beyond Measure",
-			"reference": "DFRC2:49",
-			"local_notes": "Starting wealth is $1,000,000,000, you sell at 100%",
-			"tags": [
-				"Advantage",
-				"Social",
-				"Wealth"
-			],
-			"prereqs": {
-				"type": "prereq_list",
-				"all": true,
-				"prereqs": [
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Far Too Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Crazy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Stinking Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Filthy Rich"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Average Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Dead Broke"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Poor"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Struggling"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Comfortable Wealth"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Wealthy"
-						}
-					},
-					{
-						"type": "trait_prereq",
-						"has": false,
-						"name": {
-							"compare": "is",
-							"qualifier": "Very Wealthy"
-						}
-					}
-				]
-			},
-			"base_points": 150,
-			"features": [
-				{
-					"type": "conditional_modifier",
-					"situation": "to any roll within your realm that money and title could influence",
-					"amount": 5
-				}
-			],
-			"calc": {
-				"points": 150
+				"points": 510
 			}
 		},
 		{

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -40,6 +40,44 @@
 			}
 		},
 		{
+			"id": "tpqSHJrZERB3bRKz5",
+			"name": "@Mental Quirk@",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tEl07swnu7iN4snM9",
+			"name": "@Physical Quirk@",
+			"reference": "DFA68",
+			"tags": [
+				"Physical",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
+			"id": "tJmB4zQaqf3-cVshy",
+			"name": "@Quirk@",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tXJH1POGzeky7LdsW",
 			"name": "Absent-Mindedness",
 			"reference": "DFA56",
@@ -199,6 +237,20 @@
 			}
 		},
 		{
+			"id": "tD5y-MMRYGgB-6oXS",
+			"name": "Admiration (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tLANxwsLF0L_sJo9F",
 			"name": "Aerial",
 			"reference": "DFM12",
@@ -226,189 +278,6 @@
 			"calc": {
 				"points": 100,
 				"current_level": 1
-			}
-		},
-		{
-			"id": "tJmB4zQaqf3-cVshy",
-			"name": "@Quirk@",
-			"reference": "DFA68",
-			"tags": [
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tanu5CGlA3VxZ-ISK",
-			"name": "Hobby (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tpqSHJrZERB3bRKz5",
-			"name": "@Mental Quirk@",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tEl07swnu7iN4snM9",
-			"name": "@Physical Quirk@",
-			"reference": "DFA68",
-			"tags": [
-				"Physical",
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "ticN0Q6sg54QKqL53",
-			"name": "Like (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk",
-				"Social"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "toPfyMD2mDr7lfk1Q",
-			"name": "Dislike (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tnM-jTSQy5XYt2a3u",
-			"name": "Habit (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tD5y-MMRYGgB-6oXS",
-			"name": "Admiration (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk",
-				"Social"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tGU6pQdbTEtWypJx7",
-			"name": "Speech Mannerism (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk",
-				"Social"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "toZ-5zAkPSLxZCTiF",
-			"name": "Dress Code (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk",
-				"Social"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tIVsKXnkj0R0szX0r",
-			"name": "Odd Belief (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Mental",
-				"Quirk",
-				"Social"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tioXfuuD-pM6hbg-D",
-			"name": "Weak Disadvantage (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tWMeHPNmSscqzc_-C",
-			"name": "Trivial Disadvantage (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
-			}
-		},
-		{
-			"id": "tyJBUUUWtc1jgubqj",
-			"name": "Embellishment to Disadvantage (@Subject@)",
-			"reference": "DFA68",
-			"tags": [
-				"Quirk"
-			],
-			"base_points": -1,
-			"calc": {
-				"points": -1
 			}
 		},
 		{
@@ -3074,6 +2943,19 @@
 			}
 		},
 		{
+			"id": "toPfyMD2mDr7lfk1Q",
+			"name": "Dislike (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "td1Yo0h6MN10NsrLW",
 			"name": "Disturbing Voice",
 			"reference": "DFM13",
@@ -3322,6 +3204,20 @@
 			}
 		},
 		{
+			"id": "toZ-5zAkPSLxZCTiF",
+			"name": "Dress Code (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "TpmhxbrWpe_wJe-Jx",
 			"name": "Druidic Abilities",
 			"reference": "DFA23",
@@ -3468,6 +3364,18 @@
 			"base_points": 1,
 			"calc": {
 				"points": 1
+			}
+		},
+		{
+			"id": "tyJBUUUWtc1jgubqj",
+			"name": "Embellishment to Disadvantage (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -4562,6 +4470,19 @@
 			}
 		},
 		{
+			"id": "tnM-jTSQy5XYt2a3u",
+			"name": "Habit (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "t-ZoIVX9Udlp3XnmY",
 			"name": "Halfling Marksmanship",
 			"reference": "DFA45",
@@ -5211,6 +5132,19 @@
 			"calc": {
 				"points": 5,
 				"current_level": 1
+			}
+		},
+		{
+			"id": "tanu5CGlA3VxZ-ISK",
+			"name": "Hobby (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -6219,6 +6153,20 @@
 			}
 		},
 		{
+			"id": "ticN0Q6sg54QKqL53",
+			"name": "Like (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tcy01B-6HK2nOZuRV",
 			"name": "Limited Camouflage",
 			"reference": "DFM11",
@@ -6799,6 +6747,20 @@
 			],
 			"calc": {
 				"points": 0
+			}
+		},
+		{
+			"id": "tIVsKXnkj0R0szX0r",
+			"name": "Odd Belief (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -8105,6 +8067,48 @@
 			}
 		},
 		{
+			"id": "tcai2fZI6YXeRMpgJ",
+			"name": "Sharp Teeth",
+			"reference": "DFA43",
+			"tags": [
+				"Advantage",
+				"Exotic",
+				"Physical"
+			],
+			"base_points": 1,
+			"weapons": [
+				{
+					"id": "w_K7saFqgMJYszIL7",
+					"sv": 1,
+					"damage": {
+						"type": "cut",
+						"st": "thr",
+						"base": "-1"
+					},
+					"usage": "Bite",
+					"reach": "C",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
+						},
+						{
+							"type": "dx"
+						}
+					],
+					"calc": {
+						"damage": "thr-1 cut"
+					}
+				}
+			],
+			"calc": {
+				"points": 1
+			}
+		},
+		{
 			"id": "tm9auvdYXJZ0BUS9x",
 			"name": "Shield Mastery",
 			"reference": "DFA29",
@@ -8599,6 +8603,20 @@
 			}
 		},
 		{
+			"id": "tGU6pQdbTEtWypJx7",
+			"name": "Speech Mannerism (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Mental",
+				"Quirk",
+				"Social"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tYPeYkkWBwFf693nb",
 			"name": "Spider-Climb",
 			"reference": "DFM12",
@@ -8787,48 +8805,6 @@
 			"base_points": 150,
 			"calc": {
 				"points": 150
-			}
-		},
-		{
-			"id": "tcai2fZI6YXeRMpgJ",
-			"name": "Sharp Teeth",
-			"reference": "DFA43",
-			"tags": [
-				"Advantage",
-				"Exotic",
-				"Physical"
-			],
-			"base_points": 1,
-			"weapons": [
-				{
-					"id": "w_K7saFqgMJYszIL7",
-					"sv": 1,
-					"damage": {
-						"type": "cut",
-						"st": "thr",
-						"base": "-1"
-					},
-					"usage": "Bite",
-					"reach": "C",
-					"defaults": [
-						{
-							"type": "skill",
-							"name": {
-								"compare": "is",
-								"qualifier": "Brawling"
-							}
-						},
-						{
-							"type": "dx"
-						}
-					],
-					"calc": {
-						"damage": "thr-1 cut"
-					}
-				}
-			],
-			"calc": {
-				"points": 1
 			}
 		},
 		{
@@ -9132,6 +9108,18 @@
 			"base_points": -15,
 			"calc": {
 				"points": -15
+			}
+		},
+		{
+			"id": "tWMeHPNmSscqzc_-C",
+			"name": "Trivial Disadvantage (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
 			}
 		},
 		{
@@ -9641,6 +9629,18 @@
 			}
 		},
 		{
+			"id": "tioXfuuD-pM6hbg-D",
+			"name": "Weak Disadvantage (@Subject@)",
+			"reference": "DFA68",
+			"tags": [
+				"Quirk"
+			],
+			"base_points": -1,
+			"calc": {
+				"points": -1
+			}
+		},
+		{
 			"id": "tglHg7wtR66XmqvY7",
 			"name": "Weakness",
 			"reference": "DFM14",
@@ -9722,333 +9722,6 @@
 			"id": "TUclVy7o2l531jLdA",
 			"name": "Wealth",
 			"children": [
-				{
-					"id": "tfHmfo2ucusu8hxpm",
-					"name": "Dead Broke",
-					"reference": "DFA67",
-					"local_notes": "Starting wealth is $0, you sell at 0%",
-					"tags": [
-						"Disadvantage",
-						"Social",
-						"Wealth"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Rich Beyond Measure"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Far Too Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Crazy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Stinking Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Average Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Poor"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Struggling"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Comfortable Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Very Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Filthy Rich"
-								}
-							}
-						]
-					},
-					"base_points": -25,
-					"calc": {
-						"points": -25
-					}
-				},
-				{
-					"id": "toDaCYi95LgGppaB9",
-					"name": "Poor",
-					"reference": "DFA67",
-					"local_notes": "Starting wealth is $200, you sell at 10%",
-					"tags": [
-						"Disadvantage",
-						"Social",
-						"Wealth"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Rich Beyond Measure"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Far Too Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Crazy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Stinking Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Average Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Dead Broke"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Struggling"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Comfortable Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Very Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Filthy Rich"
-								}
-							}
-						]
-					},
-					"base_points": -15,
-					"calc": {
-						"points": -15
-					}
-				},
-				{
-					"id": "tizD8SFRiMTJgERVx",
-					"name": "Struggling",
-					"reference": "DFA67",
-					"local_notes": "Starting wealth is $500, you sell at 20%",
-					"tags": [
-						"Disadvantage",
-						"Social",
-						"Wealth"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Rich Beyond Measure"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Far Too RIch"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Crazy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Stinking Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Average Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Dead Broke"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Poor"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Comfortable Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Very Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Filthy Rich"
-								}
-							}
-						]
-					},
-					"base_points": -10,
-					"calc": {
-						"points": -10
-					}
-				},
 				{
 					"id": "tv-hkvdKJkBvQnNst",
 					"name": "Average Wealth",
@@ -10269,456 +9942,6 @@
 					}
 				},
 				{
-					"id": "tC2zAZVbmELpUUQJ5",
-					"name": "Wealthy",
-					"reference": "DFA54",
-					"local_notes": "Starting wealth is $5000, you sell at 80%",
-					"tags": [
-						"Advantage",
-						"Social",
-						"Wealth"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Rich Beyond Measure"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Far Too Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Crazy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Stinking Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Average Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Dead Broke"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Poor"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Struggling"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Comfortable Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Very Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Filthy Rich"
-								}
-							}
-						]
-					},
-					"base_points": 20,
-					"calc": {
-						"points": 20
-					}
-				},
-				{
-					"id": "tw62wN9PSUOsPvkM-",
-					"name": "Very Wealthy",
-					"reference": "DFA54",
-					"local_notes": "Starting wealth is $20,000, you sell at 100%",
-					"tags": [
-						"Advantage",
-						"Social",
-						"Wealth"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Rich Beyond Measure"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Far Too Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Crazy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Stinking Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Average Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Dead Broke"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Poor"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Struggling"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Comfortable Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Filthy Rich"
-								}
-							}
-						]
-					},
-					"base_points": 30,
-					"calc": {
-						"points": 30
-					}
-				},
-				{
-					"id": "tE-1d7ORxYf-GQmFN",
-					"name": "Filthy Rich",
-					"reference": "DFRC2:49",
-					"local_notes": "Starting wealth is $100,000, you sell at 100%",
-					"tags": [
-						"Advantage",
-						"Social",
-						"Wealth"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Rich Beyond Measure"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Far Too Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Crazy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Stinking Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Average Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Dead Broke"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Poor"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Struggling"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Comfortable Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Very Wealthy"
-								}
-							}
-						]
-					},
-					"base_points": 50,
-					"features": [
-						{
-							"type": "conditional_modifier",
-							"situation": "to any roll within your realm that money and title could influence",
-							"amount": 1
-						}
-					],
-					"calc": {
-						"points": 50
-					}
-				},
-				{
-					"id": "t4lRx3OCYfWndN0DB",
-					"name": "Stinking Rich",
-					"reference": "DFRC2:49",
-					"local_notes": "Starting wealth is $1,000,000, you sell at 100%",
-					"tags": [
-						"Advantage",
-						"Social",
-						"Wealth"
-					],
-					"prereqs": {
-						"type": "prereq_list",
-						"all": true,
-						"prereqs": [
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Rich Beyond Measure"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Far Too Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Crazy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Filthy Rich"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Average Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Dead Broke"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Poor"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Struggling"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Comfortable Wealth"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Wealthy"
-								}
-							},
-							{
-								"type": "trait_prereq",
-								"has": false,
-								"name": {
-									"compare": "is",
-									"qualifier": "Very Wealthy"
-								}
-							}
-						]
-					},
-					"base_points": 75,
-					"features": [
-						{
-							"type": "conditional_modifier",
-							"situation": "to any roll within your realm that money and title could influence",
-							"amount": 2
-						}
-					],
-					"calc": {
-						"points": 75
-					}
-				},
-				{
 					"id": "tMAhrEI2tvSpv4eFi",
 					"name": "Crazy Rich",
 					"reference": "DFRC2:49",
@@ -10832,6 +10055,115 @@
 					],
 					"calc": {
 						"points": 100
+					}
+				},
+				{
+					"id": "tfHmfo2ucusu8hxpm",
+					"name": "Dead Broke",
+					"reference": "DFA67",
+					"local_notes": "Starting wealth is $0, you sell at 0%",
+					"tags": [
+						"Disadvantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": -25,
+					"calc": {
+						"points": -25
 					}
 				},
 				{
@@ -10951,6 +10283,231 @@
 					}
 				},
 				{
+					"id": "tE-1d7ORxYf-GQmFN",
+					"name": "Filthy Rich",
+					"reference": "DFRC2:49",
+					"local_notes": "Starting wealth is $100,000, you sell at 100%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							}
+						]
+					},
+					"base_points": 50,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to any roll within your realm that money and title could influence",
+							"amount": 1
+						}
+					],
+					"calc": {
+						"points": 50
+					}
+				},
+				{
+					"id": "toDaCYi95LgGppaB9",
+					"name": "Poor",
+					"reference": "DFA67",
+					"local_notes": "Starting wealth is $200, you sell at 10%",
+					"tags": [
+						"Disadvantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": -15,
+					"calc": {
+						"points": -15
+					}
+				},
+				{
 					"id": "ttD2aYm7pqgj-jeYe",
 					"name": "Rich Beyond Measure",
 					"reference": "DFRC2:49",
@@ -11064,6 +10621,449 @@
 					],
 					"calc": {
 						"points": 150
+					}
+				},
+				{
+					"id": "t4lRx3OCYfWndN0DB",
+					"name": "Stinking Rich",
+					"reference": "DFRC2:49",
+					"local_notes": "Starting wealth is $1,000,000, you sell at 100%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							}
+						]
+					},
+					"base_points": 75,
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to any roll within your realm that money and title could influence",
+							"amount": 2
+						}
+					],
+					"calc": {
+						"points": 75
+					}
+				},
+				{
+					"id": "tizD8SFRiMTJgERVx",
+					"name": "Struggling",
+					"reference": "DFA67",
+					"local_notes": "Starting wealth is $500, you sell at 20%",
+					"tags": [
+						"Disadvantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too RIch"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": -10,
+					"calc": {
+						"points": -10
+					}
+				},
+				{
+					"id": "tw62wN9PSUOsPvkM-",
+					"name": "Very Wealthy",
+					"reference": "DFA54",
+					"local_notes": "Starting wealth is $20,000, you sell at 100%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": 30,
+					"calc": {
+						"points": 30
+					}
+				},
+				{
+					"id": "tC2zAZVbmELpUUQJ5",
+					"name": "Wealthy",
+					"reference": "DFA54",
+					"local_notes": "Starting wealth is $5000, you sell at 80%",
+					"tags": [
+						"Advantage",
+						"Social",
+						"Wealth"
+					],
+					"prereqs": {
+						"type": "prereq_list",
+						"all": true,
+						"prereqs": [
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Rich Beyond Measure"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Far Too Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Crazy Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Stinking Rich"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Average Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Dead Broke"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Poor"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Struggling"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Comfortable Wealth"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Very Wealthy"
+								}
+							},
+							{
+								"type": "trait_prereq",
+								"has": false,
+								"name": {
+									"compare": "is",
+									"qualifier": "Filthy Rich"
+								}
+							}
+						]
+					},
+					"base_points": 20,
+					"calc": {
+						"points": 20
 					}
 				}
 			],

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -128,7 +128,7 @@
 		},
 		{
 			"id": "tB__Kj3_Gj55OtljV",
-			"name": "Acute Taste \u0026 Smell",
+			"name": "Acute Taste & Smell",
 			"reference": "DFA46",
 			"tags": [
 				"Advantage",
@@ -8032,15 +8032,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -8063,12 +8072,18 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling",
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Karate",
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							},
 							"modifier": -2
 						}
 					],
@@ -8790,7 +8805,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -11901,7 +11919,7 @@
 				},
 				{
 					"id": "mo580RX5rJhS3RG7m",
-					"name": "Two weapons (@First Weapon@ \u0026 @Second Weapon@)",
+					"name": "Two weapons (@First Weapon@ & @Second Weapon@)",
 					"reference": "DFA54",
 					"cost_adj": "25",
 					"features": [


### PR DESCRIPTION
 Trait lists could be arranged manually, or sorted automatically.

Being arranged manually could be a result of adding traits in the order that they're listed in the book - this *could* be approximated by sorting by page reference, and then sorting by name where the page references are identical.

This can cause problems if you accidentally sort the list while it's being edited.
* If it wasn't being edited, you could just close the tab and discard the changes, preserving the manual arrangement.
* Because you're making changes, you now have to choose between destroying the original arrangement, trying to recreate it from memory, or discarding your changes and starting over.

I think it would be better for trait lists that the ordering isn't obvious and easy to fix, for the trait list to always be automatically sorted, and alphabetically A-Z is an easy one to scroll through to search for things in by eye.

These changes are built on top of the changes in #578 and should be merged after #578.