### PR TITLE
Basic: Implemented Frequency of Appearance system from v5.41

### DIFF
--- a/Library/Basic Set/Basic Set Traits.adq
+++ b/Library/Basic Set/Basic Set Traits.adq
@@ -1713,48 +1713,6 @@
 					]
 				},
 				{
-					"id": "MRrRjoHLw87w71H83",
-					"name": "Frequency of Appearance",
-					"reference": "B37",
-					"children": [
-						{
-							"id": "madigFjYNvmTkDfKC",
-							"name": "Appears quite rarely (6-)",
-							"reference": "B36",
-							"cost_adj": "x0.5",
-							"disabled": true
-						},
-						{
-							"id": "mbQPnNWN2WvMH7bCl",
-							"name": "Appears fairly often (9-)",
-							"reference": "B36",
-							"cost_adj": "x1",
-							"disabled": true
-						},
-						{
-							"id": "m81E5PCSZ8yi2osUJ",
-							"name": "Appears quite often (12-)",
-							"reference": "B36",
-							"cost_adj": "x2",
-							"disabled": true
-						},
-						{
-							"id": "mGGMJGnxLvqbHmLjX",
-							"name": "Appears almost all the time (15-)",
-							"reference": "B36",
-							"cost_adj": "x3",
-							"disabled": true
-						},
-						{
-							"id": "mfDcsFyAJVRIys3_x",
-							"name": "Appears constantly",
-							"reference": "B36",
-							"cost_adj": "x4",
-							"disabled": true
-						}
-					]
-				},
-				{
 					"id": "mVzdHYM_kPEXr0ON7",
 					"name": "Minion",
 					"reference": "B38",
@@ -1871,6 +1829,7 @@
 					"disabled": true
 				}
 			],
+			"frequency": 9,
 			"calc": {
 				"points": 0
 			}
@@ -5238,48 +5197,6 @@
 					]
 				},
 				{
-					"id": "MwV7dfV_hDV9XQgl7",
-					"name": "Frequency of Appearance",
-					"children": [
-						{
-							"id": "mjWhsKejGYnoCUrf3",
-							"name": "Appears quite rarely",
-							"reference": "B36",
-							"reference_highlight": "Frequency of Appearance",
-							"local_notes": "6-",
-							"cost_adj": "x0.5",
-							"disabled": true
-						},
-						{
-							"id": "mzUYek2sNYafWOURZ",
-							"name": "Appears fairly often",
-							"reference": "B36",
-							"reference_highlight": "Frequency of Appearance",
-							"local_notes": "9-",
-							"cost_adj": "x1",
-							"disabled": true
-						},
-						{
-							"id": "mOyhsphtnkOWc3Sis",
-							"name": "Appears quite often",
-							"reference": "B36",
-							"reference_highlight": "Frequency of Appearance",
-							"local_notes": "12-",
-							"cost_adj": "x2",
-							"disabled": true
-						},
-						{
-							"id": "mOCL6qg1BYO3O1en3",
-							"name": "Appears almost all the time",
-							"reference": "B36",
-							"reference_highlight": "Frequency of Appearance",
-							"local_notes": "15-",
-							"cost_adj": "x3",
-							"disabled": true
-						}
-					]
-				},
-				{
 					"id": "MJreCiI-WxLQwDkxP",
 					"name": "Reliability",
 					"children": [
@@ -5328,6 +5245,7 @@
 					"disabled": true
 				}
 			],
+			"frequency": 9,
 			"calc": {
 				"points": 0
 			}
