### PR TITLE
Druidic Animal Control spell names are incorrect

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
@@ -8548,6 +8548,8 @@
 						{
 							"id": "P-v54o1GOldpgHEx0",
 							"name": "Animal Control",
+							"reference": "DFS17",
+							"reference_highlight": "(Animal) Control",
 							"children": [
 								{
 									"id": "p_cCSK1Zuv1ev3sKk",

--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
@@ -8546,238 +8546,205 @@
 					],
 					"children": [
 						{
-							"id": "pOI_ouUen4BoZN7v0",
-							"name": "Animal Control (@Animal@)",
-							"reference": "DFS17",
-							"tags": [
-								"Animal",
-								"Druidic"
-							],
-							"difficulty": "iq/h",
-							"college": [
-								"Animal"
-							],
-							"power_source": "Druidic",
-							"spell_class": "Regular",
-							"resist": "Will",
-							"casting_cost": "Variable",
-							"maintenance_cost": "Half",
-							"casting_time": "1 sec",
-							"duration": "1 min",
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										}
-									}
-								]
-							},
-							"points": 1
-						},
-						{
-							"id": "p_cCSK1Zuv1ev3sKk",
-							"name": "Animal Control (Bird)",
-							"reference": "DFS17",
-							"tags": [
-								"Animal",
-								"Druidic"
-							],
-							"difficulty": "iq/h",
-							"college": [
-								"Animal"
-							],
-							"power_source": "Druidic",
-							"spell_class": "Regular",
-							"resist": "Will",
-							"casting_cost": "3",
-							"maintenance_cost": "2",
-							"casting_time": "1 sec",
-							"duration": "1 min",
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										}
-									}
-								]
-							},
-							"points": 1
-						},
-						{
-							"id": "pgD-rNKmHXsE2W3Ba",
-							"name": "Animal Control (Fish)",
-							"reference": "DFS17",
-							"tags": [
-								"Animal",
-								"Druidic"
-							],
-							"difficulty": "iq/h",
-							"college": [
-								"Animal"
-							],
-							"power_source": "Druidic",
-							"spell_class": "Regular",
-							"resist": "Will",
-							"casting_cost": "2",
-							"maintenance_cost": "1",
-							"casting_time": "1 sec",
-							"duration": "1 min",
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										}
-									}
-								]
-							},
-							"points": 1
-						},
-						{
-							"id": "pRG_3qVZEfmjOEVZp",
-							"name": "Animal Control (Mammal)",
-							"reference": "DFS17",
-							"tags": [
-								"Animal",
-								"Druidic"
-							],
-							"difficulty": "iq/h",
-							"college": [
-								"Animal"
-							],
-							"power_source": "Druidic",
-							"spell_class": "Regular",
-							"resist": "Will",
-							"casting_cost": "5",
-							"maintenance_cost": "3",
-							"casting_time": "1 sec",
-							"duration": "1 min",
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										}
-									}
-								]
-							},
-							"points": 1
-						},
-						{
-							"id": "pizyR1mMOszVV2hUH",
-							"name": "Animal Control (Reptile)",
-							"reference": "DFS17",
-							"tags": [
-								"Animal",
-								"Druidic"
-							],
-							"difficulty": "iq/h",
-							"college": [
-								"Animal"
-							],
-							"power_source": "Druidic",
-							"spell_class": "Regular",
-							"resist": "Will",
-							"casting_cost": "2",
-							"maintenance_cost": "1",
-							"casting_time": "1 sec",
-							"duration": "1 min",
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										}
-									}
-								]
-							},
-							"points": 1
-						},
-						{
-							"id": "po9IXZ1l_WHoInrm6",
-							"name": "Animal Control (Vermin)",
-							"reference": "DFS17",
-							"tags": [
-								"Animal",
-								"Druidic"
-							],
-							"difficulty": "iq/h",
-							"college": [
-								"Animal"
-							],
-							"power_source": "Druidic",
-							"spell_class": "Regular",
-							"resist": "Will",
-							"casting_cost": "1",
-							"maintenance_cost": "1",
-							"casting_time": "1 sec",
-							"duration": "1 min",
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										}
-									}
-								]
-							},
-							"points": 1
+							"id": "P-v54o1GOldpgHEx0",
+							"name": "Animal Control",
+							"children": [
+								{
+									"id": "p_cCSK1Zuv1ev3sKk",
+									"name": "Bird Control",
+									"reference": "DFS17",
+									"tags": [
+										"Animal",
+										"Druidic"
+									],
+									"difficulty": "iq/h",
+									"college": [
+										"Animal"
+									],
+									"power_source": "Druidic",
+									"spell_class": "Regular",
+									"resist": "Will",
+									"casting_cost": "3",
+									"maintenance_cost": "2",
+									"casting_time": "1 sec",
+									"duration": "1 min",
+									"prereqs": {
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Power Investiture (Druidic)"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
+									},
+									"points": 1
+								},
+								{
+									"id": "pgD-rNKmHXsE2W3Ba",
+									"name": "Fish Control",
+									"reference": "DFS17",
+									"tags": [
+										"Animal",
+										"Druidic"
+									],
+									"difficulty": "iq/h",
+									"college": [
+										"Animal"
+									],
+									"power_source": "Druidic",
+									"spell_class": "Regular",
+									"resist": "Will",
+									"casting_cost": "2",
+									"maintenance_cost": "1",
+									"casting_time": "1 sec",
+									"duration": "1 min",
+									"prereqs": {
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Power Investiture (Druidic)"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
+									},
+									"points": 1
+								},
+								{
+									"id": "pRG_3qVZEfmjOEVZp",
+									"name": "Mammal Control",
+									"reference": "DFS17",
+									"tags": [
+										"Animal",
+										"Druidic"
+									],
+									"difficulty": "iq/h",
+									"college": [
+										"Animal"
+									],
+									"power_source": "Druidic",
+									"spell_class": "Regular",
+									"resist": "Will",
+									"casting_cost": "5",
+									"maintenance_cost": "3",
+									"casting_time": "1 sec",
+									"duration": "1 min",
+									"prereqs": {
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Power Investiture (Druidic)"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
+									},
+									"points": 1
+								},
+								{
+									"id": "pizyR1mMOszVV2hUH",
+									"name": "Reptile Control",
+									"reference": "DFS17",
+									"tags": [
+										"Animal",
+										"Druidic"
+									],
+									"difficulty": "iq/h",
+									"college": [
+										"Animal"
+									],
+									"power_source": "Druidic",
+									"spell_class": "Regular",
+									"resist": "Will",
+									"casting_cost": "2",
+									"maintenance_cost": "1",
+									"casting_time": "1 sec",
+									"duration": "1 min",
+									"prereqs": {
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Power Investiture (Druidic)"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
+									},
+									"points": 1
+								},
+								{
+									"id": "po9IXZ1l_WHoInrm6",
+									"name": "Vermin Control",
+									"reference": "DFS17",
+									"tags": [
+										"Animal",
+										"Druidic"
+									],
+									"difficulty": "iq/h",
+									"college": [
+										"Animal"
+									],
+									"power_source": "Druidic",
+									"spell_class": "Regular",
+									"resist": "Will",
+									"casting_cost": "1",
+									"maintenance_cost": "1",
+									"casting_time": "1 sec",
+									"duration": "1 min",
+									"prereqs": {
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Power Investiture (Druidic)"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
+									},
+									"points": 1
+								}
+							]
 						},
 						{
 							"id": "ptMXXYp8PP6Gf3axw",


### PR DESCRIPTION
In DFS17, the "(Animal) Control" group of spells are grouped under a single entry with each spell name being distinct only in the `Cost` section. The names used in the DFRPG Spells list were formatted differently (`Animal Control (Bird)` vs `Bird Control`). Additionally, there was a spell called `Animal Control (@Animal@)` that isn't an actual spell and shouldn't have been added.

On feedback from @maw3193 I moved the 5 animal category spells into an `Animal Control` spell container to keep them grouped and sorted under "A". This keeps the existing sorting behavior after the fix.