### PR TITLE
Basic Set Traits: Add features to range modifiers, and independent max range modifiers

### DIFF
--- a/Library/Basic Set/Basic Set Enhancement Modifiers.adm
+++ b/Library/Basic Set/Basic Set Enhancement Modifiers.adm
@@ -208,13 +208,53 @@
 			"id": "m5qUBbGg9xeI4r3J2",
 			"name": "2x Increased 1/2 D Range",
 			"reference": "B106",
-			"cost_adj": "5%"
+			"cost_adj": "5%",
+			"features": [
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 100
+				}
+			]
 		},
 		{
 			"id": "mIgewYjuzmPvs7Jx9",
 			"name": "2x Increased Range",
 			"reference": "B106",
-			"cost_adj": "10%"
+			"cost_adj": "10%",
+			"features": [
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 100
+				},
+				{
+					"type": "weapon_max_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 100
+				}
+			]
 		},
 		{
 			"id": "mibbcaZA6iq5s3ETp",
@@ -226,13 +266,53 @@
 			"id": "mQ81Xfa00tiKIE3rq",
 			"name": "5x Increased 1/2 D Range",
 			"reference": "B106",
-			"cost_adj": "10%"
+			"cost_adj": "10%",
+			"features": [
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 400
+				}
+			]
 		},
 		{
 			"id": "mZK4bwt1NTuzRaUUs",
 			"name": "5x Increased Range",
 			"reference": "B106",
-			"cost_adj": "20%"
+			"cost_adj": "20%",
+			"features": [
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 400
+				},
+				{
+					"type": "weapon_max_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 400
+				}
+			]
 		},
 		{
 			"id": "mQ7yALf2YtsIN3s3k",
@@ -244,19 +324,85 @@
 			"id": "mBGfUgwdVmDu-JkEa",
 			"name": "10x Increased 1/2 D Range",
 			"reference": "B106",
-			"cost_adj": "15%"
+			"cost_adj": "15%",
+			"features": [
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 900
+				}
+			]
 		},
 		{
 			"id": "mpGDFBAfsyxU5j-2Z",
 			"name": "10x Increased Range",
 			"reference": "B106",
-			"cost_adj": "30%"
+			"cost_adj": "30%",
+			"features": [
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 900
+				},
+				{
+					"type": "weapon_max_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 900
+				}
+			]
 		},
 		{
 			"id": "mQ_2bajRRS_CtkWAn",
 			"name": "20x Increased Range",
 			"reference": "B106",
-			"cost_adj": "40%"
+			"cost_adj": "40%",
+			"features": [
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 1900
+				},
+				{
+					"type": "weapon_max_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 1900
+				}
+			]
 		},
 		{
 			"id": "m5gGQNcBlZ5FzYfqz",
@@ -268,7 +414,33 @@
 			"id": "m-AnXjtgyaWQKXuDo",
 			"name": "50x Increased Range",
 			"reference": "B106",
-			"cost_adj": "50%"
+			"cost_adj": "50%",
+			"features": [
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 4900
+				},
+				{
+					"type": "weapon_max_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 4900
+				}
+			]
 		},
 		{
 			"id": "mAGTsEtAWMD2ns712",
@@ -280,7 +452,33 @@
 			"id": "mpImIeHrC-EfHWB2p",
 			"name": "100x Increased Range",
 			"reference": "B106",
-			"cost_adj": "60%"
+			"cost_adj": "60%",
+			"features": [
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 9900
+				},
+				{
+					"type": "weapon_max_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 9900
+				}
+			]
 		},
 		{
 			"id": "m8p4KceOcvYiszehA",

--- a/Library/Basic Set/Basic Set Enhancement Modifiers.adm
+++ b/Library/Basic Set/Basic Set Enhancement Modifiers.adm
@@ -225,6 +225,26 @@
 			]
 		},
 		{
+			"id": "m67BP0mtOdGQ8i2sV",
+			"name": "2x Increased Maximum Range",
+			"reference": "B106",
+			"cost_adj": "+5%",
+			"features": [
+				{
+					"type": "weapon_max_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 100
+				}
+			]
+		},
+		{
 			"id": "mIgewYjuzmPvs7Jx9",
 			"name": "2x Increased Range",
 			"reference": "B106",
@@ -270,6 +290,26 @@
 			"features": [
 				{
 					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 400
+				}
+			]
+		},
+		{
+			"id": "memmYES3r0GPfLA0R",
+			"name": "5x Increased Maximum Range",
+			"reference": "B106",
+			"cost_adj": "+10%",
+			"features": [
+				{
+					"type": "weapon_max_range_bonus",
 					"percent": true,
 					"selection_type": "this_weapon",
 					"name": {
@@ -341,6 +381,26 @@
 			]
 		},
 		{
+			"id": "mCv68Y4HfYDGmDq6C",
+			"name": "10x Increased Maximum Range",
+			"reference": "B106",
+			"cost_adj": "+15%",
+			"features": [
+				{
+					"type": "weapon_max_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 900
+				}
+			]
+		},
+		{
 			"id": "mpGDFBAfsyxU5j-2Z",
 			"name": "10x Increased Range",
 			"reference": "B106",
@@ -369,6 +429,26 @@
 						"compare": "at_least"
 					},
 					"amount": 900
+				}
+			]
+		},
+		{
+			"id": "m5y2Xcf9MbjWqT7wv",
+			"name": "20x Increased Maximum Range",
+			"reference": "B106",
+			"cost_adj": "+20%",
+			"features": [
+				{
+					"type": "weapon_max_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 1900
 				}
 			]
 		},
