### PR TITLE
Fix typo in Power-Ups talent

### DIFF
--- a/Library/Power Ups/Power Ups Traits.adq
+++ b/Library/Power Ups/Power Ups Traits.adq
@@ -11594,7 +11594,7 @@
 					"selection_type": "skills_with_name",
 					"name": {
 						"compare": "is",
-						"qualifier": "Macking"
+						"qualifier": "Packing"
 					},
 					"amount": 1,
 					"per_level": true


### PR DESCRIPTION
Checked the book (PDF), it clearly is Packing, not a non-existent skill.