### PR TITLE
Dungeon Fantasy 8: Add Decorative Embellishments

### DIFF
--- a/Library/Dungeon Fantasy/Dungeon Fantasy 8/Dungeon Fantasy 8 Equipment Modifiers.eqm
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 8/Dungeon Fantasy 8 Equipment Modifiers.eqm
@@ -1,0 +1,533 @@
+{
+	"version": 5,
+	"rows": [
+		{
+			"id": "flW7z7AC-TZwIYPB8",
+			"name": "Beading, Cheap, Extensive",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+4 CF"
+		},
+		{
+			"id": "fqpdUjCJbUkP_rEmj",
+			"name": "Beading, Cheap, Minimal",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+1.5 CF"
+		},
+		{
+			"id": "fzjlJGIa5pNplezqK",
+			"name": "Beading, Expensive, Extensive",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+7 CF"
+		},
+		{
+			"id": "fTfFcsO6TpcKbf95U",
+			"name": "Beading, Expensive, Minimal",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+3 CF"
+		},
+		{
+			"id": "fpsAnBrAwfBmhXLIP",
+			"name": "Beads/Nails, Extensive",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Hard"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+2 CF"
+		},
+		{
+			"id": "f8S00kHTd1dboUtDq",
+			"name": "Beads/Nails, Minimal",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Hard"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+0.75 CF"
+		},
+		{
+			"id": "fnAmpt9fV3d0rWRMs",
+			"name": "Bells, Cheap",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+3 CF"
+		},
+		{
+			"id": "fz5Y2TiJclfP-gQ3S",
+			"name": "Bells, Expensive",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+10 CF"
+		},
+		{
+			"id": "fbbvGqM43MVOYFWWL",
+			"name": "Block Printing",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+0.5 CF"
+		},
+		{
+			"id": "f4GuBFHM7U94yVRp-",
+			"name": "Branding",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+0.5 CF"
+		},
+		{
+			"id": "fE-Db_terdYlcvkv-",
+			"name": "Branding",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Hard"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+1 CF"
+		},
+		{
+			"id": "fQjssd3GTtAhHUVJJ",
+			"name": "Dyed, Average",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+4 CF"
+		},
+		{
+			"id": "fXk4xY9JuDtZghuyF",
+			"name": "Dyed, Cheap",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+1.5 CF"
+		},
+		{
+			"id": "fm5F068gKeXmzcfXD",
+			"name": "Dyed, Expensive",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+8 CF"
+		},
+		{
+			"id": "fYqGyAPCHbtxrHtxP",
+			"name": "Embroidery, Extensive",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+5 CF"
+		},
+		{
+			"id": "fguybERccM-OvtfYz",
+			"name": "Embroidery, Minimal",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+2 CF"
+		},
+		{
+			"id": "fgw17Bvs36U8gAu1U",
+			"name": "Exceptional Material",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Hard"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+19 CF"
+		},
+		{
+			"id": "fbsLJRlfVUGEZQARh",
+			"name": "Exceptional Material",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+19 CF"
+		},
+		{
+			"id": "fSYlWQ8AXzuV4L9FK",
+			"name": "Feathers, Elaborate",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+4 CF"
+		},
+		{
+			"id": "fT-jlaoKP74p0ygru",
+			"name": "Feathers, Simple",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+0.5 CF"
+		},
+		{
+			"id": "foFnzBelAgNStSJVs",
+			"name": "Fine Material",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+2 CF"
+		},
+		{
+			"id": "fhyWnQFH_V6DHMIEc",
+			"name": "Fine Material",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Hard"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+2 CF"
+		},
+		{
+			"id": "fZ4zqFktSgoIIstZc",
+			"name": "Fringe, Cheap",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+1 CF"
+		},
+		{
+			"id": "fkkzFm2rf0NLPaQIJ",
+			"name": "Fringe, Cheap",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Hard"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+0.25 CF"
+		},
+		{
+			"id": "fJflPSSeKy9AT25g_",
+			"name": "Fringe, Expensive",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+6 CF"
+		},
+		{
+			"id": "fzLnM8EbLcvu1QxXx",
+			"name": "Fringe, Expensive",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Hard"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+0.5 CF"
+		},
+		{
+			"id": "fpkmHcFcxn3RSE8SK",
+			"name": "Fur Trim, Cheap",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+3 CF"
+		},
+		{
+			"id": "ftWdkbHmmT9gDQgiQ",
+			"name": "Fur Trim, Expensive",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+8 CF"
+		},
+		{
+			"id": "f4du_jFAEN_xZxRk2",
+			"name": "Gilding",
+			"reference": "DF8:55",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+19 CF"
+		},
+		{
+			"id": "fpFzftBJbT-hqQtK2",
+			"name": "Inlay, Cheap, Extensive",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+7 CF"
+		},
+		{
+			"id": "f5yJd_BPAoup71b88",
+			"name": "Inlay, Cheap, Minimal",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+2.5 CF"
+		},
+		{
+			"id": "fX87HL1sFpDEupmXZ",
+			"name": "Inlay, Expensive, Extensive",
+			"reference": "DF8:55",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+14 CF"
+		},
+		{
+			"id": "f9pbeY34xofH08HvZ",
+			"name": "Inlay, Expensive, Minimal",
+			"reference": "DF8:55",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+6 CF"
+		},
+		{
+			"id": "fjuJqWJgsNCandM3j",
+			"name": "Lace, Extensive",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+9 CF"
+		},
+		{
+			"id": "f4pR1D8CUtK3lqFJ9",
+			"name": "Lace, Minimal",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+3.5 CF"
+		},
+		{
+			"id": "f8DwGQKKqMr5fFyXB",
+			"name": "Painting/Enamel, Extensive",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Hard"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+5 CF"
+		},
+		{
+			"id": "fZjgcb1r2RzvGAUlL",
+			"name": "Painting/Enamel, Minimal",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Hard"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+2 CF"
+		},
+		{
+			"id": "frRBtj6a_dOP6_V0o",
+			"name": "Patchwork, Cheap",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+2 CF"
+		},
+		{
+			"id": "fVmfjZ5gMBBKONJ7W",
+			"name": "Patchwork, Expensive",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+5 CF"
+		},
+		{
+			"id": "fN5j34VSc101yMDrJ",
+			"name": "Patchwork Quilt",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+8 CF"
+		},
+		{
+			"id": "f2wbzB5p71WufE3f_",
+			"name": "Quilting",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+4 CF"
+		},
+		{
+			"id": "fbgZszeBoW-FvGPye",
+			"name": "Relief, Extensive",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Hard"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+4 CF"
+		},
+		{
+			"id": "ferAAgeLwKO7XvmNz",
+			"name": "Relief, Minimal",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Hard"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+1.5 CF"
+		},
+		{
+			"id": "f2oCgW6SX3hm-1OCI",
+			"name": "Resist Dyed",
+			"reference": "DF8:53",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+2.5 CF"
+		},
+		{
+			"id": "fAfy7fJBwgggPpUEN",
+			"name": "Silver Plated",
+			"reference": "DF8:55",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+2 CF"
+		},
+		{
+			"id": "fWW_058rw8WfC4PyG",
+			"name": "Tapestry Weaving",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+6 CF"
+		},
+		{
+			"id": "fGnHVsxL7txga4clV",
+			"name": "Tattooed, Extensive",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+6 CF"
+		},
+		{
+			"id": "fJCAx0j-NYD4d5FaN",
+			"name": "Tattooed, Minimal",
+			"reference": "DF8:54",
+			"tags": [
+				"Decorative Embellishment",
+				"Soft"
+			],
+			"cost_type": "to_base_cost",
+			"cost": "+2 CF"
+		}
+	]
+}


### PR DESCRIPTION
This includes all of the Decorative Embellishments from DF8 from page 53 to 55, except Jeweled, since the cost of jewels varies and could be managed by turning the clothing into an equipment container and adding jewels from DF8 Equipment.

This was contributed by Savar via Discord.

I have made some minor tweaks from Savar's contribution, including:
* Put them in a file named "Dungeon Fantasy 8 Equipment Modifiers", since there are other equipment modifiers in DF8 that could also be added to the Master Library.
* Change the tag from "Embellishment" to "Decorative Embellishment" to contrast with "Supernatural Embellishment"s if added later.
* Sort them alphabetically (manual ordering can get accidentally destroyed by automatically sorting and create untidy diffs that are harder to review).