### PR TITLE
PY65: Minor update to Natural Weapon formatting.

### DIFF
--- a/Library/Pyramid Magazine/Pyramid 65/Pyramid 65 Traits.adq
+++ b/Library/Pyramid Magazine/Pyramid 65/Pyramid 65 Traits.adq
@@ -376,7 +376,7 @@
 							"id": "mkXLewzXrCg8C9ZeI",
 							"name": "Swing-Capable",
 							"reference": "PY65:25",
-							"local_notes": "Swing \u0026 Thrust",
+							"local_notes": "Swing & Thrust",
 							"cost_adj": "+30%",
 							"disabled": true
 						},
@@ -567,13 +567,16 @@
 								"st": "thr"
 							},
 							"usage": "Thrust",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -591,13 +594,16 @@
 								"st": "sw"
 							},
 							"usage": "Swing",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -616,7 +622,7 @@
 								"st": "thr"
 							},
 							"usage": "Rangedᵗʰʳ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -625,12 +631,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -650,7 +665,7 @@
 								"st": "sw"
 							},
 							"usage": "Rangedˢʷ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -659,12 +674,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -1051,7 +1075,7 @@
 							"id": "mF12JjPDmwyZl9MvE",
 							"name": "Swing-Capable",
 							"reference": "PY65:25",
-							"local_notes": "Swing \u0026 Thrust",
+							"local_notes": "Swing & Thrust",
 							"cost_adj": "+30%",
 							"disabled": true
 						},
@@ -1242,13 +1266,16 @@
 								"st": "thr"
 							},
 							"usage": "Thrust",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -1266,13 +1293,16 @@
 								"st": "sw"
 							},
 							"usage": "Swing",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -1291,7 +1321,7 @@
 								"st": "thr"
 							},
 							"usage": "Rangedᵗʰʳ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -1300,12 +1330,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -1325,7 +1364,7 @@
 								"st": "sw"
 							},
 							"usage": "Rangedˢʷ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -1334,12 +1373,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -1726,7 +1774,7 @@
 							"id": "mC3xega9KMOe8Z6Sr",
 							"name": "Swing-Capable",
 							"reference": "PY65:25",
-							"local_notes": "Swing \u0026 Thrust",
+							"local_notes": "Swing & Thrust",
 							"cost_adj": "+30%",
 							"disabled": true
 						},
@@ -1917,13 +1965,16 @@
 								"st": "thr"
 							},
 							"usage": "Thrust",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -1941,13 +1992,16 @@
 								"st": "sw"
 							},
 							"usage": "Swing",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -1966,7 +2020,7 @@
 								"st": "thr"
 							},
 							"usage": "Rangedᵗʰʳ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -1975,12 +2029,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -2000,7 +2063,7 @@
 								"st": "sw"
 							},
 							"usage": "Rangedˢʷ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -2009,12 +2072,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -2401,7 +2473,7 @@
 							"id": "mv_KvnpqPVJotNhH0",
 							"name": "Swing-Capable",
 							"reference": "PY65:25",
-							"local_notes": "Swing \u0026 Thrust",
+							"local_notes": "Swing & Thrust",
 							"cost_adj": "+30%",
 							"disabled": true
 						},
@@ -2592,13 +2664,16 @@
 								"st": "thr"
 							},
 							"usage": "Thrust",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -2616,13 +2691,16 @@
 								"st": "sw"
 							},
 							"usage": "Swing",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -2641,7 +2719,7 @@
 								"st": "thr"
 							},
 							"usage": "Rangedᵗʰʳ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -2650,12 +2728,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -2675,7 +2762,7 @@
 								"st": "sw"
 							},
 							"usage": "Rangedˢʷ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -2684,12 +2771,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -3076,7 +3172,7 @@
 							"id": "m_Mz-nJuR3Ujsg6ef",
 							"name": "Swing-Capable",
 							"reference": "PY65:25",
-							"local_notes": "Swing \u0026 Thrust",
+							"local_notes": "Swing & Thrust",
 							"cost_adj": "+30%",
 							"disabled": true
 						},
