### PR TITLE
Basic Set Traits: Update alternate form to name the form and specify the cost

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -1910,14 +1910,24 @@
 		},
 		{
 			"id": "tqyRvrXKWtUMlIEQe",
-			"name": "Alternate Form",
+			"name": "Alternate Form (@Form@)",
 			"reference": "B83",
+			"local_notes": "<script>entity.exists ? \"\" : \"Set levels equal to how much more the form costs than your base form, if it's your most expensive form\"</script>",
 			"tags": [
 				"Advantage",
 				"Exotic",
 				"Physical"
 			],
 			"modifiers": [
+				{
+					"id": "mhWix3XezU6yjuhRe",
+					"name": "Only one alternate form",
+					"reference": "B84",
+					"reference_highlight": "If you have a single Alternate Form",
+					"cost_adj": "-10%",
+					"affects": "levels_only",
+					"disabled": true
+				},
 				{
 					"id": "mz87VPNn5Q7CVrEob",
 					"name": "Cosmetic",
@@ -1987,8 +1997,12 @@
 				}
 			],
 			"base_points": 15,
+			"points_per_level": 1,
+			"can_level": true,
 			"calc": {
-				"points": 15
+				"points": 15,
+				"resolved_notes": "Set levels equal to how much more the form costs than your base form, if it's your most expensive form",
+				"current_level": 0
 			}
 		},
 		{

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -59,8 +59,8 @@
 			"reference": "B100, PU2:13",
 			"reference_highlight": "Perks",
 			"tags": [
-				"Physical",
-				"Perk"
+				"Perk",
+				"Physical"
 			],
 			"base_points": 1,
 			"calc": {
@@ -73,8 +73,8 @@
 			"reference": "B100, PU2:17",
 			"reference_highlight": "Perks",
 			"tags": [
-				"Social",
-				"Perk"
+				"Perk",
+				"Social"
 			],
 			"base_points": 1,
 			"calc": {
@@ -87,8 +87,8 @@
 			"reference": "B100, PU2:19",
 			"reference_highlight": "Perks",
 			"tags": [
-				"Supernatural",
-				"Perk"
+				"Perk",
+				"Supernatural"
 			],
 			"base_points": 1,
 			"calc": {
@@ -129,8 +129,8 @@
 			"reference": "B162, PU6:32",
 			"reference_highlight": "Quirks",
 			"tags": [
-				"Social",
-				"Quirk"
+				"Quirk",
+				"Social"
 			],
 			"base_points": -1,
 			"calc": {
@@ -143,8 +143,8 @@
 			"reference": "B162, PU6:33",
 			"reference_highlight": "Quirks",
 			"tags": [
-				"Supernatural",
-				"Quirk"
+				"Quirk",
+				"Supernatural"
 			],
 			"base_points": -1,
 			"calc": {
@@ -447,7 +447,7 @@
 		},
 		{
 			"id": "tAZ31tXG_HzDmVCRp",
-			"name": "Acute Taste \u0026 Smell",
+			"name": "Acute Taste & Smell",
 			"reference": "B35",
 			"tags": [
 				"Advantage",
@@ -1404,13 +1404,16 @@
 					"damage": {
 						"type": "aff"
 					},
-					"usage_notes": "Resist at \u003cscript\u003eformatNum(1-self.attachedTo.level, false, true)\u003c/script\u003e",
+					"usage_notes": "Resist at <script>formatNum(1-self.attachedTo.level, false, true)</script>",
 					"reach": "C",
 					"parry": "0",
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -1427,7 +1430,7 @@
 					"damage": {
 						"type": "aff"
 					},
-					"usage_notes": "Resist at \u003cscript\u003eformatNum(1-self.attachedTo.level, false, true)\u003c/script\u003e",
+					"usage_notes": "Resist at <script>formatNum(1-self.attachedTo.level, false, true)</script>",
 					"accuracy": "3",
 					"range": "10/100",
 					"rate_of_fire": "1",
@@ -1435,12 +1438,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -1907,7 +1919,7 @@
 			],
 			"modifiers": [
 				{
-					"id": "mpY0iLP8m3hJ-j7E9",
+					"id": "mz87VPNn5Q7CVrEob",
 					"name": "Cosmetic",
 					"reference": "B84",
 					"cost_adj": "-50%",
@@ -1915,7 +1927,7 @@
 					"disabled": true
 				},
 				{
-					"id": "mj2U1G7sRgp1zkjUN",
+					"id": "m9Fel4NlgxR0_3TRc",
 					"name": "Absorptive Change",
 					"reference": "P75",
 					"local_notes": "@Level of Absorptive Change. 1 None, 2, Light, 3, Medium, 4, Heavy, 5, Extra Heavy@",
@@ -1925,7 +1937,7 @@
 					"disabled": true
 				},
 				{
-					"id": "mdvgQf0f9_TxkwZ5r",
+					"id": "mLt6pWvn-Zo3LlEfa",
 					"name": "Active Change",
 					"reference": "P75",
 					"cost_adj": "20%",
@@ -1933,7 +1945,7 @@
 					"disabled": true
 				},
 				{
-					"id": "mbZxWjs2_ZxgMnaD9",
+					"id": "m0r1LFX4nWKS8Gbpo",
 					"name": "Non-Reciprocal Damage",
 					"reference": "P75",
 					"cost_adj": "50%",
@@ -1941,7 +1953,7 @@
 					"disabled": true
 				},
 				{
-					"id": "moVGKg9uVbnXH0Wm2",
+					"id": "mq6kg6TTUqUu4QCtX",
 					"name": "Once On, Stays On",
 					"reference": "P75",
 					"cost_adj": "50%",
@@ -1949,7 +1961,7 @@
 					"disabled": true
 				},
 				{
-					"id": "mT7eUx78V4f089O2U",
+					"id": "mTzNRvbg6L5qeZzWr",
 					"name": "Reciprocal Rest",
 					"reference": "P75",
 					"cost_adj": "30%",
@@ -1957,7 +1969,7 @@
 					"disabled": true
 				},
 				{
-					"id": "mRjnWuIqlekfi_j3E",
+					"id": "mZdOX58LdojEAftgW",
 					"name": "Projected Form",
 					"reference": "P75",
 					"cost_adj": "-50%",
@@ -1965,7 +1977,7 @@
 					"disabled": true
 				},
 				{
-					"id": "mB20loMWhiD_uU5_M",
+					"id": "mp7YPYBQH0LtrfqCU",
 					"name": "Takes Extra Time",
 					"reference": "B115",
 					"cost_adj": "-10%",
@@ -3364,7 +3376,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -3389,12 +3404,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -3503,15 +3527,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -3535,12 +3568,18 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling",
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Karate",
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							},
 							"modifier": -2
 						}
 					],
@@ -5670,7 +5709,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -5856,7 +5898,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -8184,7 +8229,7 @@
 							"id": "mnmgUy__PpxcSuWvG",
 							"name": "Powerful Individual",
 							"reference": "B135",
-							"local_notes": "\\\u003e150% of your starting points",
+							"local_notes": "\\>150% of your starting points",
 							"cost_adj": "-20",
 							"disabled": true
 						},
@@ -9318,7 +9363,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -11357,12 +11405,18 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling",
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Karate",
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							},
 							"modifier": -2
 						}
 					],
@@ -11759,7 +11813,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -11850,7 +11907,7 @@
 				"prereqs": [
 					{
 						"type": "script_prereq",
-						"script": "if (entity.exists) {\n  var points = 0;\n  for (const skill of entity.findSkills(\"@Skill@\")) {\n    points += skill.points;\n  }\n  if (points \u003e 0) {\n    \"No points are invested in @Skill@\"\n  } else {\n    \"\"\n  }\n} else {\n  \"\"\n}"
+						"script": "if (entity.exists) {\n  var points = 0;\n  for (const skill of entity.findSkills(\"@Skill@\")) {\n    points += skill.points;\n  }\n  if (points > 0) {\n    \"No points are invested in @Skill@\"\n  } else {\n    \"\"\n  }\n} else {\n  \"\"\n}"
 					}
 				]
 			},
