### PR TITLE
Adding documentation for new substitution features

### DIFF
--- a/Library/Markdown/User Guide/Character Templates.md
+++ b/Library/Markdown/User Guide/Character Templates.md
@@ -66,7 +66,7 @@ These practices help enforce rules without overwhelming players with confusing e
 
 ## Substitutions
 
-Templates can also include **substitution** using the **`@<comment>@`** format.
+Templates can also include [substitution **placeholders**](Substitutions) using the **`@Label@`** format.
 
 - When the template is applied, the comment becomes a prompt.
 - The answer replaces the placeholder wherever it appears (commonly in fields like skill specialization).

--- a/Library/Markdown/User Guide/Substitutions.md
+++ b/Library/Markdown/User Guide/Substitutions.md
@@ -1,0 +1,32 @@
+# Substitutions
+
+Substitutions can be used in most text fields in GCS.
+In their simplest form they are a simple `@Label@` **placeholder** in a text field.
+When viewing an item that has placeholders, a ![substitutions](images/icons/icn-substitutions.svg) toolbar icon becomes active.
+Clicking this icon triggers the substitutions process described below. The other way the substitutions process is triggered is when an item is copied to a template/sheet or when a template is applied to a sheet.
+
+## Applying Substitutions
+
+When an item with substitution placeholders is applied or copied it generally triggers the substitution process.
+This causes the placeholder to be converted into a Label and an Editable Combobox on a popup dialog box. If an item has multiple placeholders, they will all appear on the same dialog. This Editable Combobox may allow free-form text input and will have a drop-down triggered by the small downward arrow on the right side of the field. This list may have an option named `«not set»` that can be used to skip setting a value for the placeholder. It may also have an option for `«empty»` to specifically set the placeholder value to an empty string.
+
+## Partially Configured Substitutions
+
+When editing a template you can mark items with the `Preconfigured` flag. This is an indicator to the template application process that the selections and substitutions made for this item of the template should be skipped when applying the template. This streamlines the template application process. When an item has substitution placeholders that don't have provided replacement values, the template application process will ask you to complete those missing substitutions.
+
+## Creating Substitution Placeholders
+
+A substitution placeholder can come in a variety of formats.
+
+Older library data exclusively used the simplest form of a placeholder that only specifies a _label_ (`@Label Name@`). The placeholder parsing will attempt to turn this into a label and options in a very narrow set of cases. Barring that it will attempt to turn an older placeholder into a label and a tooltip if possible. Otherwise the entire text is treated as the label.
+
+Newer placeholders can provide a **label**, **tooltips** (`tt(text here)`), **options**, a **free-form** (`*`) flag, and an **allow-empty** (`?`) flag. Here are some examples:
+
+- @Label|*@ - Just free-form text, empty not allowed
+- @Label|*|?@ - Free form text and empty are both valid
+- @Label|One|Two@ - Mandatory selection of "One" or "Two"
+- @Label|One|Two|?@ - Mandatory selection of "One" or "Two" or the «empty» option
+- @Label|One|Two|?|*@ - Selection of "One" or "Two" or the «empty» option, or free-form text
+- @Label|tt(This is a tooltip)|One|Two|?@ - Includes a tooltip
+
+The **label** is always the text before the first `|` character. The rest of the text is split on further `|` characters. If you need to use `|` anywhere in your placeholder, you can use an escaped version (`\|`). With 3 exceptions, each of the parts after the label is an options that will be presented in the combobox drop-down. The exceptions are the two flags and tooltips. Each flag is a single character. The **allow-empty** flag is `?` and can be anywhere in the options. The **free-form** flag is `*` and can be anywhere in the options. Tooltips are in the format of `tt(tooltip text is here)` and can appear anywhere in the options. That tooltip entry would show the text "tooltip text is here" when you hover over the label on the substitutions dialog form.

--- a/Library/Markdown/User Guide/Trait Modifiers.md
+++ b/Library/Markdown/User Guide/Trait Modifiers.md
@@ -54,7 +54,7 @@ You can manage modifiers directly in the Trait Detail Editor:
 - **Delete:** Select the modifier and choose **Delete** ![delete](images/icons/icn-delete.svg).
 
 > [!TIP]
-> Some modifiers include **placeholders** (for example, `@condition@`). You can set these when first adding the
+> Some modifiers include [substitution **placeholders**](Substitutions) (for example, `@Condition@`). You can set these when first adding the
 > modifier, or later with **Set Substitutions** ![substitutions](images/icons/icn-substitutions.svg) in the toolbar.
 
 ## Editing trait modifiers

--- a/Library/Markdown/User Guide/Traits.md
+++ b/Library/Markdown/User Guide/Traits.md
@@ -49,9 +49,7 @@ When you add a trait:
 - The **Points block** updates automatically:
   - Advantages subtract from unspent points.
   - Disadvantages (negative points) add to unspent points.
-- Some traits include **substitutions** (for example, `@details@`). You can set these when first adding the trait, or
-  later with **Set Substitutions** ![substitutions](images/icons/icn-substitutions.svg) in the toolbar or by editing the
-  notes directly in the **Trait Editor**.
+- Some traits include [substitution **placeholders**](Substitutions) (for example, `@details@`). You can set these when first adding the trait, or later with **Set Substitutions** ![substitutions](images/icons/icn-substitutions.svg) in the toolbar or by editing the notes directly in the **Trait Editor**.
 - Some traits support multiple **modifiers**. When you first add a trait that has modifiers, GCS prompts you to select
   them. You can select one, several, or none. If you skip this step, you can add or edit modifiers later in the **Trait
   Detail Editor**. See [Trait Modifiers](Trait%20Modifiers) for more details.


### PR DESCRIPTION
The new substitution placeholder features need a little documentation. I added a dedicated page and adjusted the locations I found talking about substitutions to point to the new page.

This depends on the new feature being merged (https://github.com/richardwilkes/gcs/pull/1113)