### PR TITLE
High Tech Equipment: Fix the MP5 and add missing variants

### DIFF
--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -46989,6 +46989,187 @@
 			}
 		},
 		{
+			"id": "en7NDhHRNt8I7n4oT",
+			"description": "H&K MP5, 9x19mm",
+			"reference": "HT123",
+			"reference_highlight": "The original MP5",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "1500",
+			"base_weight": "6 lb",
+			"weapons": [
+				{
+					"id": "Ww9qXLufPV8uXb5rB",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "3d-1"
+					},
+					"strength": "8†",
+					"accuracy": "4",
+					"range": "170/1,900",
+					"rate_of_fire": "13",
+					"shots": "30+1(3)",
+					"bulk": "-4",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Submachine Gun"
+							}
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Rifle"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shotgun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Light Machine Gun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Submachine Gun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gun!"
+							}
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Grenade Launcher"
+							},
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gyroc"
+							},
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Light Anti-Armor Weapon"
+							},
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "3d-1 pi"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "fAKs2s6A-4oIwujLt",
+					"name": "Using unloaded stats",
+					"cost": "-29",
+					"weight": "-1.2 lb",
+					"disabled": true
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 1500,
+				"extended_value": 1500,
+				"weight": "6 lb",
+				"extended_weight": "6 lb"
+			}
+		},
+		{
 			"id": "ehSPF5Qlq2njY7GqT",
 			"description": "H&K MP5A3, 9x19mm",
 			"reference": "HT124",

--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -47351,6 +47351,187 @@
 			}
 		},
 		{
+			"id": "eApsNX4s0iJ84NJk8",
+			"description": "H&K MP5A2, 9x19mm",
+			"reference": "HT123",
+			"reference_highlight": "The MP5A2",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "1500",
+			"base_weight": "6 lb",
+			"weapons": [
+				{
+					"id": "WQlSHRld58pe4tzD-",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "3d-1"
+					},
+					"strength": "8†",
+					"accuracy": "4",
+					"range": "170/1,900",
+					"rate_of_fire": "13",
+					"shots": "30+1(3)",
+					"bulk": "-4",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Submachine Gun"
+							}
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Rifle"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shotgun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Light Machine Gun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Submachine Gun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gun!"
+							}
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Grenade Launcher"
+							},
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gyroc"
+							},
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Light Anti-Armor Weapon"
+							},
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "3d-1 pi"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "ffheP-NOfKgA6OYkR",
+					"name": "Using unloaded stats",
+					"cost": "-29",
+					"weight": "-1.2 lb",
+					"disabled": true
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 1500,
+				"extended_value": 1500,
+				"weight": "6 lb",
+				"extended_weight": "6 lb"
+			}
+		},
+		{
 			"id": "ehSPF5Qlq2njY7GqT",
 			"description": "H&K MP5A3, 9x19mm",
 			"reference": "HT124",

--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -48156,7 +48156,7 @@
 			"base_weight": "7.8 lb",
 			"weapons": [
 				{
-					"id": "WVtT-EgKdTwSphS5r",
+					"id": "Ww5FF75SLFtGZljle",
 					"sv": 1,
 					"damage": {
 						"type": "pi+",
@@ -48165,7 +48165,7 @@
 					"strength": "9†",
 					"accuracy": "4",
 					"range": "280/3,100",
-					"rate_of_fire": "6/13",
+					"rate_of_fire": "6/13!",
 					"shots": "30+1(3)",
 					"bulk": "-4*",
 					"recoil": "3",
@@ -48308,7 +48308,7 @@
 			],
 			"modifiers": [
 				{
-					"id": "flk_5Eik0scKiTTcE",
+					"id": "f01IsmtSkw9I7RHpd",
 					"name": "Using unloaded stats",
 					"cost": "-29",
 					"weight": "-1.5 lb",
@@ -48360,7 +48360,7 @@
 			"base_weight": "7.6 lb",
 			"weapons": [
 				{
-					"id": "WRlgzGquq7_683mec",
+					"id": "WHiTyXQlj8i7zCCV0",
 					"sv": 1,
 					"damage": {
 						"type": "pi+",
@@ -48369,7 +48369,7 @@
 					"strength": "8†",
 					"accuracy": "4",
 					"range": "190/2,000",
-					"rate_of_fire": "6/13",
+					"rate_of_fire": "6/13!",
 					"shots": "30+1(3)",
 					"bulk": "-4*",
 					"recoil": "2",
@@ -48512,7 +48512,7 @@
 			],
 			"modifiers": [
 				{
-					"id": "fZUVALWW-voFfVoi1",
+					"id": "fPkywSrICdG8wRAl-",
 					"name": "Using unloaded stats",
 					"cost": "-29",
 					"weight": "-1.3 lb",

--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -47712,6 +47712,187 @@
 			}
 		},
 		{
+			"id": "e41NqWQnCqoEql4z4",
+			"description": "H&K MP5A4, 9x19mm",
+			"reference": "HT123",
+			"reference_highlight": "The MP5A4",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "1500",
+			"base_weight": "7.5 lb",
+			"weapons": [
+				{
+					"id": "WLDhiiLKolviLIIzC",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "3d-1"
+					},
+					"strength": "8†",
+					"accuracy": "4",
+					"range": "170/1,900",
+					"rate_of_fire": "9/13!",
+					"shots": "30+1(3)",
+					"bulk": "-4",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Submachine Gun"
+							}
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Rifle"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shotgun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Light Machine Gun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Submachine Gun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gun!"
+							}
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Grenade Launcher"
+							},
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gyroc"
+							},
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Light Anti-Armor Weapon"
+							},
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "3d-1 pi"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "fWYQIZ2Mt6ehsWmf1",
+					"name": "Using unloaded stats",
+					"cost": "-29",
+					"weight": "-1.2 lb",
+					"disabled": true
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 1500,
+				"extended_value": 1500,
+				"weight": "7.5 lb",
+				"extended_weight": "7.5 lb"
+			}
+		},
+		{
 			"id": "EYwhrAFYFySfVw2zM",
 			"description": "H&K MP5A3, 9x19mm 15-round magazine",
 			"reference": "HT123",

--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -48731,6 +48731,188 @@
 			}
 		},
 		{
+			"id": "e_vXSGxw0Uy9H6Hww",
+			"description": "H&K MP5N, 9x19mm",
+			"reference": "HT123",
+			"reference_highlight": "The MP5N",
+			"local_notes": "ambidextrous grip",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "1500",
+			"base_weight": "7.5 lb",
+			"weapons": [
+				{
+					"id": "WNoqybFFGMyhg5yaZ",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "3d-1"
+					},
+					"strength": "8†",
+					"accuracy": "4",
+					"range": "170/1,900",
+					"rate_of_fire": "13",
+					"shots": "30+1(3)",
+					"bulk": "-4*",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Submachine Gun"
+							}
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Rifle"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shotgun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Light Machine Gun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Submachine Gun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gun!"
+							}
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Grenade Launcher"
+							},
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gyroc"
+							},
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Light Anti-Armor Weapon"
+							},
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "3d-1 pi"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "fes2E1m5nBavyngNQ",
+					"name": "Using unloaded stats",
+					"cost": "-29",
+					"weight": "-1.2 lb",
+					"disabled": true
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 1500,
+				"extended_value": 1500,
+				"weight": "7.5 lb",
+				"extended_weight": "7.5 lb"
+			}
+		},
+		{
 			"id": "e45o89fVSPiP5G_Wj",
 			"description": "H&K MP5SD3, 9x19mm",
 			"reference": "HT124",

--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -47180,13 +47180,13 @@
 				"Magazines",
 				"Submachine Gun"
 			],