@@ -3267,13 +3363,16 @@
 								"st": "thr"
 							},
 							"usage": "Thrust",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -3291,13 +3390,16 @@
 								"st": "sw"
 							},
 							"usage": "Swing",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -3316,7 +3418,7 @@
 								"st": "thr"
 							},
 							"usage": "Rangedᵗʰʳ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -3325,12 +3427,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -3350,7 +3461,7 @@
 								"st": "sw"
 							},
 							"usage": "Rangedˢʷ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -3359,12 +3470,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -3751,7 +3871,7 @@
 							"id": "m_AfRSIx3ls70GqVC",
 							"name": "Swing-Capable",
 							"reference": "PY65:25",
-							"local_notes": "Swing \u0026 Thrust",
+							"local_notes": "Swing & Thrust",
 							"cost_adj": "+30%",
 							"disabled": true
 						},
@@ -3942,13 +4062,16 @@
 								"st": "thr"
 							},
 							"usage": "Thrust",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -3966,13 +4089,16 @@
 								"st": "sw"
 							},
 							"usage": "Swing",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -3991,7 +4117,7 @@
 								"st": "thr"
 							},
 							"usage": "Rangedᵗʰʳ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -4000,12 +4126,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -4025,7 +4160,7 @@
 								"st": "sw"
 							},
 							"usage": "Rangedˢʷ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -4034,12 +4169,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -4426,7 +4570,7 @@
 							"id": "m1OpOE-qYwim_xdux",
 							"name": "Swing-Capable",
 							"reference": "PY65:25",
-							"local_notes": "Swing \u0026 Thrust",
+							"local_notes": "Swing & Thrust",
 							"cost_adj": "+30%",
 							"disabled": true
 						},
@@ -4617,13 +4761,16 @@
 								"st": "thr"
 							},
 							"usage": "Thrust",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -4641,13 +4788,16 @@
 								"st": "sw"
 							},
 							"usage": "Swing",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -4666,7 +4816,7 @@
 								"st": "thr"
 							},
 							"usage": "Rangedᵗʰʳ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -4675,12 +4825,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -4700,7 +4859,7 @@
 								"st": "sw"
 							},
 							"usage": "Rangedˢʷ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -4709,12 +4868,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -5101,7 +5269,7 @@
 							"id": "mpsam3TzCt6-AOGCj",
 							"name": "Swing-Capable",
 							"reference": "PY65:25",
-							"local_notes": "Swing \u0026 Thrust",
+							"local_notes": "Swing & Thrust",
 							"cost_adj": "+30%",
 							"disabled": true
 						},
@@ -5292,13 +5460,16 @@
 								"st": "thr"
 							},
 							"usage": "Thrust",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -5316,13 +5487,16 @@
 								"st": "sw"
 							},
 							"usage": "Swing",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -5341,7 +5515,7 @@
 								"st": "thr"
 							},
 							"usage": "Rangedᵗʰʳ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -5350,12 +5524,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -5375,7 +5558,7 @@
 								"st": "sw"
 							},
 							"usage": "Rangedˢʷ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -5384,12 +5567,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -5776,7 +5968,7 @@
 							"id": "mA_sl0WLNap8t0SxH",
 							"name": "Swing-Capable",
 							"reference": "PY65:25",
-							"local_notes": "Swing \u0026 Thrust",
+							"local_notes": "Swing & Thrust",
 							"cost_adj": "+30%",
 							"disabled": true
 						},
@@ -5967,13 +6159,16 @@
 								"st": "thr"
 							},
 							"usage": "Thrust",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -5991,13 +6186,16 @@
 								"st": "sw"
 							},
 							"usage": "Swing",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -6016,7 +6214,7 @@
 								"st": "thr"
 							},
 							"usage": "Rangedᵗʰʳ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -6025,12 +6223,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -6050,7 +6257,7 @@
 								"st": "sw"
 							},
 							"usage": "Rangedˢʷ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -6059,12 +6266,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -6451,7 +6667,7 @@
 							"id": "mLD3bSTv9iivYBDSd",
 							"name": "Swing-Capable",
 							"reference": "PY65:25",
-							"local_notes": "Swing \u0026 Thrust",
+							"local_notes": "Swing & Thrust",
 							"cost_adj": "+30%",
 							"disabled": true
 						},
