### PR TITLE
DFRPG Traits: Fix Forest Guardian

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq
@@ -4251,13 +4251,8 @@
 		},
 		{
 			"id": "t9qZw2_vMennojjML",
-			"source": {
-				"library": "richardwilkes/gcs_master_library",
-				"path": "Power Ups/Power Ups Traits.adq",
-				"id": "tmcxLSlmTsms7d0wG"
-			},
-			"name": "Talent (Forest Guardian)",
-			"reference": "PU3:10, DF3:7, DFA44, FFE18",
+			"name": "Forest Guardian",
+			"reference": "DFA44, PU3:10, DF3:7, FFE18",
 			"tags": [
 				"Advantage",
 				"Exotic",
@@ -4279,43 +4274,14 @@
 					}
 				]
 			},
-			"modifiers": [
-				{
-					"id": "M0XR8wemEmtx74MYj",
-					"name": "Benefits",
-					"children": [
-						{
-							"id": "musFB6-GcdlC50c0A",
-							"name": "Reaction Bonus",
-							"use_level_from_trait": true,
-							"features": [
-								{
-									"type": "reaction_bonus",
-									"situation": "From druids, Faeries, and bunnies.",
-									"amount": 1,
-									"per_level": true
-								}
-							]
-						},
-						{
-							"id": "msUXD-uX-YMOF6Hxh",
-							"name": "Alternative Benefit",
-							"use_level_from_trait": true,
-							"features": [
-								{
-									"type": "conditional_modifier",
-									"situation": "Bonus to notice intruders, etc in woodland where you've lived from 6-level months.",
-									"amount": 1,
-									"per_level": true
-								}
-							],
-							"disabled": true
-						}
-					]
-				}
-			],
 			"points_per_level": 5,
 			"features": [
+				{
+					"type": "reaction_bonus",
+					"situation": "from druids, Faeries, and bunnies",
+					"amount": 1,
+					"per_level": true
+				},
 				{
 					"type": "skill_bonus",
 					"selection_type": "skills_with_name",


### PR DESCRIPTION
Previous changes to use the same Forest Guardian trait everywhere in the master library came at the cost of changing the name of the Forest Guardian trait. As raised in #586 and following discussion in the Discord, too, that is not a trivial cost.

This change does the following:
* Change the name back to "Forest Guardian"
* Move the page reference for Dungeon Fantasy RPG: Adventurers to the start of the list, as it's the most relevant.
* Replace the choice of Reaction Bonus or Conditional Modifier in trait modifiers with adding the Reaction Bonus as a Feature, as DFRPG doesn't offer an alternative benefit (one must be satisfied with the adoration of bunnies).