### PR TITLE
Add Defaults to Stage Combat

### DIFF
--- a/Library/Basic Set/Basic Set Skills.skl
+++ b/Library/Basic Set/Basic Set Skills.skl
@@ -23404,6 +23404,30 @@
 					"type": "skill",
 					"name": {
 						"compare": "is",
+						"qualifier": "Combat Art"
+					},
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "Combat Sport"
+					},
+					"modifier": -2
+				},
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
+						"qualifier": "[ Placeholder for actual combat skill ]"
+					},
+					"modifier": -3
+				},
+				{
+					"type": "skill",
+					"name": {
+						"compare": "is",
 						"qualifier": "Performance"
 					},
 					"modifier": -3

--- a/Library/Basic Set/Basic Set Skills.skl
+++ b/Library/Basic Set/Basic Set Skills.skl
@@ -23420,7 +23420,7 @@
 					"type": "skill",
 					"name": {
 						"compare": "is",
-						"qualifier": "[ Placeholder for actual combat skill ]"
+						"qualifier": "@Highest real combat skill@"
 					},
 					"modifier": -3
 				},


### PR DESCRIPTION
Defaults per B222: Combat Art, Combat Sport... and a non-substitution placeholder for "actual combat skill"; as filtering skills by tags is not currently supported here.

A word of justification:

`@Substitution@` would ask the user once, upfront, for a specific skill to default to; I believe that's disingenuously simple. By the rules, the skill used here should change if another one is ever improved enough. Currently that'd be a manual process. Having players misunderstand that is not great, imo.

I trust hiding the line to be changed inside the skill editor is a good test for "are you experienced enough to understand how SC's defaulting works, and to swap out the placeholder for your highest skill as your character grows"