@@ -411,6 +491,26 @@
 			"cost_adj": "60%"
 		},
 		{
+			"id": "mUXr_mRZtQoonWFZf",
+			"name": "50x Increased Maximum Range",
+			"reference": "B106",
+			"cost_adj": "+25%",
+			"features": [
+				{
+					"type": "weapon_max_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 4900
+				}
+			]
+		},
+		{
 			"id": "m-AnXjtgyaWQKXuDo",
 			"name": "50x Increased Range",
 			"reference": "B106",
@@ -447,6 +547,26 @@
 			"name": "100x Duration",
 			"reference": "B105",
 			"cost_adj": "80%"
+		},
+		{
+			"id": "mc53zVIK8ImwirG9N",
+			"name": "100x Increased Maximum Range",
+			"reference": "B106",
+			"cost_adj": "+30%",
+			"features": [
+				{
+					"type": "weapon_max_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": 9900
+				}
+			]
 		},
 		{
 			"id": "mpImIeHrC-EfHWB2p",

--- a/Library/Basic Set/Basic Set Enhancement Modifiers.adm
+++ b/Library/Basic Set/Basic Set Enhancement Modifiers.adm
@@ -6,7 +6,7 @@
 			"name": "Size Modifier and Reach modifiers",
 			"reference": "BX402",
 			"reference_highlight": "Size Modifier and Reach",
-			"local_notes": "Add these to the traits that grant you melee attacks if you're larger than SM+0.\n\n\u003e [!NOTE]\n\u003e The SM+1 Reach Bonus should not be added to traits that give you attacks with reach greater than C (kicks from Natural Attacks and Claws are fine)",
+			"local_notes": "Add these to the traits that grant you melee attacks if you're larger than SM+0.\n\n> [!NOTE]\n> The SM+1 Reach Bonus should not be added to traits that give you attacks with reach greater than C (kicks from Natural Attacks and Claws are fine)",
 			"children": [
 				{
 					"id": "mw_Qgg67cQLZjxM9z",
@@ -331,7 +331,7 @@
 			"id": "mbO8GjGu_NuPTLz6e",
 			"name": "Area Effect",
 			"reference": "B102,P100",
-			"local_notes": "\u003cscript\u003eself.attachedTo ? `${2**self.level} yd` : \"2^level\"\u003c/script\u003e radius",
+			"local_notes": "<script>self.attachedTo ? `${2**self.level} yd` : \"2^level\"</script> radius",
 			"cost_adj": "50%",
 			"levels": 1,
 			"calc": {
@@ -494,7 +494,7 @@
 			"id": "mcXN1MCeZnZB4Jz2e",
 			"name": "Follow-Up (@Carrier Attack@)",
 			"reference": "B105,P102",
-			"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"1 point per level\"\u003c/script\u003e",
+			"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
 			"cost_adj": "1%",
 			"levels": 1,
 			"calc": {
@@ -768,7 +768,7 @@
 			"id": "msnycFZUVspQ77fd7",
 			"name": "Side Effect (@Side Effect Affliction@)",
 			"reference": "B109,P106",
-			"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"Set level to 50, plus 1 per percentage point of Affliction enhancements included (Stunning is the default, at +0%)\"\u003c/script\u003e",
+			"local_notes": "<script>self.attachedTo ? \"\" : \"Set level to 50, plus 1 per percentage point of Affliction enhancements included (Stunning is the default, at +0%)\"</script>",
 			"cost_adj": "1%",
 			"levels": 50,
 			"calc": {
@@ -785,7 +785,7 @@
 			"id": "md0iavn_lCSnS1Xkf",
 			"name": "Symptoms (@HP Threshold and Effect@)",
 			"reference": "B109",
-			"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"1 point per level\"\u003c/script\u003e",
+			"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
 			"cost_adj": "1%",
 			"calc": {
 				"resolved_notes": "1 point per level"

--- a/Library/Basic Set/Basic Set Limitation Modifiers.adm
+++ b/Library/Basic Set/Basic Set Limitation Modifiers.adm
@@ -5,7 +5,7 @@
 			"id": "m2IwCpU9KwYmjiSSA",
 			"name": "Accessibility (@Condition@)",
 			"reference": "B110,P99",
-			"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"1 point per level\"\u003c/script\u003e",
+			"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
 			"cost_adj": "-1%",
 			"calc": {
 				"resolved_notes": "1 point per level"
@@ -176,7 +176,7 @@
 			"id": "mHGpYfPpTxJ8KT7J_",
 			"name": "Follow-Up (@Carrier Attack@)",
 			"reference": "B105,P102",
-			"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"-1 point per level\"\u003c/script\u003e",
+			"local_notes": "<script>self.attachedTo ? \"\" : \"-1 point per level\"</script>",
 			"cost_adj": "-1%",
 			"levels": 1,
 			"calc": {
@@ -740,7 +740,7 @@
 			"id": "m-F3ACfcl680ioFta",
 			"name": "Resistible",
 			"reference": "B115,P105",
-			"local_notes": "HT\u003cscript\u003eself.attachedTo ? signedValue(self.level-6) : \" + (level - 6)\"\u003c/script\u003e to resist",
+			"local_notes": "HT<script>self.attachedTo ? signedValue(self.level-6) : \" + (level - 6)\"</script> to resist",
 			"cost_adj": "-5%",
 			"levels": 1,
 			"calc": {
@@ -786,7 +786,7 @@
 			"id": "mdoMyuuoZBbQiTi3L",
 			"name": "Temporary Disadvantage (@Temporary Disadvantage@)",
 			"reference": "B115,P106",
-			"local_notes": "\u003cscript\u003eself.attachedTo ? \"\" : \"1 point per level\"\u003c/script\u003e",
+			"local_notes": "<script>self.attachedTo ? \"\" : \"1 point per level\"</script>",
 			"cost_adj": "-1%",
 			"calc": {
 				"resolved_notes": "1 point per level"

--- a/Library/Basic Set/Basic Set Limitation Modifiers.adm
+++ b/Library/Basic Set/Basic Set Limitation Modifiers.adm
@@ -716,6 +716,69 @@
 			"cost_adj": "-15%"
 		},
 		{
+			"id": "mK6fZeW4XvvIWw5rn",
+			"name": "Reduced 1/2D Range",
+			"reference": "B115,P105",
+			"local_notes": "1/2",
+			"cost_adj": "-5%",
+			"features": [
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": -50
+				}
+			]
+		},
+		{
+			"id": "mcAt8NNLDtTXEsAKu",
+			"name": "Reduced 1/2D Range",
+			"reference": "B115,P105",
+			"local_notes": "1/5",
+			"cost_adj": "-10%",
+			"features": [
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": -80
+				}
+			]
+		},
+		{
+			"id": "mPO4_46YMWNzsttr7",
+			"name": "Reduced 1/2D Range",
+			"reference": "B115,P105",
+			"local_notes": "1/10",
+			"cost_adj": "-15%",
+			"features": [
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": -90
+				}
+			]
+		},
+		{
 			"id": "muEHnnBcFvKfMCDHp",
 			"name": "Reduced Range",
 			"reference": "B115,P105",

--- a/Library/Basic Set/Basic Set Limitation Modifiers.adm
+++ b/Library/Basic Set/Basic Set Limitation Modifiers.adm
@@ -719,22 +719,100 @@
 			"id": "muEHnnBcFvKfMCDHp",
 			"name": "Reduced Range",
 			"reference": "B115,P105",
-			"local_notes": "2 Range Divisor",
-			"cost_adj": "-10%"
+			"local_notes": "1/2",
+			"cost_adj": "-10%",
+			"features": [
+				{
+					"type": "weapon_max_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": -50
+				},
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": -50
+				}
+			]
 		},
 		{
 			"id": "mBiJCN2DvROTZnYPj",
 			"name": "Reduced Range",
 			"reference": "B115,P105",
-			"local_notes": "5 Range Divisor",
-			"cost_adj": "-20%"
+			"local_notes": "1/5",
+			"cost_adj": "-20%",
+			"features": [
+				{
+					"type": "weapon_max_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": -80
+				},
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": -80
+				}
+			]
 		},
 		{
 			"id": "m0Eb74zIwgb-E30D1",
 			"name": "Reduced Range",
 			"reference": "B115,P105",
-			"local_notes": "10 Range Divisor",
-			"cost_adj": "-30%"
+			"local_notes": "1/10",
+			"cost_adj": "-30%",
+			"features": [
+				{
+					"type": "weapon_max_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": -90
+				},
+				{
+					"type": "weapon_half_damage_range_bonus",
+					"percent": true,
+					"selection_type": "this_weapon",
+					"name": {
+						"compare": "is"
+					},
+					"level": {
+						"compare": "at_least"
+					},
+					"amount": -90
+				}
+			]
 		},
 		{
 			"id": "m-F3ACfcl680ioFta",


### PR DESCRIPTION
As raised by BadWolf42 on the GCS Discord, with thanks to Pan the Stargazer for providing examples of what it should do.

This includes:
* Use the "gives a weapon half-damage range modifier" and "gives a weapon maximum range modifier" features in the Increased Range and Reduced Range trait modifiers.
* Add Increased Maximum Range and Reduced 1/2D Range trait modifiers.