@@ -12410,7 +12467,7 @@
 					"id": "mWZ94aEkMmxYd7uwx",
 					"name": "Homogenous",
 					"reference": "B60",
-					"local_notes": "Altered wound modifiers: imp \u0026 pi++ are x1/2, pi+ is x1/3, pi is x1/5, pi- is x1/10",
+					"local_notes": "Altered wound modifiers: imp & pi++ are x1/2, pi+ is x1/3, pi is x1/5, pi- is x1/10",
 					"cost_adj": "40",
 					"disabled": true
 				},
@@ -12466,7 +12523,7 @@
 					"id": "m_m2GNV0JSNZjPj-C",
 					"name": "Unliving",
 					"reference": "B61",
-					"local_notes": "Altered wound modifiers: imp \u0026 pi++ are x1, pi+ is x1/2, pi is x1/3, pi- is x1/5",
+					"local_notes": "Altered wound modifiers: imp & pi++ are x1, pi+ is x1/2, pi is x1/3, pi- is x1/5",
 					"cost_adj": "20",
 					"disabled": true
 				}
@@ -13026,7 +13083,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -13051,12 +13111,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -13620,7 +13689,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -13645,12 +13717,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -14121,7 +14202,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -14146,12 +14230,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -14623,7 +14716,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -14648,12 +14744,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -15249,7 +15354,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -15274,12 +15382,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -15750,7 +15867,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -15775,12 +15895,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -16251,7 +16380,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -16276,12 +16408,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -16767,7 +16908,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -16792,12 +16936,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -17283,7 +17436,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -17308,12 +17464,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -17785,7 +17950,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -17810,12 +17978,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -18386,7 +18563,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -18411,12 +18591,21 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Innate Attack",
-							"specialization": "@Attack Type@"
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "@Attack Type@"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Innate Attack",
+							"name": {
+								"compare": "is",
+								"qualifier": "Innate Attack"
+							},
 							"modifier": -2
 						},
 						{
@@ -19671,7 +19860,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -20019,15 +20211,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -20052,15 +20253,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -22395,7 +22605,7 @@
 			"id": "tc2Bw-0JpkS5K2zxY",
 			"name": "Multimillionaire",
 			"reference": "B25, DFRC2:49, DW33",
-			"local_notes": "Starting wealth is \u003cscript\u003e\n// Partial Multimillionaire Levels (SS2:26) allows Multimillionaire level to be any multiple of 0.2.\nlet whole = Math.trunc(self.level), partial = Math.round((self.level - whole)* 10) || 1;\nformatNum(10 ** ( whole + 2) * partial, true, false)\n\u003c/script\u003ex normal",
+			"local_notes": "Starting wealth is <script>\n// Partial Multimillionaire Levels (SS2:26) allows Multimillionaire level to be any multiple of 0.2.\nlet whole = Math.trunc(self.level), partial = Math.round((self.level - whole)* 10) || 1;\nformatNum(10 ** ( whole + 2) * partial, true, false)\n</script>x normal",
 			"tags": [
 				"Advantage",
 				"Social",
@@ -22407,7 +22617,7 @@
 				"prereqs": [
 					{
 						"type": "script_prereq",
-						"script": "const statusModifier = self.findActiveModifier(\"Wealth grants Status\");\nif (statusModifier \u0026\u0026 statusModifier.level == 2 \u0026\u0026 (self.level \u003c 1 || self.level \u003e= 2)) {\n  \"Multimillionaire level must be at least 1 and less than 2 for Wealth grants Status 2\"\n} else if (statusModifier \u0026\u0026 statusModifier.level == 3 \u0026\u0026 self.level \u003c 2) {\n  \"Multimillionaire level must be at least 2 for Wealth grants Status 3\"\n} else { \n  \"\"\n}"
+						"script": "const statusModifier = self.findActiveModifier(\"Wealth grants Status\");\nif (statusModifier && statusModifier.level == 2 && (self.level < 1 || self.level >= 2)) {\n  \"Multimillionaire level must be at least 1 and less than 2 for Wealth grants Status 2\"\n} else if (statusModifier && statusModifier.level == 3 && self.level < 2) {\n  \"Multimillionaire level must be at least 2 for Wealth grants Status 3\"\n} else { \n  \"\"\n}"
 					},
 					{
 						"type": "trait_prereq",
@@ -24421,7 +24631,7 @@
 			"id": "t7a13kFVl53ZfbkrK",
 			"name": "Payload",
 			"reference": "B74",
-			"local_notes": "\u003cscript\u003e\nif(entity.exists) {\n  measure.formatWeight(\n    self.level * entity.encumbrance.basicLift / 10,\n    entity.displayWeightUnits,\n  )\n} else {\n  \"Payload will be calculated when added to a character sheet\"\n}\n\u003c/script\u003e",
+			"local_notes": "<script>\nif(entity.exists) {\n  measure.formatWeight(\n    self.level * entity.encumbrance.basicLift / 10,\n    entity.displayWeightUnits,\n  )\n} else {\n  \"Payload will be calculated when added to a character sheet\"\n}\n</script>",
 			"tags": [
 				"Advantage",
 				"Exotic",
@@ -24868,7 +25078,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -27438,7 +27651,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -27477,15 +27693,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -27508,12 +27733,18 @@
 						},
 						{
 							"type": "skill",
-							"name": "Karate",
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Brawling",
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							},
 							"modifier": -2
 						}
 					],
@@ -27559,7 +27790,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "dx"
@@ -29291,7 +29525,7 @@
 					"id": "mLKT6nC2M9dezueCh",
 					"name": "One Attack Only effects",
 					"reference": "P79",
-					"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"enable me if One Attack Only is used\"\u003c/script\u003e",
+					"local_notes": "<script>self.attachedTo ? \"\" : \"enable me if One Attack Only is used\"</script>",
 					"cost_adj": "+0",
 					"use_level_from_trait": true,
 					"features": [
@@ -29314,9 +29548,7 @@
 						}
 					],
 					"disabled": true,
-					"calc": {
-						"resolved_notes": "enable me if One Attack Only is used"
-					}
+					"calc": {}
 				},
 				{
 					"id": "m-UVJk8SZQN5VL4ns",
@@ -31790,15 +32022,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -31822,15 +32063,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -34176,7 +34426,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {


### PR DESCRIPTION
Alternate Form lets you shapeshift into one other form, at a base cost of 15 points, plus 90% of the difference in cost between your base racial template and the template of the alternate form (usually, some options remove the discount).

To support this without breaking the source library link, I've added a substitution value for the name of the other form, and allowed the cost of the form to be input using the level of the trait.