### PR TITLE
Tactical Shooting: fix deadeye

### DIFF
--- a/Library/Gun Fu/Gun Fu Traits.adq
+++ b/Library/Gun Fu/Gun Fu Traits.adq
@@ -197,11 +197,12 @@
 		{
 			"id": "tna6P7zNt41Qt3n4-",
 			"name": "Deadeye",
-			"reference": "GF18",
+			"reference": "GF18, TS38",
 			"tags": [
 				"Mental",
 				"Perk",
-				"Physical"
+				"Physical",
+				"Tactical Shooting"
 			],
 			"base_points": 1,
 			"calc": {

--- a/Library/Gun Fu/Gun Fu Traits.adq
+++ b/Library/Gun Fu/Gun Fu Traits.adq
@@ -204,9 +204,13 @@
 				"Physical",
 				"Tactical Shooting"
 			],
-			"base_points": 1,
+			"points_per_level": 1,
+			"max_levels": "3",
+			"can_level": true,
+			"levels": 1,
 			"calc": {
-				"points": 1
+				"points": 1,
+				"current_level": 1
 			}
 		},
 		{

--- a/Library/Tactical Shooting/Tactical Shooting Traits.adq
+++ b/Library/Tactical Shooting/Tactical Shooting Traits.adq
@@ -87,11 +87,17 @@
 		},
 		{
 			"id": "tTBELrZv-USnLpNdr",
+			"source": {
+				"library": "richardwilkes/gcs_master_library",
+				"path": "Gun Fu/Gun Fu Traits.adq",
+				"id": "tna6P7zNt41Qt3n4-"
+			},
 			"name": "Deadeye",
-			"reference": "TS38",
+			"reference": "GF18, TS38",
 			"tags": [
 				"Mental",
 				"Perk",
+				"Physical",
 				"Tactical Shooting"
 			],
 			"base_points": 1,

--- a/Library/Tactical Shooting/Tactical Shooting Traits.adq
+++ b/Library/Tactical Shooting/Tactical Shooting Traits.adq
@@ -472,12 +472,12 @@
 				},
 				{
 					"id": "m2e1btijoFGAYR5vd",
-					"name": "Manufacturer (e.g., H\u0026K, Federal, or Leupold): 30%.",
+					"name": "Manufacturer (e.g., H&K, Federal, or Leupold): 30%.",
 					"disabled": true
 				},
 				{
 					"id": "mQ49TXUX3la85JkcM",
-					"name": "Anything more specific (e.g., H\u0026K submachine guns): 40%.",
+					"name": "Anything more specific (e.g., H&K submachine guns): 40%.",
 					"disabled": true
 				}
 			],

--- a/Library/Tactical Shooting/Tactical Shooting Traits.adq
+++ b/Library/Tactical Shooting/Tactical Shooting Traits.adq
@@ -100,9 +100,13 @@
 				"Physical",
 				"Tactical Shooting"
 			],
-			"base_points": 1,
+			"points_per_level": 1,
+			"max_levels": "3",
+			"can_level": true,
+			"levels": 1,
 			"calc": {
-				"points": 1
+				"points": 1,
+				"current_level": 1
 			}
 		},
 		{


### PR DESCRIPTION
As reported in #598, The Deadeye trait should be a levelled trait with a maximum level of 3.

Because this trait is present in both Gun Fu and Tactical Shooting, I've updated it in both and made the Tactical Shooting one treat Gun Fu's as its source.

Closes #598 