### PR TITLE
Banestorm: Freelance Wizard Template Errata

### DIFF
--- a/Library/Banestorm/Classes/Freelance Wizard.gct
+++ b/Library/Banestorm/Classes/Freelance Wizard.gct
@@ -1447,7 +1447,7 @@
 													"modifier": -2
 												}
 											],
-											"points": 2
+											"points": 1
 										}
 									]
 								},
@@ -2414,6 +2414,51 @@
 							"id": "PMlqZacGpUkLHyoeb",
 							"name": "Air and Earth",
 							"children": [
+								{
+									"id": "poE7JctPORk2-fr9O",
+									"source": {
+										"library": "richardwilkes/gcs_master_library",
+										"path": "Magic/Magic Spells.spl",
+										"id": "pRSVvS7brLZomcwjj"
+									},
+									"name": "Body of Air",
+									"reference": "M24",
+									"tags": [
+										"Air"
+									],
+									"difficulty": "iq/h",
+									"college": [
+										"Air"
+									],
+									"power_source": "Arcane",
+									"spell_class": "Regular",
+									"resist": "HT",
+									"casting_cost": "4",
+									"maintenance_cost": "1",
+									"casting_time": "5 sec",
+									"duration": "1 min",
+									"prereq_count": 3,
+									"prereqs": {
+										"type": "prereq_list",
+										"all": true,
+										"prereqs": [
+											{
+												"type": "spell_prereq",
+												"sub_type": "name",
+												"has": true,
+												"qualifier": {
+													"compare": "is",
+													"qualifier": "shape air"
+												},
+												"quantity": {
+													"compare": "at_least",
+													"qualifier": 1
+												}
+											}
+										]
+									},
+									"points": 1
+								},
 								{
 									"id": "pnqN5eKAiXIlye9fQ",
 									"name": "Create Air",


### PR DESCRIPTION
I found a mistake in the published Banestorm Freelance Wizard template and reported it to SJG. They finally got back with the errata update that dropped 1 point in the `Innate Attack (Beam)` skill and added another `Air` spell (`Body of Air`) instead. Point balance is retained and the prereq of '6 other Air spells' is now met for `Lightning`.