### PR TITLE
Correct tech level of TL8 9mm Auto Pistol to 9

### DIFF
--- a/Library/Basic Set/Basic Set Equipment.eqp
+++ b/Library/Basic Set/Basic Set Equipment.eqp
@@ -860,7 +860,7 @@
 			"id": "e-1qmpb5zfpRBCz_F",
 			"description": "Auto Pistol, 9mm",
 			"reference": "B278",
-			"tech_level": "8",
+			"tech_level": "9",
 			"legality_class": "3",
 			"tags": [
 				"Missile Weapon"


### PR DESCRIPTION
As indicated on page 278 of the Basic Set Fourth Edition 7th printing PDF.