@@ -6942,44 +6860,6 @@
 					]
 				},
 				{
-					"id": "MxT6Har4nLjV_1Ork",
-					"name": "Frequency of Appearance",
-					"children": [
-						{
-							"id": "mpsbRoNl12zVOoa-I",
-							"name": "Appears quite rarely",
-							"reference": "B36",
-							"local_notes": "6-",
-							"cost_adj": "x0.5",
-							"disabled": true
-						},
-						{
-							"id": "mlXoKswOhZbxuwvK8",
-							"name": "Appears fairly often",
-							"reference": "B36",
-							"local_notes": "9-",
-							"cost_adj": "x1",
-							"disabled": true
-						},
-						{
-							"id": "moMKwUAPfELXesi-5",
-							"name": "Appears quite often",
-							"reference": "B36",
-							"local_notes": "12-",
-							"cost_adj": "x2",
-							"disabled": true
-						},
-						{
-							"id": "mvv9VZ5qY_hXgz58S",
-							"name": "Appears almost all the time",
-							"reference": "B36",
-							"local_notes": "15-",
-							"cost_adj": "x3",
-							"disabled": true
-						}
-					]
-				},
-				{
 					"id": "mCe6pU7XMOjr45QKq",
 					"name": "Group",
 					"reference": "B131",
@@ -6987,6 +6867,7 @@
 					"disabled": true
 				}
 			],
+			"frequency": 9,
 			"calc": {
 				"points": 0
 			}
@@ -8338,46 +8219,9 @@
 							"disabled": true
 						}
 					]
-				},
-				{
-					"id": "MMqU1hSLGjuouNY42",
-					"name": "Frequency of Appearance",
-					"children": [
-						{
-							"id": "mK05ZLdZeX4fjc7_y",
-							"name": "Appears quite rarely",
-							"reference": "B36",
-							"local_notes": "6-",
-							"cost_adj": "x0.5",
-							"disabled": true
-						},
-						{
-							"id": "mDmFOcAvOHA_34J4o",
-							"name": "Appears fairly often",
-							"reference": "B36",
-							"local_notes": "9-",
-							"cost_adj": "x1",
-							"disabled": true
-						},
-						{
-							"id": "moGIZ2LAqFeADib-4",
-							"name": "Appears quite often",
-							"reference": "B36",
-							"local_notes": "12-",
-							"cost_adj": "x2",
-							"disabled": true
-						},
-						{
-							"id": "mSQSe0Q5hBEvdko4J",
-							"name": "Appears almost all the time",
-							"reference": "B36",
-							"local_notes": "15-",
-							"cost_adj": "x3",
-							"disabled": true
-						}
-					]
 				}
 			],
+			"frequency": 9,
 			"calc": {
 				"points": 0
 			}
@@ -24532,44 +24376,6 @@
 					]
 				},
 				{
-					"id": "MGLNAdpFy9ctMywFi",
-					"name": "Frequency of Appearance",
-					"children": [
-						{
-							"id": "mZxqi4X0ICPREzdK_",
-							"name": "Appears quite rarely",
-							"reference": "B36",
-							"local_notes": "6-",
-							"cost_adj": "x0.5",
-							"disabled": true
-						},
-						{
-							"id": "mFq4QVMocJ4PXdFU2",
-							"name": "Appears fairly often",
-							"reference": "B36",
-							"local_notes": "9-",
-							"cost_adj": "x1",
-							"disabled": true
-						},
-						{
-							"id": "muMC0hhEQnSd7AqNN",
-							"name": "Appears quite often",
-							"reference": "B36",
-							"local_notes": "12-",
-							"cost_adj": "x2",
-							"disabled": true
-						},
-						{
-							"id": "m3ozVVsAKM1oBWRmd",
-							"name": "Appears almost all the time",
-							"reference": "B36",
-							"local_notes": "15-",
-							"cost_adj": "x3",
-							"disabled": true
-						}
-					]
-				},
-				{
 					"id": "mnv8XKe5NxlEXdF-d",
 					"name": "Equipment",
 					"reference": "B73",
@@ -24637,6 +24443,7 @@
 					"disabled": true
 				}
 			],
+			"frequency": 9,
 			"calc": {
 				"points": 0
 			}


### PR DESCRIPTION
Removed Frequency modifiers and changed the Frequency of Appearance dropdown from `None Required` to `9 or less (Fairly often)`, for ×1 cost. Affects the following traits:
- Ally
- Patron
- Contact
- Dependent
- Enemy

Which, unless I missed something, is every trait that uses FoA in the Basic Set.