@@ -6642,13 +6858,16 @@
 								"st": "thr"
 							},
 							"usage": "Thrust",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -6666,13 +6885,16 @@
 								"st": "sw"
 							},
 							"usage": "Swing",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -6691,7 +6913,7 @@
 								"st": "thr"
 							},
 							"usage": "Rangedᵗʰʳ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -6700,12 +6922,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -6725,7 +6956,7 @@
 								"st": "sw"
 							},
 							"usage": "Rangedˢʷ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -6734,12 +6965,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -7126,7 +7366,7 @@
 							"id": "m3loRm_lQ83Uyn3s2",
 							"name": "Swing-Capable",
 							"reference": "PY65:25",
-							"local_notes": "Swing \u0026 Thrust",
+							"local_notes": "Swing & Thrust",
 							"cost_adj": "+30%",
 							"disabled": true
 						},
@@ -7317,13 +7557,16 @@
 								"st": "thr"
 							},
 							"usage": "Thrust",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -7341,13 +7584,16 @@
 								"st": "sw"
 							},
 							"usage": "Swing",
-							"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+							"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 							"reach": "C",
 							"parry": "0",
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									}
 								},
 								{
 									"type": "dx"
@@ -7366,7 +7612,7 @@
 								"st": "thr"
 							},
 							"usage": "Rangedᵗʰʳ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -7375,12 +7621,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -7400,7 +7655,7 @@
 								"st": "sw"
 							},
 							"usage": "Rangedˢʷ",
-							"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+							"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 							"accuracy": "3",
 							"range": "x0.5/x1",
 							"rate_of_fire": "1",
@@ -7409,12 +7664,21 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Brawling",
-									"specialization": "\u003cdelete this if you took Projected\u003e"
+									"name": {
+										"compare": "is",
+										"qualifier": "Brawling"
+									},
+									"specialization": {
+										"compare": "is",
+										"qualifier": "<delete this if you took Projected>"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Innate Attack"
+									"name": {
+										"compare": "is",
+										"qualifier": "Innate Attack"
+									}
 								},
 								{
 									"type": "dx",
@@ -7554,13 +7818,16 @@
 										"st": "thr"
 									},
 									"usage": "Melee",
-									"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+									"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 									"reach": "C",
 									"parry": "0",
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
 										},
 										{
 											"type": "dx"
@@ -7578,7 +7845,7 @@
 										"st": "thr"
 									},
 									"usage": "Ranged",
-									"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+									"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 									"accuracy": "3",
 									"range": "x0.5/x1",
 									"rate_of_fire": "1",
@@ -7588,7 +7855,10 @@
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Innate Attack"
+											"name": {
+												"compare": "is",
+												"qualifier": "Innate Attack"
+											}
 										},
 										{
 											"type": "dx",
@@ -7736,13 +8006,16 @@
 										"st": "thr"
 									},
 									"usage": "Melee",
-									"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+									"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 									"reach": "C",
 									"parry": "0",
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
 										},
 										{
 											"type": "dx"
@@ -7760,7 +8033,7 @@
 										"st": "thr"
 									},
 									"usage": "Ranged",
-									"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+									"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 									"accuracy": "3",
 									"range": "x0.5/x1",
 									"rate_of_fire": "1",
@@ -7769,7 +8042,10 @@
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Innate Attack"
+											"name": {
+												"compare": "is",
+												"qualifier": "Innate Attack"
+											}
 										},
 										{
 											"type": "dx",
@@ -7852,13 +8128,16 @@
 										"type": "cor",
 										"st": "thr"
 									},
-									"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+									"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 									"reach": "C",
 									"parry": "0",
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
 										},
 										{
 											"type": "dx"
@@ -7966,13 +8245,16 @@
 										"st": "sw"
 									},
 									"usage": "Melee",
-									"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+									"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 									"reach": "C",
 									"parry": "0",
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
 										},
 										{
 											"type": "dx"
@@ -7990,7 +8272,7 @@
 										"st": "sw"
 									},
 									"usage": "Ranged",
-									"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+									"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 									"accuracy": "3",
 									"range": "x0.5/x1",
 									"rate_of_fire": "1",
@@ -8000,12 +8282,21 @@
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling",
-											"specialization": "\u003cdelete this if you took Projected\u003e"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "<delete this if you took Projected>"
+											}
 										},
 										{
 											"type": "skill",
-											"name": "Innate Attack"
+											"name": {
+												"compare": "is",
+												"qualifier": "Innate Attack"
+											}
 										},
 										{
 											"type": "dx",
@@ -8108,13 +8399,16 @@
 										"st": "thr"
 									},
 									"usage": "Slow",