-			"base_value": "27",
+			"base_value": "22.5",
 			"base_weight": "0.31 lb",
 			"quantity": 1,
 			"equipped": true,
 			"calc": {
-				"value": 27,
-				"extended_value": 27,
+				"value": 22.5,
+				"extended_value": 22.5,
 				"weight": "0.31 lb",
 				"extended_weight": "0.31 lb"
 			}
@@ -47203,13 +47203,13 @@
 				"Magazines",
 				"Submachine Gun"
 			],
-			"base_value": "29",
+			"base_value": "20",
 			"base_weight": "0.42 lb",
 			"quantity": 1,
 			"equipped": true,
 			"calc": {
-				"value": 29,
-				"extended_value": 29,
+				"value": 20,
+				"extended_value": 20,
 				"weight": "0.42 lb",
 				"extended_weight": "0.42 lb"
 			}
@@ -47226,13 +47226,13 @@
 				"Magazines",
 				"Submachine Gun"
 			],
-			"base_value": "313",
+			"base_value": "283",
 			"base_weight": "2.2 lb",
 			"quantity": 1,
 			"equipped": true,
 			"calc": {
-				"value": 313,
-				"extended_value": 313,
+				"value": 283,
+				"extended_value": 283,
 				"weight": "2.2 lb",
 				"extended_weight": "2.2 lb"
 			}
@@ -47430,13 +47430,13 @@
 				"Magazines",
 				"Submachine Gun"
 			],
-			"base_value": "29",
+			"base_value": "11",
 			"base_weight": "0.24 lb",
 			"quantity": 1,
 			"equipped": true,
 			"calc": {
-				"value": 29,
-				"extended_value": 29,
+				"value": 11,
+				"extended_value": 11,
 				"weight": "0.24 lb",
 				"extended_weight": "0.24 lb"
 			}
@@ -47634,13 +47634,13 @@
 				"Magazines",
 				"Submachine Gun"
 			],
-			"base_value": "29",
+			"base_value": "20",
 			"base_weight": "0.25 lb",
 			"quantity": 1,
 			"equipped": true,
 			"calc": {
-				"value": 29,
-				"extended_value": 29,
+				"value": 20,
+				"extended_value": 20,
 				"weight": "0.25 lb",
 				"extended_weight": "0.25 lb"
 			}

