### PR TITLE
Adding new "Heteronomy" trait

### DIFF
--- a/Library/1shotadventures/Characters/Harry Potter and the Warlocks Tower/Alissa_Turpin.gcs
+++ b/Library/1shotadventures/Characters/Harry Potter and the Warlocks Tower/Alissa_Turpin.gcs
@@ -904,7 +904,7 @@
 					"id": "muxA1lmu7IsbWeJDs",
 					"name": "Minion",
 					"reference": "B38",
-					"local_notes": "IQ 0 or Slave Mentality",
+					"local_notes": "IQ 0 or Heteronomy",
 					"disabled": true
 				},
 				{

--- a/Library/Action/Action Traits.adq
+++ b/Library/Action/Action Traits.adq
@@ -2851,7 +2851,7 @@
 							"id": "mVx8y8W7NJBLLzpxh",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/After the End/Templates/Doc.gct
+++ b/Library/After the End/Templates/Doc.gct
@@ -229,7 +229,7 @@
 											"id": "mIAEX0dnY85_Lug2k",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -452,7 +452,7 @@
 											"id": "mnU6lH6LCwEpvv7E_",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -675,7 +675,7 @@
 											"id": "m__1tPM2jHZIethLz",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -900,7 +900,7 @@
 											"id": "mdNIoUfu1QYpIcEPG",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/After the End/Templates/Hulk.gct
+++ b/Library/After the End/Templates/Hulk.gct
@@ -929,7 +929,7 @@
 											"id": "msNAISlSn3PhROYSk",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -1152,7 +1152,7 @@
 											"id": "mRpUL3SoUBXG-K_Ta",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -1375,7 +1375,7 @@
 											"id": "mmdx6WCTDa8thtLqt",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -1600,7 +1600,7 @@
 											"id": "mlLN6vE3Tdw0Tg95P",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/After the End/Templates/Hunter.gct
+++ b/Library/After the End/Templates/Hunter.gct
@@ -1444,7 +1444,7 @@
 											"id": "mPOqtlAj0k9_lYJvv",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/After the End/Templates/Nomad.gct
+++ b/Library/After the End/Templates/Nomad.gct
@@ -779,7 +779,7 @@
 											"id": "mEGV-GEqn4KvPqxiy",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -1002,7 +1002,7 @@
 											"id": "mvQJmnqhnz4jHdjWp",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -1225,7 +1225,7 @@
 											"id": "mWFIqY7jI1rcIKfco",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -1733,7 +1733,7 @@
 											"id": "mRrvFFMM2cL2tG5Tv",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/After the End/Templates/Scavenger.gct
+++ b/Library/After the End/Templates/Scavenger.gct
@@ -1541,7 +1541,7 @@
 											"id": "meH1gmUJ61fVTRUCC",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/After the End/Templates/Trader.gct
+++ b/Library/After the End/Templates/Trader.gct
@@ -1733,7 +1733,7 @@
 											"id": "m_OsqNkvxhgtmG4Kw",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -3020,7 +3020,7 @@
 											"id": "mYjFU5cv8I97D714E",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -3243,7 +3243,7 @@
 											"id": "mlDcNPBM-R0voAPmj",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -3466,7 +3466,7 @@
 											"id": "meSM9_JUuJCwTek0b",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/After the End/Templates/Trooper.gct
+++ b/Library/After the End/Templates/Trooper.gct
@@ -732,7 +732,7 @@
 											"id": "mWAbBShtVJza9XNxb",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -955,7 +955,7 @@
 											"id": "miDdljoYKKhO59hVw",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -1178,7 +1178,7 @@
 											"id": "miVdEEb3pPMcg8stJ",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Banestorm/Classes/Courtier.gct
+++ b/Library/Banestorm/Classes/Courtier.gct
@@ -359,7 +359,7 @@
 											"id": "mzovafWTtOlPFicL1",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Banestorm/Classes/Healer.gct
+++ b/Library/Banestorm/Classes/Healer.gct
@@ -313,7 +313,7 @@
 											"id": "ml_8YGVN3ha8ddoC3",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -1716,7 +1716,7 @@
 					"id": "mVzdHYM_kPEXr0ON7",
 					"name": "Minion",
 					"reference": "B38",
-					"local_notes": "IQ 0 or Slave Mentality",
+					"local_notes": "IQ 0 or Heteronomy",
 					"disabled": true
 				},
 				{

--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -10983,6 +10983,19 @@
 			}
 		},
 		{
+			"id": "tcy9AWlzMa9O75YZO",
+			"name": "Heteronomy",
+			"reference": "B138,B154",
+			"tags": [
+				"Disadvantage",
+				"Mental"
+			],
+			"base_points": -40,
+			"calc": {
+				"points": -40
+			}
+		},
+		{
 			"id": "t7x0UhMbIv9VWYd8n",
 			"name": "Hidebound",
 			"reference": "B138",
@@ -28152,7 +28165,7 @@
 		{
 			"id": "tJi-TQmfqXXVH24kt",
 			"name": "Slave Mentality",
-			"reference": "B154",
+			"reference": "B154,B138",
 			"tags": [
 				"Disadvantage",
 				"Mental"

--- a/Library/Basic Set/Meta-Traits/Automaton.gct
+++ b/Library/Basic Set/Meta-Traits/Automaton.gct
@@ -255,8 +255,8 @@
 				},
 				{
 					"id": "ty24z06PI31wyMx1X",
-					"name": "Slave Mentality",
-					"reference": "B154",
+					"name": "Heteronomy",
+					"reference": "B138",
 					"tags": [
 						"Disadvantage",
 						"Mental"

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Cleric.gct
@@ -1004,7 +1004,7 @@
 													"id": "msR43nSVYDZKmEw8b",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1226,7 +1226,7 @@
 													"id": "mkjUiqjT0dqV123sL",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Druid.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Druid.gct
@@ -328,7 +328,7 @@
 													"id": "mhpUeyIhQY4f0dLfe",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mJBk8M4LJLjw6WJUR",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 1/Classes/Holy Warrior.gct
@@ -560,7 +560,7 @@
 													"id": "mHpEzrrFE-jLu0RKJ",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -782,7 +782,7 @@
 													"id": "me3D5ItZX10QJkTZj",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 14/Dungeon Fantasy 14 Traits.adq
@@ -3746,7 +3746,7 @@
 									"id": "mUmDGQai230RF6d7x",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 14/Mentalist.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 14/Mentalist.gct
@@ -3868,7 +3868,7 @@
 															"id": "mY2SY6cpZ1K7ArVAc",
 															"name": "Minion",
 															"reference": "B38",
-															"local_notes": "IQ 0 or Slave Mentality",
+															"local_notes": "IQ 0 or Heteronomy",
 															"disabled": true
 														},
 														{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 3/Evil Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 3/Evil Cleric.gct
@@ -1076,7 +1076,7 @@
 													"id": "mZo-GaNZTnw8JKK3x",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1298,7 +1298,7 @@
 													"id": "m08dacX9HhoxrJpcA",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 3/Unholy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 3/Unholy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "m7uWgezfYVcZQGg1i",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mBI10RT4X8Um7jkgf",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 5/Divine Elements/Death Element.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 5/Divine Elements/Death Element.gct
@@ -277,7 +277,7 @@
 									"id": "mktqAKTVHrL_ttbPD",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 5/Familiars.adq
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 5/Familiars.adq
@@ -164,7 +164,7 @@
 									"id": "mKn4ciRnx5svFAEUd",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -916,7 +916,7 @@
 									"id": "mc8KfDGMNBytbobOU",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -1795,7 +1795,7 @@
 									"id": "mJfN11ph_mGSHVcBU",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -3171,7 +3171,7 @@
 									"id": "mck3K83QQlgwZyhvS",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -3713,7 +3713,7 @@
 									"id": "mpxP5Q9gAcQxRLI-B",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -4547,7 +4547,7 @@
 									"id": "mydplaDkrzp9i8Ny0",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -6077,7 +6077,7 @@
 									"id": "m-SJ1BrMAoQkozfET",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -6964,7 +6964,7 @@
 									"id": "mqsDdPLemJLxWcMRW",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -7907,7 +7907,7 @@
 									"id": "mwKdd4o_VgtJgiUk1",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -8843,7 +8843,7 @@
 									"id": "mVqeU76yL6Wl4hA39",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -10083,7 +10083,7 @@
 									"id": "m6eUC1MWEPq98BnXa",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -10460,7 +10460,7 @@
 									"id": "mb4QWeWHPkCnHQ6HF",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -12436,7 +12436,7 @@
 									"id": "mr4RDV-jC61tnXhrJ",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -14208,7 +14208,7 @@
 									"id": "msdBxSGuvIRqCQ4sJ",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -15257,7 +15257,7 @@
 									"id": "mQ2DBOkEHd69kKNl3",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -16387,7 +16387,7 @@
 									"id": "mIbTJ-h_F74SIKYYl",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -17474,7 +17474,7 @@
 									"id": "mhzX2uw5XQAb1ntbX",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -19130,7 +19130,7 @@
 									"id": "mQdAcQAzP1QDQh1P7",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -21354,7 +21354,7 @@
 									"id": "mIWfpxVXDQDjWuxA7",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Agriculture Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Agriculture Cleric.gct
@@ -1075,7 +1075,7 @@
 													"id": "mv4-AJIFnS-bQP6j0",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1297,7 +1297,7 @@
 													"id": "mqxHfCsAEH26h5N1X",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Artificer Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Artificer Cleric.gct
@@ -1004,7 +1004,7 @@
 													"id": "mGqJnVwGyhttkOzMU",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1226,7 +1226,7 @@
 													"id": "mZPp-_AjtX0CKHsL3",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/City Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/City Cleric.gct
@@ -1011,7 +1011,7 @@
 													"id": "muEkKLHLMrrBBqoGi",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1233,7 +1233,7 @@
 													"id": "mGpuu3qL55iK5MSNV",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Death Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Death Cleric.gct
@@ -896,7 +896,7 @@
 													"id": "m-DvZKJGaz6ZhY3aa",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1118,7 +1118,7 @@
 													"id": "mSbPCMji6rFcc1uYI",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Earth Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Earth Cleric.gct
@@ -1004,7 +1004,7 @@
 													"id": "muYP6B7Qa9dhqGbYF",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1226,7 +1226,7 @@
 													"id": "mryYcmGgsn6JFFahK",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Fire Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Fire Cleric.gct
@@ -1004,7 +1004,7 @@
 													"id": "mVsRk_jO6rLkFm18q",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1226,7 +1226,7 @@
 													"id": "mEQuGAYXy8khxsr3R",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Healing Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Healing Cleric.gct
@@ -1004,7 +1004,7 @@
 													"id": "mJ4OVa5Qzs0wqbDHA",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1226,7 +1226,7 @@
 													"id": "mqtUKBn_6uUu6zY6K",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Hunter Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Hunter Cleric.gct
@@ -1004,7 +1004,7 @@
 													"id": "mQ9BVxauc0mrdZvzH",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1226,7 +1226,7 @@
 													"id": "m-FP7ETdFgzpYcfrE",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Love and Fertility Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Love and Fertility Cleric.gct
@@ -1840,7 +1840,7 @@
 													"id": "mW12UnHKOMVRrdhzl",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -2062,7 +2062,7 @@
 													"id": "mFpfK4tojLwF9mmz_",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Messenger Rogue Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Messenger Rogue Cleric.gct
@@ -1164,7 +1164,7 @@
 													"id": "mwSAutz4ZMbpvQvPs",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1386,7 +1386,7 @@
 													"id": "mPvCFH2zHtPN5wiZT",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Night Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Night Cleric.gct
@@ -1004,7 +1004,7 @@
 													"id": "mAhNZWEhx0dKyfsnX",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1226,7 +1226,7 @@
 													"id": "mTO0PRTheCrZ5AmKB",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Sea Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Sea Cleric.gct
@@ -1190,7 +1190,7 @@
 													"id": "m995HfEWUtb4GdlON",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1412,7 +1412,7 @@
 													"id": "mTo-rJY-yOQcnnOxH",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Storm Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Storm Cleric.gct
@@ -896,7 +896,7 @@
 													"id": "mS7xXLy0iFFvpFmwZ",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1118,7 +1118,7 @@
 													"id": "mrkZxJfKOEp_cRBLb",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Sun Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/Sun Cleric.gct
@@ -1004,7 +1004,7 @@
 													"id": "m0tJYEIXCLv6kIVLL",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1226,7 +1226,7 @@
 													"id": "mWjlpzvHHIqjr9qGi",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/War Cleric.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Cleric Variants/War Cleric.gct
@@ -1235,7 +1235,7 @@
 													"id": "mhq4kBLDsCiLDz5qA",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1457,7 +1457,7 @@
 													"id": "mb2aPRjBjFE08Ekyq",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Agriculture Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Agriculture Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "mtltg7_VPxaRJrNyB",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "m9w4N6ciuTpT8ocob",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Artificer Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Artificer Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "mq8EPlJ7zdZNywR-v",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mByyso3Sp-aEA1NA6",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Death Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Death Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "mpIuBAh940ycXU1Me",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mCzq3dOK9WNv9fPsH",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Earth Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Earth Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "m4VYQSipUzrmzqk4B",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mMX-gbFzX9gvS14oQ",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Fire Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Fire Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "mLPXjvvpqDgzKxL68",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mvmH6g_ISlW6b-2xp",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Healing Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Healing Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "mEdLSRkzTEmu_D6MA",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mhIKN3ikg0mtbk3pE",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Hunter Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Hunter Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "mOYkbsaAg60qXuiCs",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mLHLYVXHO7aEpdWw-",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Love and Fertility Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Love and Fertility Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "m1-eJ_JG4nltNh2RH",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "m8KpVx2uQErOmMP_D",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Messenger Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Messenger Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "m5UEDD9EajeQb7jyT",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mhR9PPDE7eJbMf_aG",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Night Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Night Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "mmMgaynfX_AJlTzzh",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mJnN0yqtcJE3n5OrY",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Rogue Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Rogue Holy Warrior.gct
@@ -976,7 +976,7 @@
 													"id": "ms67H4A4IAoO7lZ8K",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1198,7 +1198,7 @@
 													"id": "mxfZs9fA2XujxGg_B",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Sea Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Sea Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "mZ1Lc1Pjssq14-gAQ",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mXVdPDnhTYK11FTlM",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Storm Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Storm Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "mo7G3Pg8F2RxcON0q",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mQor49vvGbf-rVKJ1",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Sun Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Sun Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "meLSncCWpQtefaOV0",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mZrgCc4wOb68K1thz",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Urban Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/Urban Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "m0osSp7N_vF_0pIvK",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mtbC0f24AqXJrOex1",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/War Holy Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 7/Holy Warrior Variants/War Holy Warrior.gct
@@ -328,7 +328,7 @@
 													"id": "mC8PoaaatNqt6iYIJ",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -550,7 +550,7 @@
 													"id": "mKLonEvnviZ9jogs_",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 9/Classes/Demonologist.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 9/Classes/Demonologist.gct
@@ -378,7 +378,7 @@
 											"id": "ms0KuidpGqGq2LVHy",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -652,7 +652,7 @@
 											"id": "mSImNC4RLIkOQTLhs",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -926,7 +926,7 @@
 											"id": "mH5PZwMQzlLgePhrv",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -1199,7 +1199,7 @@
 											"id": "m5Av5taPD7WqdN9vu",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -1473,7 +1473,7 @@
 											"id": "mW_MkIIinpv6Dn3dm",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 9/Classes/Elementalist.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 9/Classes/Elementalist.gct
@@ -561,7 +561,7 @@
 													"id": "mGSK4HybXexwudlf4",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 9/Classes/Necromancer.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 9/Classes/Necromancer.gct
@@ -453,7 +453,7 @@
 											"id": "mIjLgEeE4-2mAPDOV",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality"
+											"local_notes": "IQ 0 or Heteronomy"
 										},
 										{
 											"id": "MlPAvRwfKsUCm1-3w",
@@ -761,7 +761,7 @@
 											"id": "mNW7Dptxh7lDVdULn",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality"
+											"local_notes": "IQ 0 or Heteronomy"
 										},
 										{
 											"id": "MsEIdWxcoqU7c0AGU",
@@ -1069,7 +1069,7 @@
 											"id": "mUG6XY4qV8kX8-AXQ",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality"
+											"local_notes": "IQ 0 or Heteronomy"
 										},
 										{
 											"id": "MQRyWjpV_ERQTEDof",
@@ -1371,7 +1371,7 @@
 											"id": "mYGnISrBBCBOYzloa",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -1673,7 +1673,7 @@
 											"id": "mZ5GKxMoG0dU-yIIn",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -1975,7 +1975,7 @@
 											"id": "mTe2Av2ujyCvjYS29",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 9/Classes/Shaman.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 9/Classes/Shaman.gct
@@ -1722,7 +1722,7 @@
 											"id": "m1Mphk9mBCBOeXB8j",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -1963,7 +1963,7 @@
 											"id": "miJ8TeLPr3-UKiaeS",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -2204,7 +2204,7 @@
 											"id": "mIRrIogWA4BwApUZz",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -2443,7 +2443,7 @@
 											"id": "mWIxZM7zp9x66loft",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -2683,7 +2683,7 @@
 											"id": "mRNuPFOeGR4U4P7jv",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -2923,7 +2923,7 @@
 											"id": "mkKySnOp876to4eDq",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -3163,7 +3163,7 @@
 											"id": "meYvBlZJQyiCC3J9T",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -3403,7 +3403,7 @@
 											"id": "m2B3QqEDcp8bMgoai",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -3643,7 +3643,7 @@
 											"id": "m-PfE4J5njOlwE-9o",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -3883,7 +3883,7 @@
 											"id": "mVVxq_Qx5wa__ApJd",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -4123,7 +4123,7 @@
 											"id": "mvAW_VVUvon4xCzYh",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -4363,7 +4363,7 @@
 											"id": "meB4OVNGgpwNyeZn0",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -4603,7 +4603,7 @@
 											"id": "my_ty7DiZv1Rty1tM",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -4843,7 +4843,7 @@
 											"id": "mMThIrjbD52K9AwHY",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Barbarians/Barbarian.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Barbarians/Barbarian.gct
@@ -540,7 +540,7 @@
 											"id": "mpPFWvCeibXwWYo-U",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Barbarians/Rage Barbarian.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Barbarians/Rage Barbarian.gct
@@ -565,7 +565,7 @@
 											"id": "mXBRU0Nc-iOQCyNX5",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Barbarians/Savage Warrior.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Barbarians/Savage Warrior.gct
@@ -540,7 +540,7 @@
 											"id": "mbsqdwNDk9djvmkGo",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Barbarians/Survivor.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Barbarians/Survivor.gct
@@ -565,7 +565,7 @@
 											"id": "mjsUm9NTnPXeLxtdt",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Aristocrat Henchman.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Aristocrat Henchman.gct
@@ -276,7 +276,7 @@
 											"id": "mDVe6S46jJlD7FyV2",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Aristocrat.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy Denizens/Swashbucklers/Aristocrat.gct
@@ -352,7 +352,7 @@
 											"id": "m7W3PGb7S1xxOAmmu",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Fantasy Folk/Elves/Profession Templates/Forest Warden.gct
+++ b/Library/Fantasy Folk/Elves/Profession Templates/Forest Warden.gct
@@ -480,7 +480,7 @@
 									"id": "mlVMiCqEkHV0x5CcO",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Fantasy Folk/Winged Folk/Profession Templates/Trader.gct
+++ b/Library/Fantasy Folk/Winged Folk/Profession Templates/Trader.gct
@@ -2022,7 +2022,7 @@
 									"id": "mXW8ZNt_EWBImc2Ez",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Fantasy/Classes/Bandit.gct
+++ b/Library/Fantasy/Classes/Bandit.gct
@@ -312,7 +312,7 @@
 											"id": "mp3i9KZeySYe-nxXK",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Fantasy/Classes/Battle Wizard.gct
+++ b/Library/Fantasy/Classes/Battle Wizard.gct
@@ -907,7 +907,7 @@
 											"id": "mnCvqnf97u3WcIizZ",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Fantasy/Classes/Enchanter.gct
+++ b/Library/Fantasy/Classes/Enchanter.gct
@@ -480,7 +480,7 @@
 											"id": "mFbJ1kBKEjtLA8wzF",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Fantasy/Classes/Hedge Wizard.gct
+++ b/Library/Fantasy/Classes/Hedge Wizard.gct
@@ -515,7 +515,7 @@
 											"id": "mUtnrHZKbVHzKx-1U",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Fantasy/Classes/Holy Man.gct
+++ b/Library/Fantasy/Classes/Holy Man.gct
@@ -702,7 +702,7 @@
 											"id": "msNhu4eFTdsbpGj0r",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Fantasy/Classes/Merchant.gct
+++ b/Library/Fantasy/Classes/Merchant.gct
@@ -777,7 +777,7 @@
 											"id": "mucB3-4hZRazw8IKP",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Historical Folks/Actor.gct
+++ b/Library/Historical Folks/Actor.gct
@@ -200,7 +200,7 @@
 											"id": "m2YjWCLWgC--Zst1T",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Home Brew/Enraged Eggplant/Magic/Sorcery Spells.adq
+++ b/Library/Home Brew/Enraged Eggplant/Magic/Sorcery Spells.adq
@@ -162,7 +162,7 @@
 							"id": "mEVGuoBumoLR4R5Xh",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -10021,7 +10021,7 @@
 							"id": "mA7IJhJ8IMuXIj3he",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -20792,7 +20792,7 @@
 							"id": "mVdGsuKVM89U5KZpV",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -21376,7 +21376,7 @@
 							"id": "mEfQFsTgYgzBePJSq",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -21635,7 +21635,7 @@
 							"id": "mN-H-a_tWHv3eY4b7",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -21907,7 +21907,7 @@
 							"id": "mb_Dv-Mxt0znXKMhV",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -98823,7 +98823,7 @@
 							"id": "m1hfC2hUEwCfsF29i",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -116083,7 +116083,7 @@
 							"id": "mVVlPy-lxX8d745EK",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -125704,7 +125704,7 @@
 							"id": "mXdBTa8Tof0Z-kSjU",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -125964,7 +125964,7 @@
 							"id": "mH5BZTi1zvoh9Bj-n",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -126223,7 +126223,7 @@
 							"id": "muDK8DcJXNiR9P3LE",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -126482,7 +126482,7 @@
 							"id": "mt1ARS4jDR7baA44-",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -127634,7 +127634,7 @@
 							"id": "mflnS2w9RdZJUf9_h",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -130528,7 +130528,7 @@
 							"id": "mB2VP-ZHMGNorL_mV",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -131497,7 +131497,7 @@
 							"id": "mN5qHhuUGue55B5Fe",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -132649,7 +132649,7 @@
 							"id": "m9Pn_S-J1yH1DA_gt",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -133005,7 +133005,7 @@
 							"id": "m36F1ogTcYArU6kvs",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -180816,7 +180816,7 @@
 							"id": "mzlDiqye0-beLhNKu",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -221400,7 +221400,7 @@
 							"id": "mGPD5T1u7kCM6B6r-",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -261259,7 +261259,7 @@
 							"id": "miCwjMoz8hgMsvz2h",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -268835,7 +268835,7 @@
 							"id": "mD7YjdjgOVyh7Zb8p",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -269103,7 +269103,7 @@
 							"id": "m7qwUWYOW17gZz9Pg",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -269396,7 +269396,7 @@
 							"id": "m0BIjJ6xj1dP3CLxk",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -316320,7 +316320,7 @@
 							"id": "makNHHQn18jPaz22F",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -316588,7 +316588,7 @@
 							"id": "m5F76NY1o0VaXuSyb",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -317739,7 +317739,7 @@
 							"id": "mLFyqCC_e9ApOLxlD",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -318408,7 +318408,7 @@
 							"id": "mNqLwEiKOAIto05H4",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality"
+							"local_notes": "IQ 0 or Heteronomy"
 						},
 						{
 							"id": "mE1WYApnAO_P4PZS4",
@@ -367070,7 +367070,7 @@
 							"id": "mzNp88aQwoMWZmVSn",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality"
+							"local_notes": "IQ 0 or Heteronomy"
 						},
 						{
 							"id": "m7sfV5gnTmB8gLshN",
@@ -446444,7 +446444,7 @@
 							"id": "mVKVC5n2t8BIoxlw5",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -449783,7 +449783,7 @@
 							"id": "mAmxi5oRlf6KwbzNr",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality"
+							"local_notes": "IQ 0 or Heteronomy"
 						},
 						{
 							"id": "mDShaHY7pYBvT_Nw5",
@@ -558055,7 +558055,7 @@
 							"id": "mrbwKyU7bfrIf1k2J",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -558836,7 +558836,7 @@
 							"id": "m9tCc-vINSvLEZ5aF",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -601701,7 +601701,7 @@
 							"id": "meH0bYPYRo8yEd9QN",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -602082,7 +602082,7 @@
 							"id": "mbmtElDmrMAnXZiCI",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -602350,7 +602350,7 @@
 							"id": "mwpaHjCNdTiUecpN8",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -602618,7 +602618,7 @@
 							"id": "miC_5mB9mJviKJmJp",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -602889,7 +602889,7 @@
 							"id": "mxW7vXmngxCKPr5Lw",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -603152,7 +603152,7 @@
 							"id": "mt_F9hAzJDj4wlKnc",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -603420,7 +603420,7 @@
 							"id": "mYn05aiTlWVyeq_3q",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -603687,7 +603687,7 @@
 							"id": "mzVtMIZoTHYtWR-JJ",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -604182,7 +604182,7 @@
 							"id": "mXM49RowdBjIzdI3f",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -604430,7 +604430,7 @@
 							"id": "myY5tHUUP3px04EGS",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -647233,7 +647233,7 @@
 							"id": "mkh1mZ6iCMl0HQBU6",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -668141,7 +668141,7 @@
 							"id": "mDRI48ZVX1vmL4Nqz",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -673260,7 +673260,7 @@
 							"id": "m3eybAXxTJN-rP--1",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality"
+							"local_notes": "IQ 0 or Heteronomy"
 						},
 						{
 							"id": "m2VlxmMNJVDFV8KTb",

--- a/Library/Home Brew/Enraged Eggplant/Magic/Wizardry (Clerical).adq
+++ b/Library/Home Brew/Enraged Eggplant/Magic/Wizardry (Clerical).adq
@@ -10050,7 +10050,7 @@
 							"id": "mC3IlmVI_J5kNPB_v",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality"
+							"local_notes": "IQ 0 or Heteronomy"
 						},
 						{
 							"id": "MB2-6WCqPVxdxKbww",
@@ -10603,7 +10603,7 @@
 							"id": "mOz1o-IjJG9KL_Y-y",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality"
+							"local_notes": "IQ 0 or Heteronomy"
 						},
 						{
 							"id": "M6Tu66XntY28I-15Y",
@@ -26161,7 +26161,7 @@
 							"id": "mI-lvV2E4Nf9x1vq7",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -30733,7 +30733,7 @@
 									"id": "mjfuzOkAodQliW59F",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -31093,7 +31093,7 @@
 									"id": "mRogqakeyafxfE-6j",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -31453,7 +31453,7 @@
 									"id": "mByLogA_J9GNrFyBE",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -31825,7 +31825,7 @@
 									"id": "mh3rPdqmDjcXEN8M2",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -32185,7 +32185,7 @@
 									"id": "mxZeM0oiaZmzcIXfm",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -32545,7 +32545,7 @@
 									"id": "mJavhfE6OVBTjgfkW",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -32917,7 +32917,7 @@
 									"id": "mbx3g1xSGgQfbnJlC",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -33277,7 +33277,7 @@
 									"id": "mDuklV564TfQIfcfv",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -33637,7 +33637,7 @@
 									"id": "m2Cg39dsI5NaqQ_30",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -34009,7 +34009,7 @@
 									"id": "m2Cdo5t2ScQ32x_9k",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -34369,7 +34369,7 @@
 									"id": "moB3ca6e7I5OozCOc",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -34729,7 +34729,7 @@
 									"id": "mMUobEbgoL1Kseq2k",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -60685,7 +60685,7 @@
 							"id": "mg-4X9eoDAKSdwM1o",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -80171,7 +80171,7 @@
 									"id": "mMvF9-W10gJbNzP0t",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -80571,7 +80571,7 @@
 									"id": "mkA6-VWqXg0SLJkDa",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -80971,7 +80971,7 @@
 									"id": "meXELdXEEvCgtwx6T",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -81371,7 +81371,7 @@
 									"id": "mD7xyXm9dnhJ-R6mO",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -81771,7 +81771,7 @@
 									"id": "mNk1wUZM4IEBHYDbp",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -82171,7 +82171,7 @@
 									"id": "mEireR1GNJfZHwt__",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -82571,7 +82571,7 @@
 									"id": "miAkoDD-TypJv3Zhd",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -82971,7 +82971,7 @@
 									"id": "mjIdssbnbjbNgV01M",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -83371,7 +83371,7 @@
 									"id": "mGBT3RB1_pFo4jTAI",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -95295,7 +95295,7 @@
 							"id": "msCOFbVARo8SWuOsj",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -157902,7 +157902,7 @@
 									"id": "mOrJ_p8IqQ-J8snxy",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -158263,7 +158263,7 @@
 									"id": "muioOM_EDDQah7C05",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -158624,7 +158624,7 @@
 									"id": "mxwv1uCd9WbB2P32b",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -158996,7 +158996,7 @@
 									"id": "mpdW1XtoA7xkFe5Ws",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -159356,7 +159356,7 @@
 									"id": "mBz52aeVZVFPO24XX",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -159716,7 +159716,7 @@
 									"id": "mjXjnAyNcsUVvmzpo",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -160088,7 +160088,7 @@
 									"id": "m1r6pI8Eq-SwNV7bI",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -160448,7 +160448,7 @@
 									"id": "m3y7DgmyzuYGKBO8K",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -160808,7 +160808,7 @@
 									"id": "mEfLPPnOOsvBtbi4z",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -161180,7 +161180,7 @@
 									"id": "mvDy8mG8gMCn06yHp",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -161540,7 +161540,7 @@
 									"id": "mBXbFK3IbRuLfLUEb",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -161900,7 +161900,7 @@
 									"id": "m7Csd0xgsZLAl1AqW",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -162272,7 +162272,7 @@
 									"id": "mHZYBfAJcuJDMwmnJ",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -162632,7 +162632,7 @@
 									"id": "mPIH38IUTlTETxMoE",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -162992,7 +162992,7 @@
 									"id": "msneyEGjePAbqZgJ_",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -200133,7 +200133,7 @@
 							"id": "m-kw7cw_VXqSDdxjU",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -248055,7 +248055,7 @@
 							"id": "mGjN8C2YhWyYXN5Sa",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality"
+							"local_notes": "IQ 0 or Heteronomy"
 						},
 						{
 							"id": "M1Z-l7y_rVRZZp-CB",
@@ -254030,7 +254030,7 @@
 							"id": "mYT0kkiMg8ByrmOdi",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality"
+							"local_notes": "IQ 0 or Heteronomy"
 						},
 						{
 							"id": "MIBO1XVl9lal3iBvW",
@@ -306980,7 +306980,7 @@
 							"id": "mwsbGn-vOTHyMmdEV",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -307711,7 +307711,7 @@
 									"id": "mb8gaVdBS0TnO8U1o",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -308071,7 +308071,7 @@
 									"id": "mKdJKDiQYYOkslSJU",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -308431,7 +308431,7 @@
 									"id": "mS24EeV_ZhFLu7DmO",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -385546,7 +385546,7 @@
 							"id": "mPnB9_zRq_y5WiStD",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -401518,7 +401518,7 @@
 									"id": "mVY0sj9murd4eqTog",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -401878,7 +401878,7 @@
 									"id": "mIt7AwNe7yIqjNzsd",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -402238,7 +402238,7 @@
 									"id": "mv8RXVNLBVXfNt5aW",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -410850,7 +410850,7 @@
 									"id": "muwixUGJlTbcJhyav",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -411250,7 +411250,7 @@
 									"id": "mrSdr7ANzrdsBpkXe",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -411650,7 +411650,7 @@
 									"id": "mpsFblxdReA2-H5e8",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -412050,7 +412050,7 @@
 									"id": "muHne8sy3Wx5SqZ0Z",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -412450,7 +412450,7 @@
 									"id": "mdsYXF3TNg7xEKFiP",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -412850,7 +412850,7 @@
 									"id": "msNNFtoritoTSMNJO",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -413250,7 +413250,7 @@
 									"id": "me0pXxTr5QsXILE6y",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -413650,7 +413650,7 @@
 									"id": "mnPDUL0zSYg2DLKG0",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -414050,7 +414050,7 @@
 									"id": "mHVoviFd0LaRKLuV2",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -414464,7 +414464,7 @@
 									"id": "m4u0yrSFWg3ff1XXe",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -414865,7 +414865,7 @@
 									"id": "mSrlsImZJUGG1A3eH",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -415266,7 +415266,7 @@
 									"id": "m1XufbGVRfdzcw-De",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -415667,7 +415667,7 @@
 									"id": "mkwOtVEPYuYUrum21",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -416068,7 +416068,7 @@
 									"id": "m-wWayYEXCs0JxejW",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -416469,7 +416469,7 @@
 									"id": "mwDLMnrhhgOlB56ry",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -416870,7 +416870,7 @@
 									"id": "mEjeoJnILFSDqQ4ts",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -417271,7 +417271,7 @@
 									"id": "mEbmZCBmsLdXqWgM4",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -417672,7 +417672,7 @@
 									"id": "mWYIdG2kuzfSonxfL",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -418084,7 +418084,7 @@
 									"id": "m-rJPM8OPhByz1UtJ",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -418484,7 +418484,7 @@
 									"id": "mRjO8KVDP9X1QSJqp",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -418884,7 +418884,7 @@
 									"id": "m96bOWBc0RzD2RwTw",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -419284,7 +419284,7 @@
 									"id": "mNApmXVfIXcJMDtRR",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -419684,7 +419684,7 @@
 									"id": "ms9AYdBDyRslQfqve",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -420084,7 +420084,7 @@
 									"id": "mGEqnHjpHz3cjW8M1",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -420484,7 +420484,7 @@
 									"id": "mQWN1gyDEQSACgPpk",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -420884,7 +420884,7 @@
 									"id": "mg9mxHm8aNCWevSC9",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -421284,7 +421284,7 @@
 									"id": "mQe2iZLW83yCss0qd",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -421911,7 +421911,7 @@
 									"id": "mDicjRFVo9Dlj3V_x",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -422312,7 +422312,7 @@
 									"id": "mP6Iap-ewWStMng0p",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -422713,7 +422713,7 @@
 									"id": "mL36pV_iAgzZZiiU6",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -423114,7 +423114,7 @@
 									"id": "mShKs1LN_RhHbukHi",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -423515,7 +423515,7 @@
 									"id": "mG-rYsCYrbMVcxJWF",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -423916,7 +423916,7 @@
 									"id": "mStroES3w4Y635045",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -424317,7 +424317,7 @@
 									"id": "mUH_X-foQR3EYVNWT",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -424718,7 +424718,7 @@
 									"id": "mX_HGCi7HHwjxaGQX",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -425119,7 +425119,7 @@
 									"id": "mwN8nZejEGv2Jk9U0",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -425526,7 +425526,7 @@
 							"id": "mcKGZD_LdpBzp7NSn",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -425886,7 +425886,7 @@
 							"id": "mPqSucmFavRecsVtW",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -426232,7 +426232,7 @@
 									"id": "mEgtS5ctQAfesaW71",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -426632,7 +426632,7 @@
 									"id": "mx0SI2_L_XZBqoDAA",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -427032,7 +427032,7 @@
 									"id": "mzQ8-kekJ5NR9l1aR",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -427432,7 +427432,7 @@
 									"id": "m7Dx7qAkxEUEm73bU",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -427832,7 +427832,7 @@
 									"id": "mJCBr6hVQuCfd90LU",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -428232,7 +428232,7 @@
 									"id": "mPd1zpg9YPf3neIyS",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -428632,7 +428632,7 @@
 									"id": "ml6JbwUtYvQAsDSFv",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -429032,7 +429032,7 @@
 									"id": "mKm_ml5ZhTnQahYzE",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -429432,7 +429432,7 @@
 									"id": "mWmzpiv5YMcq5-QnD",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Home Brew/Enraged Eggplant/Magic/Wizardry.adq
+++ b/Library/Home Brew/Enraged Eggplant/Magic/Wizardry.adq
@@ -6298,7 +6298,7 @@
 							"id": "mBM2mmDxfWrAuFYCk",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality"
+							"local_notes": "IQ 0 or Heteronomy"
 						},
 						{
 							"id": "Md_7SZUU1UmKow5Wp",
@@ -6851,7 +6851,7 @@
 							"id": "mviLMe9hhGYlYOs0X",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality"
+							"local_notes": "IQ 0 or Heteronomy"
 						},
 						{
 							"id": "MYKfQPDlJP4_3x8Pf",
@@ -20769,7 +20769,7 @@
 							"id": "mV3ACy_rIyvq4z9iC",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -23412,7 +23412,7 @@
 									"id": "mMq2t1QBnGK4HYUDC",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -23774,7 +23774,7 @@
 									"id": "mWegPolPNEf3XJqoF",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -24136,7 +24136,7 @@
 									"id": "mEnJUnPSiHYxdr0Ov",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -24511,7 +24511,7 @@
 									"id": "ma88yC5hv-PC0WPsF",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -24873,7 +24873,7 @@
 									"id": "m6YXt6woPfS9KeXAv",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -25235,7 +25235,7 @@
 									"id": "m7iRyrg8vdlX54DyR",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -25610,7 +25610,7 @@
 									"id": "m8tuwEY4H3dnulUWw",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -25972,7 +25972,7 @@
 									"id": "moBuX_Kl1VmVmP14U",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -26334,7 +26334,7 @@
 									"id": "mz4yvv3Cxydl0IY6s",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -26709,7 +26709,7 @@
 									"id": "mIe4NT31rqN4Q2P2h",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -27071,7 +27071,7 @@
 									"id": "mk3UKQq88DyuFYKB0",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -27433,7 +27433,7 @@
 									"id": "m1l0sniF8u9iNFRB8",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -50128,7 +50128,7 @@
 							"id": "mvaGPyJteWL1t1PJX",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -64826,7 +64826,7 @@
 									"id": "mZUFnuMy_01jirB4J",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -65227,7 +65227,7 @@
 									"id": "mSLJPmWFz_Q1oyXpj",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -65628,7 +65628,7 @@
 									"id": "mZ4KTSI4VT0zvTIdY",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -66029,7 +66029,7 @@
 									"id": "mYR4wsKXHecD6hZzm",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -66430,7 +66430,7 @@
 									"id": "mu1C9GPZdA2w48GuR",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -66831,7 +66831,7 @@
 									"id": "mLS2bTZqbtGmE3beV",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -67232,7 +67232,7 @@
 									"id": "mBxyCyiPYIuW1bS9O",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -67633,7 +67633,7 @@
 									"id": "mcL1s6LGzQos6bOyA",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -68034,7 +68034,7 @@
 									"id": "m6Gy2OF2jvDWxs5TJ",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -68448,7 +68448,7 @@
 									"id": "mAfE3iiI6WLUSLaAf",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality"
+									"local_notes": "IQ 0 or Heteronomy"
 								},
 								{
 									"id": "MAHiAPOLQ2G6PJv60",
@@ -68850,7 +68850,7 @@
 									"id": "mZU9oGrjdoC_eJdx5",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality"
+									"local_notes": "IQ 0 or Heteronomy"
 								},
 								{
 									"id": "MfNen5WFYSpoV8bwF",
@@ -69252,7 +69252,7 @@
 									"id": "mQ-UZY-99klK988GQ",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality"
+									"local_notes": "IQ 0 or Heteronomy"
 								},
 								{
 									"id": "MBYKHKJYo2EL4jVb9",
@@ -69654,7 +69654,7 @@
 									"id": "mPWg4ln-NL_8clCxS",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality"
+									"local_notes": "IQ 0 or Heteronomy"
 								},
 								{
 									"id": "MI9kEvqykpGXxOJRf",
@@ -70056,7 +70056,7 @@
 									"id": "mOHe6xa-4YmbHPGS2",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality"
+									"local_notes": "IQ 0 or Heteronomy"
 								},
 								{
 									"id": "MDoutnff6s_FIDcgW",
@@ -70458,7 +70458,7 @@
 									"id": "mJDyxuauYE75AB2p6",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality"
+									"local_notes": "IQ 0 or Heteronomy"
 								},
 								{
 									"id": "MbRKUOjr8CiwsV2Ga",
@@ -70860,7 +70860,7 @@
 									"id": "mNaISW_A1LmNsDKf7",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality"
+									"local_notes": "IQ 0 or Heteronomy"
 								},
 								{
 									"id": "MFGu2qQ6ouxgmHHD1",
@@ -71262,7 +71262,7 @@
 									"id": "m_ISniWGIVafCP5qN",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality"
+									"local_notes": "IQ 0 or Heteronomy"
 								},
 								{
 									"id": "MlE4Y97mkp0lDWen3",
@@ -71664,7 +71664,7 @@
 									"id": "mcEeEMpOlNnkupz-s",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality"
+									"local_notes": "IQ 0 or Heteronomy"
 								},
 								{
 									"id": "M0m4WretURrb3kqMF",
@@ -82339,7 +82339,7 @@
 							"id": "mKPzhymydBMP1mGFf",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -135043,7 +135043,7 @@
 									"id": "mVwpEn7cmGg9XWVUk",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -135404,7 +135404,7 @@
 									"id": "m2ckakvqb3AL4IjZm",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -135765,7 +135765,7 @@
 									"id": "mKQFFn3UqUZx0G5hI",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -136140,7 +136140,7 @@
 									"id": "mDPi6kPmtTJpLSpKk",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -136502,7 +136502,7 @@
 									"id": "m-4Y6721aniX-XUbL",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -136864,7 +136864,7 @@
 									"id": "mH3W0Bd9h4UOEgsV8",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -137239,7 +137239,7 @@
 									"id": "mL8uwpvKl9lj8VbFF",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -137601,7 +137601,7 @@
 									"id": "mC2pxIe2W5Hmucuea",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -137963,7 +137963,7 @@
 									"id": "mHQNHzHoCH50N2Mnf",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -138338,7 +138338,7 @@
 									"id": "mILvT_qo5KNQ9SkD6",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -138700,7 +138700,7 @@
 									"id": "m6fpLQpf1yYldORly",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -139062,7 +139062,7 @@
 									"id": "mwTEIFHTLQNeyc3Bx",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -139437,7 +139437,7 @@
 									"id": "mVvR2xMo5K59JMlr_",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -139799,7 +139799,7 @@
 									"id": "md2oGiO53cbWOy7Wq",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -140161,7 +140161,7 @@
 									"id": "m9BgxZSR478MWEbuT",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -175382,7 +175382,7 @@
 							"id": "m1W19Ctt2nojd0BWt",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -218287,7 +218287,7 @@
 							"id": "mvIfyUQlcxoRxP-Ay",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality"
+							"local_notes": "IQ 0 or Heteronomy"
 						},
 						{
 							"id": "MpQZsWllLKw90uc5m",
@@ -223504,7 +223504,7 @@
 							"id": "myy0v0f_KKI__1_sT",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality"
+							"local_notes": "IQ 0 or Heteronomy"
 						},
 						{
 							"id": "MrBKpYbpccTkrE2fk",
@@ -274957,7 +274957,7 @@
 							"id": "m86H40WOyDtYItdlG",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -275678,7 +275678,7 @@
 									"id": "m0o7bGA1bRRmZrtVx",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -276039,7 +276039,7 @@
 									"id": "mon2Gr45k7ArMaIJ-",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -276400,7 +276400,7 @@
 									"id": "mgmJxqmE_bDlJeFXX",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -345804,7 +345804,7 @@
 							"id": "mrkWPBLAIsKzFHvjB",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -361001,7 +361001,7 @@
 									"id": "mSMcuFNixxkHTuFyd",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -361362,7 +361362,7 @@
 									"id": "mzOCieCbgQ2R79tgr",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -361723,7 +361723,7 @@
 									"id": "mOh9tHbtBGVKPAeMb",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -369274,7 +369274,7 @@
 									"id": "muqgUUcUyGi-gSBCL",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -369676,7 +369676,7 @@
 									"id": "mJ3Wh7f24W_r0gTdh",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -370078,7 +370078,7 @@
 									"id": "mNKhGN4OiVcCYovWo",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -370480,7 +370480,7 @@
 									"id": "mJqpoj3QXnWichQnY",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -370882,7 +370882,7 @@
 									"id": "mkd8XKs1KRFSvaN00",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -371284,7 +371284,7 @@
 									"id": "mybGyBp8j-udA8z6u",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -371686,7 +371686,7 @@
 									"id": "m8pyu6FBp4jCM4j2M",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -372088,7 +372088,7 @@
 									"id": "mLIeT7Knqa7VHM_Ia",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -372490,7 +372490,7 @@
 									"id": "mw6VO6Hk5_ZvpQoSF",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -372905,7 +372905,7 @@
 									"id": "m0G1mLpaenW-xZn5d",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -373307,7 +373307,7 @@
 									"id": "mIBgxyVhd0SlPowvx",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -373709,7 +373709,7 @@
 									"id": "mdAG2RE-WDRkRMWpn",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -374111,7 +374111,7 @@
 									"id": "mORyU6ekvpXm-pRtK",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -374513,7 +374513,7 @@
 									"id": "mcNgb_VMaBwLi20pt",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -374915,7 +374915,7 @@
 									"id": "mvuAMEpJLUa-oLinZ",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -375317,7 +375317,7 @@
 									"id": "mGYre1zyUwp2C6BLd",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -375719,7 +375719,7 @@
 									"id": "mcGHs0kyrVAVc2moJ",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -376121,7 +376121,7 @@
 									"id": "m2KyUZ0UhEJetZONm",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -376536,7 +376536,7 @@
 									"id": "mbeVoYIGt8-Hxff2x",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -376938,7 +376938,7 @@
 									"id": "m6mMBbf9mHe16hfZE",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -377340,7 +377340,7 @@
 									"id": "motryjkEVGfceT0PX",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -377742,7 +377742,7 @@
 									"id": "ma3eVxyg2bPrxsZOY",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -378144,7 +378144,7 @@
 									"id": "mOiD5fXATxnA2ZCJo",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -378546,7 +378546,7 @@
 									"id": "mVs-6LnOyYhgRTCEe",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -378948,7 +378948,7 @@
 									"id": "m5SNewteRzo397ehU",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -379350,7 +379350,7 @@
 									"id": "m9ukVVUaNM1Rm1hJP",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -379752,7 +379752,7 @@
 									"id": "mXzpCRSaPYa403Y5-",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -380379,7 +380379,7 @@
 									"id": "maUPUuyr24rxj3g5r",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -380780,7 +380780,7 @@
 									"id": "mB5oELhddUiPl81uF",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -381181,7 +381181,7 @@
 									"id": "mQb92vdESnRtX7Eix",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -381582,7 +381582,7 @@
 									"id": "mElgYHoy4Wp4W8Mkj",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -381983,7 +381983,7 @@
 									"id": "mhGK3a8VV3U2BYYVp",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -382384,7 +382384,7 @@
 									"id": "m_Yx-4Rgqu3WkHhS0",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -382785,7 +382785,7 @@
 									"id": "mzDc59AOi0vhnDKY2",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -383186,7 +383186,7 @@
 									"id": "mNveCxor9zW3_bmF2",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -383587,7 +383587,7 @@
 									"id": "m_jHHu5iMqsnAzsUz",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -384002,7 +384002,7 @@
 									"id": "mzSUdtyXG2GiXTL1Z",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -384404,7 +384404,7 @@
 									"id": "mx-4sKk1b7EuemU_K",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -384806,7 +384806,7 @@
 									"id": "mrfK_yKO-AbYC6H8k",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -385208,7 +385208,7 @@
 									"id": "mNubn9D1P2GENWTee",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -385610,7 +385610,7 @@
 									"id": "mRm3f6_SE7nG1NCd6",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -386012,7 +386012,7 @@
 									"id": "mMLsoly8p4h_ZXRxG",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -386414,7 +386414,7 @@
 									"id": "mMI5xdE8BOaXTRsWV",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -386816,7 +386816,7 @@
 									"id": "mncUVnq6Wun-DWwZy",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{
@@ -387218,7 +387218,7 @@
 									"id": "mNIr-XFgfq3gai-6E",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Boneyard.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Boneyard.gcs
@@ -2526,7 +2526,7 @@
 											"id": "ml-0JFie5O2--L8DJ",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality"
+											"local_notes": "IQ 0 or Heteronomy"
 										},
 										{
 											"id": "mVqvDBTVIg1q7LQRm",

--- a/Library/Home Brew/Enraged Eggplant/Monsters/Dullahan.gcs
+++ b/Library/Home Brew/Enraged Eggplant/Monsters/Dullahan.gcs
@@ -1693,7 +1693,7 @@
 											"id": "mUPFRLw-pw4I0YmKi",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -1987,7 +1987,7 @@
 											"id": "m6ijJBoUHlmXn3Dac",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -2281,7 +2281,7 @@
 											"id": "milNBicALrcdVsH4p",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -2575,7 +2575,7 @@
 											"id": "meSi6F-7b_rIq6PLw",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Home Brew/Enraged Eggplant/Occupational Templates/Druid.gct
+++ b/Library/Home Brew/Enraged Eggplant/Occupational Templates/Druid.gct
@@ -309,7 +309,7 @@
 									"id": "mu9h3Fz7rY3sMaMf_",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Home Brew/Enraged Eggplant/Occupational Templates/Sorcerer.gct
+++ b/Library/Home Brew/Enraged Eggplant/Occupational Templates/Sorcerer.gct
@@ -174,7 +174,7 @@
 									"id": "mBmIww6FAXUTZ9Bg6",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Home Brew/Enraged Eggplant/Occupational Templates/Wizard.gct
+++ b/Library/Home Brew/Enraged Eggplant/Occupational Templates/Wizard.gct
@@ -173,7 +173,7 @@
 									"id": "mHgTf4FB2vGPdAg-8",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Home Brew/Enraged Eggplant/Psionics/Psionics (Eggplant).adq
+++ b/Library/Home Brew/Enraged Eggplant/Psionics/Psionics (Eggplant).adq
@@ -61304,7 +61304,7 @@
 									"id": "mw2eA9ZPnOrkEgfWT",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality"
+									"local_notes": "IQ 0 or Heteronomy"
 								},
 								{
 									"id": "mrp7B68C7qLxFwMZ6",

--- a/Library/Home Brew/Historical Folks Skill Sets/Skill Sets/Royal-Advisor.gct
+++ b/Library/Home Brew/Historical Folks Skill Sets/Skill Sets/Royal-Advisor.gct
@@ -344,7 +344,7 @@
 							"id": "mMPo5_E4Levju1Y_t",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Spider Daedra.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Spider Daedra.gcs
@@ -924,7 +924,7 @@
 							"id": "m_dkHrpYiyYBO8Wl3",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Xivilai.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Xivilai.gcs
@@ -1559,7 +1559,7 @@
 							"id": "myJItuvm4FhlXVBWM",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Spriggan Matron.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Spriggan Matron.gcs
@@ -1941,7 +1941,7 @@
 							"id": "m--zwRU1pjvQsTzrz",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Spriggan.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Spriggan.gcs
@@ -1916,7 +1916,7 @@
 							"id": "mOxZ-xfeVCI-QwGvy",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Wispmother.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Wispmother.gcs
@@ -1776,7 +1776,7 @@
 					"id": "mj7cDA5gy0jiirttv",
 					"name": "Minion",
 					"reference": "B38",
-					"local_notes": "IQ 0 or Slave Mentality"
+					"local_notes": "IQ 0 or Heteronomy"
 				},
 				{
 					"id": "mXnLcBy7WaSEXyIou",

--- a/Library/Horror/Classes/Aristocrat.gct
+++ b/Library/Horror/Classes/Aristocrat.gct
@@ -620,7 +620,7 @@
 											"id": "mrDTWKb2dJbXwDeo2",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Horror/Classes/Attorney.gct
+++ b/Library/Horror/Classes/Attorney.gct
@@ -556,7 +556,7 @@
 											"id": "mgxwX9raIip8foQ9Y",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Horror/Classes/Detective.gct
+++ b/Library/Horror/Classes/Detective.gct
@@ -457,7 +457,7 @@
 											"id": "mAM4owaSqs9oAtPh8",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Horror/Classes/Mystic Charlatan.gct
+++ b/Library/Horror/Classes/Mystic Charlatan.gct
@@ -308,7 +308,7 @@
 											"id": "m17G6QyqH779Yal8P",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -531,7 +531,7 @@
 											"id": "mCHWOoE6vLOeUxCRc",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Horror/Classes/Mystic Practitioner.gct
+++ b/Library/Horror/Classes/Mystic Practitioner.gct
@@ -2161,7 +2161,7 @@
 													"id": "m9kfdravBTIbFkcha",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Horror/Classes/Priest.gct
+++ b/Library/Horror/Classes/Priest.gct
@@ -404,7 +404,7 @@
 											"id": "mokYjrEw4VkAYAYkD",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Lands Out of Time/Classes/Timelost Explorer.gct
+++ b/Library/Lands Out of Time/Classes/Timelost Explorer.gct
@@ -449,7 +449,7 @@
 											"id": "mYzTzpgsdEEdLZxFR",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Lands Out of Time/Classes/Timelost Kid.gct
+++ b/Library/Lands Out of Time/Classes/Timelost Kid.gct
@@ -363,7 +363,7 @@
 											"id": "mMo-SBQHmKtbAtLts",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Lands Out of Time/Classes/Tribal Shaman.gct
+++ b/Library/Lands Out of Time/Classes/Tribal Shaman.gct
@@ -627,7 +627,7 @@
 											"id": "m6R5iwezrXJ1ER6Mr",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Monster Hunters/Classes/Champions/Commando.gct
+++ b/Library/Monster Hunters/Classes/Champions/Commando.gct
@@ -334,7 +334,7 @@
 											"id": "mEajNe35drnJ2-aYH",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Monster Hunters/Classes/Champions/Crusader.gct
+++ b/Library/Monster Hunters/Classes/Champions/Crusader.gct
@@ -242,7 +242,7 @@
 											"id": "m-CYnL8JwchUMTas3",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Monster Hunters/Classes/Champions/Experiment.gct
+++ b/Library/Monster Hunters/Classes/Champions/Experiment.gct
@@ -423,7 +423,7 @@
 											"id": "m39XG9g-PBo1sWzQv",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Monster Hunters/Classes/Champions/Inhuman.gct
+++ b/Library/Monster Hunters/Classes/Champions/Inhuman.gct
@@ -289,7 +289,7 @@
 											"id": "mz0j0kiRqAJvxajvy",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Monster Hunters/Classes/Champions/Sage.gct
+++ b/Library/Monster Hunters/Classes/Champions/Sage.gct
@@ -1140,7 +1140,7 @@
 											"id": "m-8X3hrVltBEbT9WX",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Monster Hunters/Classes/Champions/Sleuth.gct
+++ b/Library/Monster Hunters/Classes/Champions/Sleuth.gct
@@ -1857,7 +1857,7 @@
 											"id": "mNrq9SmH4U0XGeLb9",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Monster Hunters/Classes/Champions/Techie.gct
+++ b/Library/Monster Hunters/Classes/Champions/Techie.gct
@@ -778,7 +778,7 @@
 											"id": "mbgglSf_pes1v_X2Q",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Monster Hunters/Classes/Champions/Warrior.gct
+++ b/Library/Monster Hunters/Classes/Champions/Warrior.gct
@@ -689,7 +689,7 @@
 											"id": "m76Pko9LjV4Ii9Z6_",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Monster Hunters/Classes/Champions/Witch.gct
+++ b/Library/Monster Hunters/Classes/Champions/Witch.gct
@@ -1379,7 +1379,7 @@
 											"id": "mvdLaXt-7c5Kqig4n",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Mysteries/Classes/Defense Attorney.gct
+++ b/Library/Mysteries/Classes/Defense Attorney.gct
@@ -207,7 +207,7 @@
 									"id": "mxr4B3xH1fF_KUgqv",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Mysteries/Classes/Genius Detective.gct
+++ b/Library/Mysteries/Classes/Genius Detective.gct
@@ -194,7 +194,7 @@
 							"id": "ml66zCcAtIcR1uyqP",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Powers/Powers - Divine Favor Traits.adq
+++ b/Library/Powers/Powers - Divine Favor Traits.adq
@@ -2185,7 +2185,7 @@
 							"id": "mBrOf3LIOpAXu892I",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -4772,7 +4772,7 @@
 							"id": "mSOA5NXcvLfoQT-JF",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{
@@ -6071,7 +6071,7 @@
 							"id": "mKlyPtop9ln3Jozet",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Psionics/Classes/Celebrity.gct
+++ b/Library/Psionics/Classes/Celebrity.gct
@@ -2782,7 +2782,7 @@
 											"id": "mgh2E2HCHAhFO-pxu",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -3226,7 +3226,7 @@
 											"id": "mlIgrmOF-Jla-ofDk",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Psionics/Classes/Child.gct
+++ b/Library/Psionics/Classes/Child.gct
@@ -520,7 +520,7 @@
 											"id": "mtKvONGDDtjE8tbWm",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Psionics/Classes/Criminal.gct
+++ b/Library/Psionics/Classes/Criminal.gct
@@ -749,7 +749,7 @@
 											"id": "mjul6NTrQvtYRx75D",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -1254,7 +1254,7 @@
 											"id": "m_Am85NxBpoFuVRUR",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Psionics/Classes/Investigator.gct
+++ b/Library/Psionics/Classes/Investigator.gct
@@ -842,7 +842,7 @@
 											"id": "mg8XKzoSf_4RKxftm",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Psionics/Classes/Manipulator.gct
+++ b/Library/Psionics/Classes/Manipulator.gct
@@ -1490,7 +1490,7 @@
 											"id": "m5IXObs_rx7XZ1mf0",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Psionics/Classes/Parapsychologist.gct
+++ b/Library/Psionics/Classes/Parapsychologist.gct
@@ -511,7 +511,7 @@
 											"id": "m1q176pfTEWWQsNnG",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Psionics/Classes/Secret Agent.gct
+++ b/Library/Psionics/Classes/Secret Agent.gct
@@ -1510,7 +1510,7 @@
 											"id": "mCPGsKYzs9ACWlKuF",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Psionics/Classes/Soothsayer.gct
+++ b/Library/Psionics/Classes/Soothsayer.gct
@@ -322,7 +322,7 @@
 											"id": "mOWqFF1tyVMQCx8aV",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Pyramid Magazine/Pyramid 36/Cleric.gct
+++ b/Library/Pyramid Magazine/Pyramid 36/Cleric.gct
@@ -1043,7 +1043,7 @@
 													"id": "m9TckEDluoUz1ghaG",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1265,7 +1265,7 @@
 													"id": "mVuQ3DjXM-hRCcQnQ",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Pyramid Magazine/Pyramid 36/Warrior-Saint.gct
+++ b/Library/Pyramid Magazine/Pyramid 36/Warrior-Saint.gct
@@ -494,7 +494,7 @@
 													"id": "mYJmwZTVSsYaDWypZ",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -716,7 +716,7 @@
 													"id": "mKNsJui-FZgTu29qy",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Pyramid Magazine/Pyramid 50/Gray Necromancer.gct
+++ b/Library/Pyramid Magazine/Pyramid 50/Gray Necromancer.gct
@@ -169,7 +169,7 @@
 											"id": "m1XtFMfMBvR5S6e0s",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -397,7 +397,7 @@
 											"id": "mo3Y4sL95-vD3iGZY",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{
@@ -628,7 +628,7 @@
 											"id": "mz-Ww2zHgvVSuUZYK",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality"
+											"local_notes": "IQ 0 or Heteronomy"
 										},
 										{
 											"id": "mEFQYNX3pFgg3_tFK",
@@ -866,7 +866,7 @@
 											"id": "mHJ4EAg6_aMqEfOWl",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality"
+											"local_notes": "IQ 0 or Heteronomy"
 										},
 										{
 											"id": "mbQdMitzwpeUEkTA4",
@@ -1104,7 +1104,7 @@
 											"id": "mXPzUowAjha3B-uJx",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality"
+											"local_notes": "IQ 0 or Heteronomy"
 										},
 										{
 											"id": "mbbgzwVIDVOEsuW_0",

--- a/Library/Pyramid Magazine/Pyramid 60/Beastmaster.gct
+++ b/Library/Pyramid Magazine/Pyramid 60/Beastmaster.gct
@@ -1589,7 +1589,7 @@
 													"id": "mGwTXfGFpoKug6Urw",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Pyramid Magazine/Pyramid 68/Elemental Druid.gct
+++ b/Library/Pyramid Magazine/Pyramid 68/Elemental Druid.gct
@@ -347,7 +347,7 @@
 													"id": "maMsQNi7Y3HLYN42B",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1061,7 +1061,7 @@
 													"id": "md5Yi_i6sjs3kWhyO",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Pyramid Magazine/Pyramid 68/High Druid.gct
+++ b/Library/Pyramid Magazine/Pyramid 68/High Druid.gct
@@ -346,7 +346,7 @@
 													"id": "mArI39Dr1SAwcSa86",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -568,7 +568,7 @@
 													"id": "m1Ulc1Wvv33xuB4aS",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Pyramid Magazine/Pyramid 78/Chaos Holy Warrior.gct
+++ b/Library/Pyramid Magazine/Pyramid 78/Chaos Holy Warrior.gct
@@ -371,7 +371,7 @@
 													"id": "m_7hTkHvWTMgFi9Ym",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -593,7 +593,7 @@
 													"id": "mm75J5pXNLTaHBLH0",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Pyramid Magazine/Pyramid 78/Chaos Priest.gct
+++ b/Library/Pyramid Magazine/Pyramid 78/Chaos Priest.gct
@@ -346,7 +346,7 @@
 													"id": "mWOjf4qII4UfYktF3",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -568,7 +568,7 @@
 													"id": "mh4AYMohWuwrPHzen",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Pyramid Magazine/Pyramid 78/Order Holy Warrior.gct
+++ b/Library/Pyramid Magazine/Pyramid 78/Order Holy Warrior.gct
@@ -371,7 +371,7 @@
 													"id": "mwEDxtOiQ52KCcKTM",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -593,7 +593,7 @@
 													"id": "m8fHr94WhFTvSSl7d",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Pyramid Magazine/Pyramid 78/Order Justicar.gct
+++ b/Library/Pyramid Magazine/Pyramid 78/Order Justicar.gct
@@ -1377,7 +1377,7 @@
 													"id": "mVPHTcH9teYQe31e_",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1599,7 +1599,7 @@
 													"id": "m4pGrnWcc2TVgetbJ",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Pyramid Magazine/Pyramid 78/Order Priest.gct
+++ b/Library/Pyramid Magazine/Pyramid 78/Order Priest.gct
@@ -1004,7 +1004,7 @@
 													"id": "m9lQJcvwM6zJ2sG7Q",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{
@@ -1226,7 +1226,7 @@
 													"id": "mz3J3Mo0izk5tv6Qa",
 													"name": "Minion",
 													"reference": "B38",
-													"local_notes": "IQ 0 or Slave Mentality",
+													"local_notes": "IQ 0 or Heteronomy",
 													"disabled": true
 												},
 												{

--- a/Library/Pyramid Magazine/Pyramid 99/Dullahan.gct
+++ b/Library/Pyramid Magazine/Pyramid 99/Dullahan.gct
@@ -429,7 +429,7 @@
 							"id": "meFCu05B4vxjMRLVI",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Pyramid Magazine/Pyramid 99/Valkyrie.gct
+++ b/Library/Pyramid Magazine/Pyramid 99/Valkyrie.gct
@@ -515,7 +515,7 @@
 							"id": "ml5K7TYSN8TG-30ZW",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Reign of Steel Will to Live/Classes/Androids/Aniroid Ranger.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Androids/Aniroid Ranger.gct
@@ -160,7 +160,7 @@
 							"id": "mjwdMuLDR-7b6zL8p",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Reign of Steel Will to Live/Classes/Humans/FBI Agent.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/FBI Agent.gct
@@ -160,7 +160,7 @@
 							"id": "m3ZqBkAoVx6u072e_",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Guerilla Fighter.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Guerilla Fighter.gct
@@ -164,7 +164,7 @@
 									"id": "mJusedMgIrTBdTD7l",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Marauder.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Marauder.gct
@@ -159,7 +159,7 @@
 							"id": "mYG1GYh7IjocmxPTG",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Reign of Steel Will to Live/Classes/Humans/Preacher or Missionary.gct
+++ b/Library/Reign of Steel Will to Live/Classes/Humans/Preacher or Missionary.gct
@@ -159,7 +159,7 @@
 							"id": "myInn3LXPneSNI3QG",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Steampunk/Templates/Radical.gct
+++ b/Library/Steampunk/Templates/Radical.gct
@@ -205,7 +205,7 @@
 											"id": "m1rgyDMNPIHBe-32-",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Supers/Templates/Stage Magician with Powers.gct
+++ b/Library/Supers/Templates/Stage Magician with Powers.gct
@@ -675,7 +675,7 @@
 							"id": "mE1vjLBDtLb6w7es3",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Tales of the Solar Patrol/Classes/Explorer.gct
+++ b/Library/Tales of the Solar Patrol/Classes/Explorer.gct
@@ -451,7 +451,7 @@
 							"id": "m3GytSlcL37wqtZh1",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Tales of the Solar Patrol/Classes/Pirate.gct
+++ b/Library/Tales of the Solar Patrol/Classes/Pirate.gct
@@ -313,7 +313,7 @@
 							"id": "mCeSdPzwTyejJyUe-",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Tales of the Solar Patrol/Races and Animals/Jupiter/The Overlord of Jupiter.gcs
+++ b/Library/Tales of the Solar Patrol/Races and Animals/Jupiter/The Overlord of Jupiter.gcs
@@ -923,7 +923,7 @@
 					"id": "mA3lH6FBU6snsBlFr",
 					"name": "Minion",
 					"reference": "B38",
-					"local_notes": "IQ 0 or Slave Mentality",
+					"local_notes": "IQ 0 or Heteronomy",
 					"disabled": true
 				},
 				{

--- a/Library/Thaumatology/Thaumatology Magical Styles/Magical Style - The Onyx Path.gct
+++ b/Library/Thaumatology/Thaumatology Magical Styles/Magical Style - The Onyx Path.gct
@@ -934,7 +934,7 @@
 									"id": "mYNw3elD3413EoJti",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality"
+									"local_notes": "IQ 0 or Heteronomy"
 								},
 								{
 									"id": "MUBIxMaH2JFjBsig1",

--- a/Library/Transhuman Space/Cybershells/Puppet Implant.gct
+++ b/Library/Transhuman Space/Cybershells/Puppet Implant.gct
@@ -298,7 +298,7 @@
 							"id": "msTSvJO7y9Ju1ec9m",
 							"name": "Minion",
 							"reference": "B38",
-							"local_notes": "IQ 0 or Slave Mentality",
+							"local_notes": "IQ 0 or Heteronomy",
 							"disabled": true
 						},
 						{

--- a/Library/Traveller/Races/Sheol/Sheol - Squid Mother.gct
+++ b/Library/Traveller/Races/Sheol/Sheol - Squid Mother.gct
@@ -355,7 +355,7 @@
 									"id": "mjvsRbKZiR3qEqc3Y",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Traveller/Templates/Attorney.gct
+++ b/Library/Traveller/Templates/Attorney.gct
@@ -227,7 +227,7 @@
 											"id": "m-GAXnOSD4ex6mP6P",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Traveller/Templates/Bureaucrat.gct
+++ b/Library/Traveller/Templates/Bureaucrat.gct
@@ -330,7 +330,7 @@
 											"id": "mbMfIuHoApL_YZ-PK",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Traveller/Templates/Capitalist.gct
+++ b/Library/Traveller/Templates/Capitalist.gct
@@ -227,7 +227,7 @@
 											"id": "mm78LTrYmrMkuC8BJ",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Traveller/Templates/Dilettante.gct
+++ b/Library/Traveller/Templates/Dilettante.gct
@@ -237,7 +237,7 @@
 											"id": "m04P3GljutpperxG0",
 											"name": "Minion",
 											"reference": "B38",
-											"local_notes": "IQ 0 or Slave Mentality",
+											"local_notes": "IQ 0 or Heteronomy",
 											"disabled": true
 										},
 										{

--- a/Library/Traveller/Templates/Diplomat.gct
+++ b/Library/Traveller/Templates/Diplomat.gct
@@ -242,7 +242,7 @@
 									"id": "md4Pl3oiCAexrawGL",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Traveller/Templates/Politician.gct
+++ b/Library/Traveller/Templates/Politician.gct
@@ -275,7 +275,7 @@
 									"id": "mvQgiIm5OckuzAAAo",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Traveller/Templates/Scientist.gct
+++ b/Library/Traveller/Templates/Scientist.gct
@@ -208,7 +208,7 @@
 									"id": "magP031JICTX5KUOx",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{

--- a/Library/Vorkosigan Saga/Dendarii Mercenary.gct
+++ b/Library/Vorkosigan Saga/Dendarii Mercenary.gct
@@ -635,7 +635,7 @@
 									"id": "mbg6IXxL7q7nyWOdg",
 									"name": "Minion",
 									"reference": "B38",
-									"local_notes": "IQ 0 or Slave Mentality",
+									"local_notes": "IQ 0 or Heteronomy",
 									"disabled": true
 								},
 								{


### PR DESCRIPTION
- Added new `Heteronomy` trait from 4e Basic Set Revised (Replaces `Slave Mentality`)
- Updated `Automoton` Meta-Trait to use `Heteronomy`
- Updated `Minion` trait to mention `Heteronomy` (includes every use of the trait)