-									"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+									"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 									"reach": "C",
 									"parry": "0",
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
 										},
 										{
 											"type": "dx"
@@ -8132,13 +8426,16 @@
 										"st": "thr"
 									},
 									"usage": "Quick",
-									"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+									"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 									"reach": "C",
 									"parry": "0",
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
 										},
 										{
 											"type": "dx"
@@ -8281,13 +8578,16 @@
 										"type": "cr",
 										"st": "sw"
 									},
-									"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+									"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 									"reach": "C",
 									"parry": "0",
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
 										},
 										{
 											"type": "dx"
@@ -8493,13 +8793,16 @@
 										"type": "burn sur",
 										"st": "sw"
 									},
-									"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+									"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 									"reach": "C",
 									"parry": "0",
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
 										},
 										{
 											"type": "dx"
@@ -8594,13 +8897,16 @@
 										"st": "thr"
 									},
 									"usage": "Gore",
-									"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+									"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 									"reach": "C",
 									"parry": "0",
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
 										},
 										{
 											"type": "dx"
@@ -8714,13 +9020,16 @@
 										"type": "fat",
 										"st": "thr"
 									},
-									"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+									"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 									"reach": "C",
 									"parry": "0",
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
 										},
 										{
 											"type": "dx"
@@ -8861,13 +9170,16 @@
 										"st": "sw"
 									},
 									"usage": "Melee",
-									"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+									"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 									"reach": "C",
 									"parry": "0",
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
 										},
 										{
 											"type": "dx"
@@ -8885,7 +9197,7 @@
 										"st": "sw"
 									},
 									"usage": "Ranged",
-									"usage_notes": "Effective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.",
+									"usage_notes": "Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))</script> lb.",
 									"accuracy": "3",
 									"range": "x0.5/x1",
 									"rate_of_fire": "1",
@@ -8894,11 +9206,17 @@
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
 										},
 										{
 											"type": "skill",
-											"name": "Innate Attack"
+											"name": {
+												"compare": "is",
+												"qualifier": "Innate Attack"
+											}
 										},
 										{
 											"type": "dx",
@@ -9021,13 +9339,16 @@
 										"st": "thr"
 									},
 									"usage": "Thrust",
-									"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+									"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 									"reach": "C",
 									"parry": "0",
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
 										},
 										{
 											"type": "dx"
@@ -9045,13 +9366,16 @@
 										"st": "sw"
 									},
 									"usage": "Swing",
-									"usage_notes": "\u003cscript\u003eself.attachedTo.activeModifiers.filter((obj) =\u003e obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\u003c/script\u003e\nEffective Wt.\n\u003cscript\u003efunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\u003c/script\u003e.\n\u003cscript\u003eself.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"\u003c/script\u003e",
+									"usage_notes": "<script>self.attachedTo.activeModifiers.filter((obj) => obj.tags.includes(\"Quality\")).pop()?.notes.concat(\".\") || \"\"\n</script> Effective weight <script>\nfunction lvl(trait) {return (self.attachedTo.findActiveModifier(trait)?.level/10 || 0)}; \n($st/10)*(1+lvl(\"Heavy\")-lvl(\"Light\"))\n</script> lb.\n<script>self.attachedTo.findActiveModifier(\"Flexible\")?.notes.concat(\".\") || \"\"</script>",
 									"reach": "C",
 									"parry": "0",
 									"defaults": [
 										{
 											"type": "skill",
-											"name": "Brawling"
+											"name": {
+												"compare": "is",
+												"qualifier": "Brawling"
+											}
 										},
 										{
 											"type": "dx"


### PR DESCRIPTION
At some point between #485 and now, handling of line breaks in notes fields changed.

- Fixed spontaneous line breaks between:
  - the word "weight" and the weight value;
  - weapon quality and the weight line.
- While I'm down here... (There was extra space, so why not?)
  - Expanded "Wt." to the full word "weight"
  - Added "lb." unit.

Also 20 or so lines of automatic non-visible changes by GCS. Fun.

Screenshot of changes:
<img width="363" height="282" alt="image" src="https://github.com/user-attachments/assets/cbaeefd6-bf8f-4e49-9827-237959f27c28" />