--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -47170,6 +47170,187 @@
 			}
 		},
 		{
+			"id": "e1VC3qFSCCHwoB75e",
+			"description": "H&K MP5A1, 9x19mm",
+			"reference": "HT123",
+			"reference_highlight": "The MP5A1",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "1500",
+			"base_weight": "5.3 lb",
+			"weapons": [
+				{
+					"id": "WcM2JnjvRU5MPufha",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "3d-1"
+					},
+					"strength": "8†",
+					"accuracy": "3",
+					"range": "170/1,900",
+					"rate_of_fire": "13",
+					"shots": "30+1(3)",
+					"bulk": "-3",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Submachine Gun"
+							}
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Rifle"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shotgun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Light Machine Gun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Submachine Gun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gun!"
+							}
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Grenade Launcher"
+							},
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gyroc"
+							},
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Light Anti-Armor Weapon"
+							},
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "3d-1 pi"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "fdLMT0_9-79ISOKMx",
+					"name": "Using unloaded stats",
+					"cost": "-29",
+					"weight": "-1.2 lb",
+					"disabled": true
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 1500,
+				"extended_value": 1500,
+				"weight": "5.3 lb",
+				"extended_weight": "5.3 lb"
+			}
+		},
+		{
 			"id": "ehSPF5Qlq2njY7GqT",
 			"description": "H&K MP5A3, 9x19mm",
 			"reference": "HT124",

--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -47010,7 +47010,7 @@
 					"strength": "8†",
 					"accuracy": "4",
 					"range": "170/1,900",
-					"rate_of_fire": "18",
+					"rate_of_fire": "13",
 					"shots": "30+1(3)",
 					"bulk": "-4*",
 					"recoil": "2",

--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -48075,7 +48075,7 @@
 		},
 		{
 			"id": "EYwhrAFYFySfVw2zM",
-			"description": "H&K MP5A3, 9x19mm 15-round magazine",
+			"description": "H&K MP5, 9x19mm 15-round magazine",
 			"reference": "HT123",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "7",
@@ -48098,7 +48098,7 @@
 		},
 		{
 			"id": "EDlNYo1n2ckFINtv_",
-			"description": "H&K MP5A3, 9x19mm 30-round magazine",
+			"description": "H&K MP5, 9x19mm 30-round magazine",
 			"reference": "HT123",
 			"local_notes": "Requires 9x19mm ammunition",
 			"tech_level": "7",
@@ -48121,7 +48121,7 @@
 		},
 		{
 			"id": "E4Ii5NWM8dtMm9lXf",
-			"description": "H&K MP5A3, 9x19mm 100-round drum magazine",
+			"description": "H&K MP5, 9x19mm 100-round drum magazine",
 			"reference": "HT123",
 			"local_notes": "-1 Bulk, Requires 9x19mm ammunition",
 			"tech_level": "7",

--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -47893,6 +47893,187 @@
 			}
 		},
 		{
+			"id": "eMi4yMvcqjfa0sIaw",
+			"description": "H&K MP5A5, 9x19mm",
+			"reference": "HT123",
+			"reference_highlight": "The MP5A5",
+			"tech_level": "7",
+			"legality_class": "2",
+			"tags": [
+				"Firearms"
+			],
+			"base_value": "1500",
+			"base_weight": "7.5 lb",
+			"weapons": [
+				{
+					"id": "W2VS8k6NwADvbkRto",
+					"sv": 1,
+					"damage": {
+						"type": "pi",
+						"base": "3d-1"
+					},
+					"strength": "8†",
+					"accuracy": "4",
+					"range": "170/1,900",
+					"rate_of_fire": "9/13!",
+					"shots": "30+1(3)",
+					"bulk": "-4*",
+					"recoil": "2",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Submachine Gun"
+							}
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Rifle"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shotgun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Light Machine Gun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Submachine Gun"
+							},
+							"modifier": -2
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gun!"
+							}
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Grenade Launcher"
+							},
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gyroc"
+							},
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Light Anti-Armor Weapon"
+							},
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "3d-1 pi"
+					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "f9TsPicXpYFkQZddW",
+					"name": "Using unloaded stats",
+					"cost": "-29",
+					"weight": "-1.2 lb",
+					"disabled": true
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 1500,
+				"extended_value": 1500,
+				"weight": "7.5 lb",
+				"extended_weight": "7.5 lb"
+			}
+		},
+		{
 			"id": "EYwhrAFYFySfVw2zM",
 			"description": "H&K MP5A3, 9x19mm 15-round magazine",
 			"reference": "HT123",


### PR DESCRIPTION
This does:
* Fix the cost of the MP5's magazines double-counting the cost of ammunition
* Fix the MP5's RoF being erroneously listed as 18 instead of 13.
* Add the MP5, MP5A1 to MP5A5 and MP5N variants.
* Rename the MP5's magazines to not be MP5A3-exclusive.
* Change the RoF of the MP5/10A3 and MP5/40A3 to have their highest RoF marked as full-automatic.