### PR TITLE
Druidic Repel Animal spell names are incorrect

### DIFF
--- a/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
+++ b/Library/Dungeon Fantasy RPG/Dungeon Fantasy RPG Spells.spl
@@ -9739,232 +9739,207 @@
 							"points": 1
 						},
 						{
-							"id": "p7uDCbN6tQTNjcbXr",
-							"name": "Repel Animal (@Animal@)",
+							"id": "P5DAXi9Ku8FLiKM1T",
+							"name": "Repel Animal",
 							"reference": "DFS19",
-							"tags": [
-								"Animal",
-								"Druidic"
-							],
-							"difficulty": "iq/h",
-							"college": [
-								"Animal"
-							],
-							"power_source": "Druidic",
-							"spell_class": "Area",
-							"casting_cost": "Variable",
-							"maintenance_cost": "-",
-							"casting_time": "10 sec",
-							"duration": "1 hr",
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										}
-									}
-								]
-							},
-							"points": 1
-						},
-						{
-							"id": "p9yqM_LUSn5EebWAr",
-							"name": "Repel Animal (Bird)",
-							"reference": "DFS19",
-							"tags": [
-								"Animal",
-								"Druidic"
-							],
-							"difficulty": "iq/h",
-							"college": [
-								"Animal"
-							],
-							"power_source": "Druidic",
-							"spell_class": "Area",
-							"casting_cost": "3",
-							"maintenance_cost": "-",
-							"casting_time": "10 sec",
-							"duration": "1 hr",
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										}
-									}
-								]
-							},
-							"points": 1
-						},
-						{
-							"id": "pt0v23tMVKlPatI2P",
-							"name": "Repel Animal (Fish)",
-							"reference": "DFS19",
-							"tags": [
-								"Animal",
-								"Druidic"
-							],
-							"difficulty": "iq/h",
-							"college": [
-								"Animal"
-							],
-							"power_source": "Druidic",
-							"spell_class": "Area",
-							"casting_cost": "2",
-							"maintenance_cost": "-",
-							"casting_time": "10 sec",
-							"duration": "1 hr",
-							"prereqs": {
-								"type": "prereq_list",
-								"all": false,
-								"prereqs": [
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										}
-									}
-								]
-							},
-							"points": 1
-						},
-						{
-							"id": "psusCKip_wOR9bjsD",
-							"name": "Repel Animal (Mammal)",
-							"reference": "DFS19",
-							"tags": [
-								"Animal",
-								"Druidic"
-							],
-							"difficulty": "iq/h",
-							"college": [
-								"Animal"
-							],
-							"power_source": "Druidic",
-							"spell_class": "Area",
-							"casting_cost": "5",
-							"maintenance_cost": "-",
-							"casting_time": "10 sec",
-							"duration": "1 hr",
-							"prereqs": {
-								"type": "prereq_list",
-								"all": true,
-								"prereqs": [
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										}
-									}
-								]
-							},
-							"points": 1
-						},
-						{
-							"id": "pB-AAhVshcbnIK7uR",
-							"name": "Repel Animal (Reptile)",
-							"reference": "DFS19",
-							"tags": [
-								"Animal",
-								"Druidic"
-							],
-							"difficulty": "iq/h",
-							"college": [
-								"Animal"
-							],
-							"power_source": "Druidic",
-							"spell_class": "Area",
-							"casting_cost": "2",
-							"maintenance_cost": "-",
-							"casting_time": "10 sec",
-							"duration": "1 hr",
-							"prereqs": {
-								"type": "prereq_list",
-								"all": true,
-								"prereqs": [
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										}
-									}
-								]
-							},
-							"points": 1
-						},
-						{
-							"id": "pc1MfJ3MhtZIqhUBE",
-							"name": "Repel Animal (Vermin)",
-							"reference": "DFS19",
-							"tags": [
-								"Animal",
-								"Druidic"
-							],
-							"difficulty": "iq/h",
-							"college": [
-								"Animal"
-							],
-							"power_source": "Druidic",
-							"spell_class": "Area",
-							"casting_cost": "1",
-							"maintenance_cost": "-",
-							"casting_time": "10 sec",
-							"duration": "1 hr",
-							"prereqs": {
-								"type": "prereq_list",
-								"all": true,
-								"prereqs": [
-									{
-										"type": "trait_prereq",
-										"has": true,
-										"name": {
-											"compare": "is",
-											"qualifier": "Power Investiture (Druidic)"
-										},
-										"level": {
-											"compare": "at_least",
-											"qualifier": 2
-										}
-									}
-								]
-							},
-							"points": 1
+							"reference_highlight": "Repel (Animal)",
+							"children": [
+								{
+									"id": "p9yqM_LUSn5EebWAr",
+									"name": "Repel Bird",
+									"reference": "DFS19",
+									"reference_highlight": "Repel (Animal)",
+									"tags": [
+										"Animal",
+										"Druidic"
+									],
+									"difficulty": "iq/h",
+									"college": [
+										"Animal"
+									],
+									"power_source": "Druidic",
+									"spell_class": "Area",
+									"casting_cost": "3",
+									"maintenance_cost": "-",
+									"casting_time": "10 sec",
+									"duration": "1 hr",
+									"prereqs": {
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Power Investiture (Druidic)"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
+									},
+									"points": 1
+								},
+								{
+									"id": "pt0v23tMVKlPatI2P",
+									"name": "Repel Fish",
+									"reference": "DFS19",
+									"reference_highlight": "Repel (Animal)",
+									"tags": [
+										"Animal",
+										"Druidic"
+									],
+									"difficulty": "iq/h",
+									"college": [
+										"Animal"
+									],
+									"power_source": "Druidic",
+									"spell_class": "Area",
+									"casting_cost": "2",
+									"maintenance_cost": "-",
+									"casting_time": "10 sec",
+									"duration": "1 hr",
+									"prereqs": {
+										"type": "prereq_list",
+										"all": false,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Power Investiture (Druidic)"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
+									},
+									"points": 1
+								},
+								{
+									"id": "psusCKip_wOR9bjsD",
+									"name": "Repel Mammal",
+									"reference": "DFS19",
+									"reference_highlight": "Repel (Animal)",
+									"tags": [
+										"Animal",
+										"Druidic"
+									],
+									"difficulty": "iq/h",
+									"college": [
+										"Animal"
+									],
+									"power_source": "Druidic",
+									"spell_class": "Area",
+									"casting_cost": "5",
+									"maintenance_cost": "-",
+									"casting_time": "10 sec",
+									"duration": "1 hr",
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Power Investiture (Druidic)"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
+									},
+									"points": 1
+								},
+								{
+									"id": "pB-AAhVshcbnIK7uR",
+									"name": "Repel Reptile",
+									"reference": "DFS19",
+									"reference_highlight": "Repel (Animal)",
+									"tags": [
+										"Animal",
+										"Druidic"
+									],
+									"difficulty": "iq/h",
+									"college": [
+										"Animal"
+									],
+									"power_source": "Druidic",
+									"spell_class": "Area",
+									"casting_cost": "2",
+									"maintenance_cost": "-",
+									"casting_time": "10 sec",
+									"duration": "1 hr",
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Power Investiture (Druidic)"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
+									},
+									"points": 1
+								},
+								{
+									"id": "pc1MfJ3MhtZIqhUBE",
+									"name": "Repel Vermin",
+									"reference": "DFS19",
+									"reference_highlight": "Repel (Animal)",
+									"tags": [
+										"Animal",
+										"Druidic"
+									],
+									"difficulty": "iq/h",
+									"college": [
+										"Animal"
+									],
+									"power_source": "Druidic",
+									"spell_class": "Area",
+									"casting_cost": "1",
+									"maintenance_cost": "-",
+									"casting_time": "10 sec",
+									"duration": "1 hr",
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "trait_prereq",
+												"has": true,
+												"name": {
+													"compare": "is",
+													"qualifier": "Power Investiture (Druidic)"
+												},
+												"level": {
+													"compare": "at_least",
+													"qualifier": 2
+												}
+											}
+										]
+									},
+									"points": 1
+								}
+							]
 						},
 						{
 							"id": "pD_uh3zQwsc5XU8Za",


### PR DESCRIPTION
In DFS17, the "Repel (Animal)" group of spells are grouped under a single entry with each spell name being distinct only in the Cost section. The spell calls out that it's costs are identical to the counterpart `(Animal) Control` spells. The names used in the DFRPG Spells list were formatted differently (`Repel Animal (Bird)` vs `Repel Bird`) than what they should be (based on how `(Animal) Control` names spells). Additionally, there was a spell called `Repel (@Animal@)` that isn't an actual spell and shouldn't have been added.

On feedback from @maw3193 I moved the 5 spells into a Repel Animal container to keep them grouped and sorted under "R". This keeps the existing sorting behavior after the fix.