### PR TITLE
Low-Tech: Minor polish for Firearms

### DIFF
--- a/Library/Low Tech/Low Tech Equipment.eqp
+++ b/Library/Low Tech/Low Tech Equipment.eqp
@@ -150,12 +150,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -236,25 +245,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -266,12 +299,12 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block when used in a shield wall",
+					"situation": "to Dodge, Parry & Block when used in a shield wall",
 					"amount": 1
 				},
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 2
 				}
 			],
@@ -287,6 +320,7 @@
 			"id": "eUstq-45wBk7_FmeT",
 			"description": "Arquebus",
 			"reference": "LT92",
+			"local_notes": ".60 caliber matchlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -309,6 +343,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-6",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -316,12 +351,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Musket"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -481,12 +525,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear Thrower"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear Thrower"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						}
 					],
@@ -516,12 +569,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear Thrower"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear Thrower"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						}
 					],
@@ -586,16 +648,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -622,21 +693,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -681,7 +764,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -707,36 +793,57 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Sword!"
+							"name": {
+								"compare": "is",
+								"qualifier": "Sword!"
+							}
 						}
 					],
 					"calc": {
@@ -762,36 +869,57 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Sword!"
+							"name": {
+								"compare": "is",
+								"qualifier": "Sword!"
+							}
 						}
 					],
 					"calc": {
@@ -865,21 +993,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -906,21 +1046,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -1006,7 +1158,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -1091,7 +1246,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -1176,7 +1334,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -1261,7 +1422,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -1330,12 +1494,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -1423,12 +1596,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -1516,12 +1698,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -1609,12 +1800,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -1641,12 +1841,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -1734,12 +1943,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -1766,12 +1984,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -1859,12 +2086,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -1891,12 +2127,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -2000,12 +2245,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -2093,12 +2347,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -2125,12 +2388,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -2218,12 +2490,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -2250,12 +2531,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -2408,31 +2698,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -2459,31 +2767,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -2510,16 +2836,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -2546,16 +2881,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -2637,41 +2981,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -2697,41 +3065,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -2856,8 +3248,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						}
 					],
 					"calc": {
@@ -2926,8 +3324,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						}
 					],
 					"calc": {
@@ -2996,8 +3400,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						}
 					],
 					"calc": {
@@ -3066,8 +3476,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						}
 					],
 					"calc": {
@@ -3136,8 +3552,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						}
 					],
 					"calc": {
@@ -3188,8 +3610,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						}
 					],
 					"calc": {
@@ -3271,21 +3699,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -3312,21 +3752,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -3354,21 +3806,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -3414,7 +3878,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -3460,7 +3927,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -3543,7 +4013,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Blowpipe"
+							"name": {
+								"compare": "is",
+								"qualifier": "Blowpipe"
+							}
 						}
 					],
 					"calc": {
@@ -3582,6 +4055,7 @@
 			"id": "eWrPImwlzokA72wRG",
 			"description": "Blunderbuss",
 			"reference": "LT92",
+			"local_notes": ".62 caliber flintlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -3601,8 +4075,10 @@
 					"usage": "Shoot",
 					"accuracy": "2",
 					"range": "45/810",
+					"rate_of_fire": "1x7",
 					"shots": "1(40)",
 					"bulk": "-6",
+					"recoil": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -3610,12 +4086,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Shotgun"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shotgun"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -3738,31 +4223,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -3789,31 +4292,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -3840,16 +4361,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -3876,16 +4406,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -3932,16 +4471,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Flail"
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -3
 						}
 					],
@@ -3965,11 +4513,17 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Bolas"
+							"name": {
+								"compare": "is",
+								"qualifier": "Bolas"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Sling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Sling"
+							}
 						},
 						{
 							"type": "dx",
@@ -4020,16 +4574,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Flail"
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -3
 						}
 					],
@@ -4054,7 +4617,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Bolas"
+							"name": {
+								"compare": "is",
+								"qualifier": "Bolas"
+							}
 						}
 					],
 					"calc": {
@@ -4096,6 +4662,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-12",
+					"recoil": "5",
 					"defaults": [
 						{
 							"type": "iq",
@@ -4103,8 +4670,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -4160,6 +4733,7 @@
 			"id": "e6WpgdLqh299llIej",
 			"description": "Bombard, Large",
 			"reference": "LT87",
+			"reference_highlight": "Bombard",
 			"tech_level": "3",
 			"legality_class": "2",
 			"tags": [
@@ -4182,6 +4756,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-16",
+					"recoil": "5",
 					"defaults": [
 						{
 							"type": "iq",
@@ -4189,8 +4764,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -4256,8 +4837,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Stick"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Stick"
+							}
 						}
 					],
 					"calc": {
@@ -4393,15 +4980,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -4439,6 +5035,7 @@
 			"id": "eJ9fllNnD0219w6js",
 			"description": "Breechloading Carbine",
 			"reference": "LT94",
+			"local_notes": ".54 caliber wheellock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -4461,6 +5058,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(10)",
 					"bulk": "-5",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -4468,12 +5066,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Rifle"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Rifle"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -4574,31 +5181,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -4625,31 +5250,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -4799,6 +5442,7 @@
 			"id": "ePh8_14rCd7DrMUhP",
 			"description": "Caliver",
 			"reference": "LT92",
+			"local_notes": ".59 caliber matchlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -4821,6 +5465,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-5",
+					"recoil": "4",
 					"defaults": [
 						{
 							"type": "dx",
@@ -4828,12 +5473,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Musket"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -4951,6 +5605,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(100)",
 					"bulk": "-16",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -4958,13 +5613,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -5025,6 +5689,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-13",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -5032,13 +5697,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -5117,6 +5791,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-15",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -5124,13 +5799,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -5209,6 +5893,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(70)",
 					"bulk": "-16",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -5216,13 +5901,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -5296,6 +5990,7 @@
 			"id": "eDwly9qJ7ondSbli6",
 			"description": "Carbine",
 			"reference": "LT92",
+			"local_notes": ".69 caliber wheellock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -5318,6 +6013,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(40)",
 					"bulk": "-4",
+					"recoil": "4",
 					"defaults": [
 						{
 							"type": "dx",
@@ -5325,12 +6021,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Musket"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -5437,12 +6142,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -5625,31 +6339,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -5675,31 +6407,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -5744,15 +6494,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -5808,21 +6567,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Kusari"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -5870,21 +6641,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Kusari"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -5932,21 +6715,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Kusari"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -5994,21 +6789,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Kusari"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -6112,12 +6919,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Disc"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Disc"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Throwing",
+							"name": {
+								"compare": "is",
+								"qualifier": "Throwing"
+							},
 							"modifier": -2
 						}
 					],
@@ -6184,7 +7000,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -6234,13 +7053,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Liquid Projector",
+							"name": {
+								"compare": "is",
+								"qualifier": "Liquid Projector"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Liquid Projector",
-							"specialization": "Flamethrower"
+							"name": {
+								"compare": "is",
+								"qualifier": "Liquid Projector"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Flamethrower"
+							}
 						}
 					],
 					"calc": {
@@ -6345,17 +7173,26 @@
 						},
 						{
 							"type": "skill",
-							"name": "Net",
+							"name": {
+								"compare": "is",
+								"qualifier": "Net"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Cloak"
+							"name": {
+								"compare": "is",
+								"qualifier": "Cloak"
+							}
 						}
 					],
 					"calc": {
@@ -6403,17 +7240,26 @@
 						},
 						{
 							"type": "skill",
-							"name": "Net",
+							"name": {
+								"compare": "is",
+								"qualifier": "Net"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Cloak"
+							"name": {
+								"compare": "is",
+								"qualifier": "Cloak"
+							}
 						}
 					],
 					"calc": {
@@ -6461,17 +7307,26 @@
 						},
 						{
 							"type": "skill",
-							"name": "Net",
+							"name": {
+								"compare": "is",
+								"qualifier": "Net"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Cloak"
+							"name": {
+								"compare": "is",
+								"qualifier": "Cloak"
+							}
 						}
 					],
 					"calc": {
@@ -6519,17 +7374,26 @@
 						},
 						{
 							"type": "skill",
-							"name": "Net",
+							"name": {
+								"compare": "is",
+								"qualifier": "Net"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Cloak"
+							"name": {
+								"compare": "is",
+								"qualifier": "Cloak"
+							}
 						}
 					],
 					"calc": {
@@ -6577,17 +7441,26 @@
 						},
 						{
 							"type": "skill",
-							"name": "Net",
+							"name": {
+								"compare": "is",
+								"qualifier": "Net"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Cloak"
+							"name": {
+								"compare": "is",
+								"qualifier": "Cloak"
+							}
 						}
 					],
 					"calc": {
@@ -6635,17 +7508,26 @@
 						},
 						{
 							"type": "skill",
-							"name": "Net",
+							"name": {
+								"compare": "is",
+								"qualifier": "Net"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Cloak"
+							"name": {
+								"compare": "is",
+								"qualifier": "Cloak"
+							}
 						}
 					],
 					"calc": {
@@ -7451,25 +8333,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -7481,7 +8387,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 2
 				}
 			],
@@ -7540,7 +8446,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -7635,7 +8544,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -8306,6 +9218,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-8",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "iq",
@@ -8313,8 +9226,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -8403,7 +9322,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -8439,12 +9361,13 @@
 						"base": "6d+2"
 					},
 					"strength": "16M†",
-					"usage": "Shoot Stone Ball",
+					"usage": "Stone Ball",
 					"accuracy": "2",
 					"range": "60/550",
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-8",
+					"recoil": "5",
 					"defaults": [
 						{
 							"type": "iq",
@@ -8452,8 +9375,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -8468,11 +9397,13 @@
 						"base": "1d-1"
 					},
 					"strength": "19M†",
-					"usage": "Shoot Lead Shot",
+					"usage": "Lead Shot",
 					"accuracy": "1",
 					"range": "130/1,200",
 					"rate_of_fire": "1x100",
 					"shots": "1(60)",
+					"bulk": "-8",
+					"recoil": "1/5",
 					"defaults": [
 						{
 							"type": "iq",
@@ -8480,8 +9411,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -8565,21 +9502,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						}
 					],
@@ -8606,17 +9555,26 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -8714,6 +9672,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(70)",
 					"bulk": "-15",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -8721,13 +9680,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -8826,41 +9794,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa"
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							}
 						}
 					],
 					"calc": {
@@ -8886,41 +9878,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -8944,7 +9960,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -9055,21 +10074,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -9098,8 +10129,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						}
 					],
 					"calc": {
@@ -9145,31 +10182,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -9195,31 +10250,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -9270,7 +10343,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Sling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Sling"
+							}
 						}
 					],
 					"calc": {
@@ -9375,21 +10451,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -9416,31 +10504,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche"
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -9592,12 +10698,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Disc"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Disc"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Throwing",
+							"name": {
+								"compare": "is",
+								"qualifier": "Throwing"
+							},
 							"modifier": -2
 						}
 					],
@@ -9800,7 +10915,7 @@
 		},
 		{
 			"id": "ekt9QLYR7ywXpcCGl",
-			"description": "Dragon Pistol, Heavy Bullet",
+			"description": "Dragoon Pistol, Heavy Bullet",
 			"reference": "LT94",
 			"tech_level": "4",
 			"tags": [
@@ -9818,7 +10933,7 @@
 		},
 		{
 			"id": "ee5aFS8NYxDUkZPNi",
-			"description": "Dragon Pistol, Light Bullet",
+			"description": "Dragoon Pistol, Light Bullet",
 			"reference": "LT94",
 			"tech_level": "4",
 			"tags": [
@@ -9838,6 +10953,7 @@
 			"id": "eAuqzoGL1Fp0OxFeu",
 			"description": "Dragoon Pistol, Heavy",
 			"reference": "LT93",
+			"local_notes": ".65 caliber flintlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -9860,6 +10976,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(20)",
 					"bulk": "-4",
+					"recoil": "3",
 					"defaults": [
 						{
 							"type": "dx",
@@ -9867,12 +10984,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Pistol"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -9893,6 +11019,7 @@
 			"id": "e-QkIPkcPJEgVnWtA",
 			"description": "Dragoon Pistol, Light",
 			"reference": "LT93",
+			"local_notes": ".56 caliber flintlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -9915,6 +11042,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(20)",
 					"bulk": "-4",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -9922,12 +11050,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Pistol"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -9973,26 +11110,41 @@
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -4
 						}
 					],
@@ -10031,6 +11183,7 @@
 			"id": "eeoIt6AJrsf9pxzmy",
 			"description": "Duck’s Foot Pistol",
 			"reference": "LT93",
+			"local_notes": ".40 caliber flintlock. ",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -10050,8 +11203,10 @@
 					"usage": "Shoot",
 					"accuracy": "1",
 					"range": "40/420",
+					"rate_of_fire": "1x4/4",
 					"shots": "1(20i)",
 					"bulk": "-3",
+					"recoil": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -10059,12 +11214,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Pistol"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -10111,21 +11275,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -10152,21 +11328,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -10193,21 +11381,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -10253,25 +11453,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -10318,21 +11542,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -10359,21 +11595,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -10420,21 +11668,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -10461,21 +11721,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -10502,21 +11774,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -10557,12 +11841,18 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						}
 					],
@@ -10574,7 +11864,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 3
 				}
 			],
@@ -10633,41 +11923,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -10693,41 +12007,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -11253,26 +12591,41 @@
 						},
 						{
 							"type": "skill",
-							"name": "Rapier"
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -11299,26 +12652,41 @@
 						},
 						{
 							"type": "skill",
-							"name": "Rapier"
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -11407,13 +12775,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Liquid Projector",
+							"name": {
+								"compare": "is",
+								"qualifier": "Liquid Projector"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Liquid Projector",
-							"specialization": "Flamethrower"
+							"name": {
+								"compare": "is",
+								"qualifier": "Liquid Projector"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Flamethrower"
+							}
 						}
 					],
 					"calc": {
@@ -11460,31 +12837,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -11511,31 +12906,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -11652,41 +13065,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -11713,41 +13150,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -11790,6 +13251,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-12",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -11797,13 +13259,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -11881,6 +13352,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-10",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -11888,13 +13360,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -12248,13 +13729,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Liquid Projector",
+							"name": {
+								"compare": "is",
+								"qualifier": "Liquid Projector"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Liquid Projector",
-							"specialization": "Flamethrower"
+							"name": {
+								"compare": "is",
+								"qualifier": "Liquid Projector"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Flamethrower"
+							}
 						}
 					],
 					"calc": {
@@ -12304,13 +13794,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Liquid Projector",
+							"name": {
+								"compare": "is",
+								"qualifier": "Liquid Projector"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Liquid Projector",
-							"specialization": "Flamethrower"
+							"name": {
+								"compare": "is",
+								"qualifier": "Liquid Projector"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Flamethrower"
+							}
 						}
 					],
 					"calc": {
@@ -12393,21 +13892,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -12466,6 +13977,7 @@
 			"id": "eqm-l8KNxjOGPkr2y",
 			"description": "Flintlock Carbine",
 			"reference": "LT92",
+			"local_notes": ".62 caliber",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -12487,7 +13999,8 @@
 					"range": "65/670",
 					"rate_of_fire": "1",
 					"shots": "1(40)",
-					"bulk": "-4",
+					"bulk": "-4*",
+					"recoil": "4",
 					"defaults": [
 						{
 							"type": "dx",
@@ -12495,12 +14008,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Musket"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -12746,7 +14268,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -12784,6 +14309,7 @@
 			"id": "e9FqkRToOywT7jj5F",
 			"description": "Fowling Piece, Double",
 			"reference": "LT92",
+			"local_notes": "12 gauge flintlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -12804,8 +14330,10 @@
 					"usage": "Shoot",
 					"accuracy": "2",
 					"range": "15/330",
+					"rate_of_fire": "1x175",
 					"shots": "2(40i)",
 					"bulk": "-8",
+					"recoil": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -12813,12 +14341,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Shotgun"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shotgun"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -12839,6 +14376,7 @@
 			"id": "eeJsYOXLUOfaJPTWK",
 			"description": "Fowling Piece, Single",
 			"reference": "LT92",
+			"local_notes": "12 gauge flintlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -12859,8 +14397,10 @@
 					"usage": "Shoot",
 					"accuracy": "2",
 					"range": "15/330",
+					"rate_of_fire": "1x175",
 					"shots": "1(40)",
 					"bulk": "-7",
+					"recoil": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -12868,12 +14408,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Shotgun"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shotgun"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -12894,6 +14443,7 @@
 			"id": "eP4YOxuKnf5Y3AIuA",
 			"description": "Fusil de Chasse",
 			"reference": "LT92",
+			"local_notes": ".55 caliber flintlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -12916,6 +14466,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(40)",
 					"bulk": "-5",
+					"recoil": "3",
 					"defaults": [
 						{
 							"type": "dx",
@@ -12923,12 +14474,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Musket"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -12967,6 +14527,7 @@
 			"id": "eObrfS7vuahB9FW9i",
 			"description": "Fusil Ordinaire",
 			"reference": "LT92",
+			"local_notes": ".64 caliber flintlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -12989,6 +14550,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(40)",
 					"bulk": "-5",
+					"recoil": "4",
 					"defaults": [
 						{
 							"type": "dx",
@@ -12996,12 +14558,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Musket"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -13066,21 +14637,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -13107,21 +14690,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -13163,7 +14758,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Garrote"
+							"name": {
+								"compare": "is",
+								"qualifier": "Garrote"
+							}
 						}
 					],
 					"calc": {
@@ -13212,7 +14810,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -13298,12 +14899,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -13373,12 +14983,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -13461,21 +15080,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -13502,21 +15133,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -13702,6 +15345,7 @@
 			"id": "eRS8VyYOWFgYlcFMu",
 			"description": "Gonne",
 			"reference": "LT91",
+			"local_notes": ".87 caliber",
 			"tech_level": "3",
 			"legality_class": "2",
 			"tags": [
@@ -13724,6 +15368,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(30)",
 					"bulk": "-5",
+					"recoil": "4",
 					"defaults": [
 						{
 							"type": "dx",
@@ -13731,12 +15376,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Gonne"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gonne"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -4
 						}
 					],
@@ -13757,6 +15411,8 @@
 					"range": "75/1,200",
 					"rate_of_fire": "1",
 					"shots": "1(30)",
+					"bulk": "-5",
+					"recoil": "3",
 					"defaults": [
 						{
 							"type": "dx",
@@ -13764,12 +15420,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Gonne"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gonne"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -4
 						}
 					],
@@ -13888,21 +15553,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -13949,16 +15626,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -13985,16 +15671,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -14079,21 +15774,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -14120,21 +15827,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -14161,21 +15880,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -14300,13 +16031,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Harpoon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Harpoon"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -2
 						}
 					],
@@ -14352,16 +16095,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -14390,8 +16142,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						}
 					],
 					"calc": {
@@ -14435,25 +16193,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -14465,7 +16247,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 2
 				}
 			],
@@ -14560,21 +16342,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -14601,21 +16395,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -14666,7 +16472,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Sling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Sling"
+							}
 						}
 					],
 					"calc": {
@@ -14730,16 +16539,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -14766,16 +16584,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -14814,6 +16641,7 @@
 			"id": "e0bHi9bawivyZ3RGD",
 			"description": "Highland Pistol",
 			"reference": "LT93",
+			"local_notes": ".52 caliber flintlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -14836,6 +16664,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(20)",
 					"bulk": "-3",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -14843,12 +16672,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Pistol"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -14929,25 +16767,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -14959,7 +16821,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 3
 				}
 			],
@@ -14999,25 +16861,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -15029,7 +16915,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 2
 				}
 			],
@@ -15070,7 +16956,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -15353,42 +17242,66 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -5
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -5
 						}
 					],
@@ -15414,42 +17327,66 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -5
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -5
 						}
 					],
@@ -15479,8 +17416,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						}
 					],
 					"calc": {
@@ -15678,7 +17621,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -15800,7 +17746,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Blowpipe"
+							"name": {
+								"compare": "is",
+								"qualifier": "Blowpipe"
+							}
 						}
 					],
 					"calc": {
@@ -15979,13 +17928,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Liquid Projector",
+							"name": {
+								"compare": "is",
+								"qualifier": "Liquid Projector"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Liquid Projector",
-							"specialization": "Flamethrower"
+							"name": {
+								"compare": "is",
+								"qualifier": "Liquid Projector"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Flamethrower"
+							}
 						}
 					],
 					"calc": {
@@ -16032,16 +17990,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -16071,18 +18038,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear Thrower",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear Thrower"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Harpoon",
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Harpoon"
+							},
 							"modifier": -2
 						}
 					],
@@ -16129,16 +18111,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -16168,18 +18159,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear Thrower",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear Thrower"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Harpoon",
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Harpoon"
+							},
 							"modifier": -2
 						}
 					],
@@ -16225,31 +18231,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -16276,31 +18300,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -16346,31 +18388,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -16396,31 +18456,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -16447,16 +18525,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Staff"
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -2
 						}
 					],
@@ -16483,16 +18570,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Staff"
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -2
 						}
 					],
@@ -16519,16 +18615,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -16609,40 +18714,64 @@
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai"
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche"
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -16668,40 +18797,64 @@
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai"
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche"
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -16722,6 +18875,7 @@
 			"id": "en4F5-Hs9cuPtw0ed",
 			"description": "Jäger Rifle",
 			"reference": "LT94",
+			"local_notes": ".65 caliber wheellock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -16744,6 +18898,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-6",
+					"recoil": "3",
 					"defaults": [
 						{
 							"type": "dx",
@@ -16751,12 +18906,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Rifle"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Rifle"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -16795,6 +18959,7 @@
 			"id": "e1d5I1DEgBx7csoY9",
 			"description": "Jäger Rifle, Double-Barreled",
 			"reference": "LT94",
+			"local_notes": ".65 caliber wheellock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -16817,6 +18982,7 @@
 					"rate_of_fire": "1",
 					"shots": "2(60i)",
 					"bulk": "-7",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -16824,12 +18990,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Rifle"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Rifle"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -16909,31 +19084,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -16960,31 +19153,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -17011,16 +19222,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -17047,16 +19267,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -17104,21 +19333,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -17145,21 +19386,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -17252,45 +19505,72 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -17317,45 +19597,72 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -17418,25 +19725,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -17448,7 +19779,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 3
 				}
 			],
@@ -17490,21 +19821,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -17531,21 +19874,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -17572,31 +19927,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche"
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -17623,31 +19996,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche"
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -17703,16 +20094,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -17759,21 +20159,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -17800,21 +20212,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -17862,21 +20286,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Kusari"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -17903,21 +20339,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Kusari"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -17965,21 +20413,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Kusari"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -18006,21 +20466,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Kusari"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -18047,21 +20519,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Kusari"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -18109,21 +20593,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Kusari"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -18150,21 +20646,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Kusari"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -18265,21 +20773,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -18306,21 +20826,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -18367,11 +20899,17 @@
 						},
 						{
 							"type": "skill",
-							"name": "Lance"
+							"name": {
+								"compare": "is",
+								"qualifier": "Lance"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -3
 						}
 					],
@@ -18431,6 +20969,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(20)",
 					"bulk": "-6",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -18438,13 +20977,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -18544,31 +21092,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -18595,31 +21161,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -18682,17 +21266,26 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -5
 						}
 					],
@@ -18719,22 +21312,34 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -5
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -6
 						}
 					],
@@ -18764,8 +21369,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						}
 					],
 					"calc": {
@@ -18812,41 +21423,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -18873,41 +21508,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -18964,21 +21623,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -19004,21 +21675,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -19046,8 +21729,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						}
 					],
 					"calc": {
@@ -19090,11 +21779,17 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Net"
+							"name": {
+								"compare": "is",
+								"qualifier": "Net"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Cloak",
+							"name": {
+								"compare": "is",
+								"qualifier": "Cloak"
+							},
 							"modifier": -5
 						}
 					],
@@ -19142,41 +21837,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -19221,25 +21940,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -19251,7 +21994,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 3
 				}
 			],
@@ -19291,25 +22034,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -19321,7 +22088,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 3
 				}
 			],
@@ -19363,42 +22130,66 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -5
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -5
 						}
 					],
@@ -19424,42 +22215,66 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -5
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -5
 						}
 					],
@@ -19488,8 +22303,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						}
 					],
 					"calc": {
@@ -19532,7 +22353,10 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Lasso"
+							"name": {
+								"compare": "is",
+								"qualifier": "Lasso"
+							}
 						}
 					],
 					"calc": {
@@ -19578,31 +22402,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -19629,31 +22471,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -19680,16 +22540,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -19716,16 +22585,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -20155,31 +23033,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -20206,31 +23102,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -20277,26 +23191,41 @@
 						},
 						{
 							"type": "skill",
-							"name": "Rapier"
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -20323,26 +23252,41 @@
 						},
 						{
 							"type": "skill",
-							"name": "Rapier"
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -20389,21 +23333,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -20430,21 +23386,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -20491,26 +23459,41 @@
 						},
 						{
 							"type": "skill",
-							"name": "Rapier"
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -20558,16 +23541,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -20615,16 +23607,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -20672,16 +23673,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -20729,16 +23739,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -20786,16 +23805,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -20843,16 +23871,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -20900,16 +23937,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -21029,22 +24075,34 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						}
 					],
 					"calc": {
@@ -21195,21 +24253,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -21235,21 +24305,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -21276,41 +24358,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -21336,41 +24442,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -21417,16 +24547,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -21453,16 +24592,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -21509,16 +24657,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Staff"
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -2
 						}
 					],
@@ -21545,16 +24702,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Staff"
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -2
 						}
 					],
@@ -21591,12 +24757,13 @@
 						"base": "7d-1"
 					},
 					"strength": "21M†",
-					"usage": "Shoot Lead Ball",
+					"usage": "Lead Ball",
 					"accuracy": "1",
 					"range": "130/1,200",
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-10",
+					"recoil": "4",
 					"defaults": [
 						{
 							"type": "dx",
@@ -21608,8 +24775,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -21623,11 +24796,14 @@
 						"type": "pi+",
 						"base": "1d-1"
 					},
-					"usage": "Shoot Lead Shot",
+					"strength": "21M†",
+					"usage": "Lead Shot",
 					"accuracy": "1",
 					"range": "130/1,200",
 					"rate_of_fire": "1x100",
 					"shots": "1(60)",
+					"bulk": "-10",
+					"recoil": "1/4",
 					"defaults": [
 						{
 							"type": "iq",
@@ -21635,8 +24811,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -21740,7 +24922,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Bow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Bow"
+							}
 						}
 					],
 					"calc": {
@@ -21786,31 +24971,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -21837,31 +25040,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -21888,16 +25109,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -21924,16 +25154,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -21998,16 +25237,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -22034,21 +25282,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -22078,8 +25338,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						}
 					],
 					"calc": {
@@ -22126,41 +25392,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -22186,41 +25476,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -22268,31 +25582,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -22319,31 +25651,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -22390,31 +25740,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche"
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -22440,31 +25808,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche"
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -22491,21 +25877,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -22531,21 +25929,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -22619,21 +26029,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -22678,25 +26100,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -22708,7 +26154,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 2
 				}
 			],
@@ -22748,25 +26194,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -22778,7 +26248,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 2
 				}
 			],
@@ -22817,11 +26287,17 @@
 					"defaults": [
 						{
 							"type": "skill",
-							"name": "Net"
+							"name": {
+								"compare": "is",
+								"qualifier": "Net"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Cloak",
+							"name": {
+								"compare": "is",
+								"qualifier": "Cloak"
+							},
 							"modifier": -5
 						}
 					],
@@ -23532,7 +27008,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -23552,6 +27031,7 @@
 			"id": "eEHSjsOCxFFh6ET2f",
 			"description": "Military Pistol",
 			"reference": "LT93",
+			"local_notes": ".55 caliber wheellock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -23574,6 +27054,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(20)",
 					"bulk": "-4",
+					"recoil": "3",
 					"defaults": [
 						{
 							"type": "dx",
@@ -23581,12 +27062,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Pistol"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -23652,16 +27142,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -23709,16 +27208,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -23767,16 +27275,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -23847,8 +27364,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						}
 					],
 					"calc": {
@@ -23912,21 +27435,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -23953,21 +27488,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -23994,21 +27541,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -24074,16 +27633,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Flail"
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -3
 						}
 					],
@@ -24104,7 +27672,7 @@
 			"id": "eEhkIZOjs7PhrvwwY",
 			"description": "Mr. Facing-Both-Ways Gonne",
 			"reference": "LT91",
-			"local_notes": "Bullet.",
+			"local_notes": ".87 caliber",
 			"tech_level": "3",
 			"legality_class": "2",
 			"tags": [
@@ -24127,6 +27695,7 @@
 					"rate_of_fire": "1",
 					"shots": "2(30i)",
 					"bulk": "-6",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -24134,12 +27703,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Gonne"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gonne"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -4
 						}
 					],
@@ -24160,6 +27738,7 @@
 			"id": "eikIB_Ocnu5vBx_AY",
 			"description": "Musket",
 			"reference": "LT92",
+			"local_notes": ".80 caliber matchlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -24182,6 +27761,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-7",
+					"recoil": "4",
 					"defaults": [
 						{
 							"type": "dx",
@@ -24189,12 +27769,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Musket"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -24275,25 +27864,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						}
 					],
@@ -24305,7 +27918,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 3
 				}
 			],
@@ -24345,15 +27958,24 @@
 						},
 						{
 							"type": "skill",
-							"name": "Boxing"
+							"name": {
+								"compare": "is",
+								"qualifier": "Boxing"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Karate"
+							"name": {
+								"compare": "is",
+								"qualifier": "Karate"
+							}
 						}
 					],
 					"calc": {
@@ -24408,21 +28030,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -24449,21 +28083,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -24490,16 +28136,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -24526,16 +28181,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -24619,16 +28283,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Flail"
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -3
 						}
 					],
@@ -24675,21 +28348,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -24881,25 +28566,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -24911,7 +28620,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or buckler side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or buckler side",
 					"amount": 1
 				}
 			],
@@ -24952,31 +28661,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -25003,31 +28730,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -25180,12 +28925,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -25273,12 +29027,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -25317,6 +29080,7 @@
 			"id": "ezwT3uQOuPnl9J7Oa",
 			"description": "Petronel",
 			"reference": "LT93",
+			"local_notes": ".60 caliber wheellock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -25339,6 +29103,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(40)",
 					"bulk": "-7",
+					"recoil": "3",
 					"defaults": [
 						{
 							"type": "dx",
@@ -25346,12 +29111,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Pistol"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -25416,16 +29190,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -25526,16 +29309,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -25779,7 +29571,10 @@
 							"defaults": [
 								{
 									"type": "block",
-									"name": "Cloak"
+									"name": {
+										"compare": "is",
+										"qualifier": "Cloak"
+									}
 								}
 							],
 							"calc": {
@@ -25802,16 +29597,25 @@
 							"defaults": [
 								{
 									"type": "skill",
-									"name": "Cloak"
+									"name": {
+										"compare": "is",
+										"qualifier": "Cloak"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Net",
+									"name": {
+										"compare": "is",
+										"qualifier": "Net"
+									},
 									"modifier": -4
 								},
 								{
 									"type": "skill",
-									"name": "Shield",
+									"name": {
+										"compare": "is",
+										"qualifier": "Shield"
+									},
 									"modifier": -4
 								},
 								{
@@ -25892,26 +29696,41 @@
 										},
 										{
 											"type": "skill",
-											"name": "Knife"
+											"name": {
+												"compare": "is",
+												"qualifier": "Knife"
+											}
 										},
 										{
 											"type": "skill",
-											"name": "Force Sword",
+											"name": {
+												"compare": "is",
+												"qualifier": "Force Sword"
+											},
 											"modifier": -3
 										},
 										{
 											"type": "skill",
-											"name": "Main-Gauche",
+											"name": {
+												"compare": "is",
+												"qualifier": "Main-Gauche"
+											},
 											"modifier": -3
 										},
 										{
 											"type": "skill",
-											"name": "Shortsword",
+											"name": {
+												"compare": "is",
+												"qualifier": "Shortsword"
+											},
 											"modifier": -3
 										},
 										{
 											"type": "skill",
-											"name": "Sword!"
+											"name": {
+												"compare": "is",
+												"qualifier": "Sword!"
+											}
 										}
 									],
 									"calc": {
@@ -25936,26 +29755,41 @@
 										},
 										{
 											"type": "skill",
-											"name": "Knife"
+											"name": {
+												"compare": "is",
+												"qualifier": "Knife"
+											}
 										},
 										{
 											"type": "skill",
-											"name": "Force Sword",
+											"name": {
+												"compare": "is",
+												"qualifier": "Force Sword"
+											},
 											"modifier": -3
 										},
 										{
 											"type": "skill",
-											"name": "Main-Gauche",
+											"name": {
+												"compare": "is",
+												"qualifier": "Main-Gauche"
+											},
 											"modifier": -3
 										},
 										{
 											"type": "skill",
-											"name": "Shortsword",
+											"name": {
+												"compare": "is",
+												"qualifier": "Shortsword"
+											},
 											"modifier": -3
 										},
 										{
 											"type": "skill",
-											"name": "Sword!"
+											"name": {
+												"compare": "is",
+												"qualifier": "Sword!"
+											}
 										}
 									],
 									"calc": {
@@ -25982,8 +29816,14 @@
 										},
 										{
 											"type": "skill",
-											"name": "Thrown Weapon",
-											"specialization": "Knife"
+											"name": {
+												"compare": "is",
+												"qualifier": "Thrown Weapon"
+											},
+											"specialization": {
+												"compare": "is",
+												"qualifier": "Knife"
+											}
 										}
 									],
 									"calc": {
@@ -26122,7 +29962,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -26251,6 +30094,7 @@
 			"id": "eaLpwe40QwHRSk5Ot",
 			"description": "Pocket Pistol",
 			"reference": "LT93",
+			"local_notes": ".33 caliber wheellock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -26273,6 +30117,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(20)",
 					"bulk": "-1",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -26280,12 +30125,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Pistol"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -26350,21 +30204,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -26391,21 +30257,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -26452,21 +30330,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -26493,21 +30383,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -26534,21 +30436,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Polearm"
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -26600,12 +30514,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -26765,7 +30688,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -26840,7 +30766,7 @@
 			"id": "ek9PiJhQ5UEqXYawL",
 			"description": "Puckle Gun",
 			"reference": "LT92",
-			"local_notes": "Normally used with a tripod mount; Spare cylinder (empty): $200, 10 lbs.",
+			"local_notes": "1.25 caliber flintlock. Normally used with a tripod mount. Reloading by swapping cylinders takes (15).",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -26863,6 +30789,7 @@
 					"rate_of_fire": "1",
 					"shots": "9(10i)",
 					"bulk": "-8",
+					"recoil": "1",
 					"defaults": [
 						{
 							"type": "dx",
@@ -26870,12 +30797,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Musket"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -26914,6 +30850,7 @@
 			"id": "eXrjLew_ws9E0wkPB",
 			"description": "Puffer Pistol",
 			"reference": "LT93",
+			"local_notes": ".53 caliber wheellock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -26936,6 +30873,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(20)",
 					"bulk": "-3",
+					"recoil": "3",
 					"defaults": [
 						{
 							"type": "dx",
@@ -26943,12 +30881,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Pistol"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -27030,7 +30977,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -27056,16 +31006,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Staff"
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -2
 						}
 					],
@@ -27092,16 +31051,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Staff"
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -2
 						}
 					],
@@ -27128,16 +31096,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Staff"
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -2
 						}
 					],
@@ -27218,21 +31195,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -27260,21 +31249,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai"
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -27321,16 +31322,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Staff"
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -2
 						}
 					],
@@ -27357,16 +31367,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Staff"
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -2
 						}
 					],
@@ -27393,16 +31412,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -27429,16 +31457,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -27459,6 +31496,7 @@
 			"id": "e8bSmtIoMuno3Qqwu",
 			"description": "Queen Anne Pistol",
 			"reference": "LT93",
+			"local_notes": ".50 caliber flintlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -27481,6 +31519,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-3",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -27488,12 +31527,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Pistol"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -27609,6 +31657,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-9",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -27616,13 +31665,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -27794,26 +31852,41 @@
 						},
 						{
 							"type": "skill",
-							"name": "Rapier"
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -27935,7 +32008,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Bow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Bow"
+							}
 						}
 					],
 					"calc": {
@@ -27985,7 +32061,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Bow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Bow"
+							}
 						}
 					],
 					"calc": {
@@ -28035,7 +32114,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -28170,25 +32252,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -28200,7 +32306,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 3
 				}
 			],
@@ -28241,25 +32347,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -28271,7 +32401,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 2
 				}
 			],
@@ -28313,21 +32443,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -28353,31 +32495,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche"
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -28425,21 +32585,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Kusari"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -28466,21 +32638,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Kusari"
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -28545,21 +32729,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -28589,8 +32785,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						}
 					],
 					"calc": {
@@ -28636,31 +32838,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Saber"
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -28687,26 +32907,41 @@
 						},
 						{
 							"type": "skill",
-							"name": "Saber"
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						},
 						{
@@ -29232,21 +33467,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai"
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -29272,21 +33519,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai"
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -29312,31 +33571,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche"
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -29362,31 +33639,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche"
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -29414,8 +33709,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						}
 					],
 					"calc": {
@@ -29458,6 +33759,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-13",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -29465,13 +33767,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -29682,7 +33993,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -29748,7 +34062,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -29814,7 +34131,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -29883,12 +34203,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -29976,12 +34305,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -30069,12 +34407,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -30162,12 +34509,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -30255,12 +34611,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -30326,21 +34691,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -30367,21 +34744,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -30408,21 +34797,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -30588,7 +34989,7 @@
 		},
 		{
 			"id": "e9P5qO-f7jTa_aKoE",
-			"description": "Ship's  Gun, 4-lb.",
+			"description": "Ship's Gun, 4-lb.",
 			"reference": "LT89",
 			"local_notes": "Requires 2 crew",
 			"tech_level": "4",
@@ -30613,6 +35014,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-12",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -30620,13 +35022,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -30644,7 +35055,7 @@
 		},
 		{
 			"id": "ejpsgfl8GVo0GSC0e",
-			"description": "Ship's  Gun, 9-lb.",
+			"description": "Ship's Gun, 9-lb.",
 			"reference": "LT89",
 			"local_notes": "Requires 4 crew",
 			"tech_level": "4",
@@ -30669,6 +35080,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-14",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -30676,13 +35088,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -30700,7 +35121,7 @@
 		},
 		{
 			"id": "e8uitUlp0r15b5FgG",
-			"description": "Ship's  Gun, 18-lb.",
+			"description": "Ship's Gun, 18-lb.",
 			"reference": "LT89",
 			"local_notes": "Requires 6 crew",
 			"tech_level": "4",
@@ -30725,6 +35146,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(70)",
 					"bulk": "-15",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -30732,13 +35154,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -30756,7 +35187,7 @@
 		},
 		{
 			"id": "eq5zVXQqWxQYWE3NB",
-			"description": "Ship's  Gun, 42-lb.",
+			"description": "Ship's Gun, 42-lb.",
 			"reference": "LT89",
 			"local_notes": "Requires 11 crew",
 			"tech_level": "4",
@@ -30781,6 +35212,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(90)",
 					"bulk": "-16",
+					"recoil": "4",
 					"defaults": [
 						{
 							"type": "dx",
@@ -30788,13 +35220,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -30812,7 +35253,7 @@
 		},
 		{
 			"id": "eYy_BK5oehGuVMSAi",
-			"description": "Ship's Gun,4-lb. Cannonball",
+			"description": "Ship's Gun, 4-lb. Cannonball",
 			"reference": "LT89",
 			"tech_level": "4",
 			"tags": [
@@ -30830,7 +35271,7 @@
 		},
 		{
 			"id": "eNA2w45uk8D7UQqj_",
-			"description": "Ship's Gun,9-lb. Cannonball",
+			"description": "Ship's Gun, 9-lb. Cannonball",
 			"reference": "LT89",
 			"tech_level": "4",
 			"tags": [
@@ -30848,7 +35289,7 @@
 		},
 		{
 			"id": "et2MCUquQj6FTKB3G",
-			"description": "Ship's Gun,18-lb. Cannonball",
+			"description": "Ship's Gun, 18-lb. Cannonball",
 			"reference": "LT89",
 			"tech_level": "4",
 			"tags": [
@@ -30866,7 +35307,7 @@
 		},
 		{
 			"id": "e4bYSKykFC8rGhkVE",
-			"description": "Ship's Gun,42-lb. Cannonball",
+			"description": "Ship's Gun, 42-lb. Cannonball",
 			"reference": "LT89",
 			"tech_level": "4",
 			"tags": [
@@ -31020,45 +35461,72 @@
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -31084,50 +35552,80 @@
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -31177,7 +35675,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Bow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Bow"
+							}
 						}
 					],
 					"calc": {
@@ -31223,16 +35724,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -31258,16 +35768,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -31313,26 +35832,41 @@
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -4
 						}
 					],
@@ -31358,26 +35892,41 @@
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -4
 						}
 					],
@@ -31423,41 +35972,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -31484,41 +36057,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -31566,31 +36163,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -31617,31 +36232,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -31747,16 +36380,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -31783,16 +36425,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -31818,16 +36469,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -31879,7 +36539,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -31980,21 +36643,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -32021,31 +36696,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche"
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -32123,7 +36816,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Sling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Sling"
+							}
 						}
 					],
 					"calc": {
@@ -32248,7 +36944,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -32277,7 +36976,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Crossbow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Crossbow"
+							}
 						}
 					],
 					"calc": {
@@ -32342,17 +37044,26 @@
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						}
 					],
 					"calc": {
@@ -32397,41 +37108,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -32458,41 +37193,65 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -3
 						}
 					],
@@ -32540,21 +37299,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -32581,21 +37352,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -32624,8 +37407,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						}
 					],
 					"calc": {
@@ -32671,16 +37460,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -32710,8 +37508,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						}
 					],
 					"calc": {
@@ -32757,16 +37561,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -32796,8 +37609,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						}
 					],
 					"calc": {
@@ -32841,25 +37660,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -32871,7 +37714,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 1
 				}
 			],
@@ -32911,25 +37754,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Shield"
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shield"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Buckler",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Buckler"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Force Shield",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Force Shield"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Shield",
-							"specialization": "Guige",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shield"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Guige"
+							},
 							"modifier": -2
 						}
 					],
@@ -32941,7 +37808,7 @@
 			"features": [
 				{
 					"type": "conditional_modifier",
-					"situation": "to Dodge, Parry \u0026 Block against attacks from the front or shield side",
+					"situation": "to Dodge, Parry & Block against attacks from the front or shield side",
 					"amount": 1
 				}
 			],
@@ -32984,17 +37851,26 @@
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						}
 					],
 					"calc": {
@@ -33023,8 +37899,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						}
 					],
 					"calc": {
@@ -33070,42 +37952,66 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -5
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -5
 						}
 					],
@@ -33132,42 +38038,66 @@
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -5
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -6
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa",
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							},
 							"modifier": -5
 						}
 					],
@@ -33196,8 +38126,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						}
 					],
 					"calc": {
@@ -33243,26 +38179,41 @@
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -4
 						}
 					],
@@ -33394,16 +38345,25 @@
 								},
 								{
 									"type": "skill",
-									"name": "Axe/Mace"
+									"name": {
+										"compare": "is",
+										"qualifier": "Axe/Mace"
+									}
 								},
 								{
 									"type": "skill",
-									"name": "Flail",
+									"name": {
+										"compare": "is",
+										"qualifier": "Flail"
+									},
 									"modifier": -4
 								},
 								{
 									"type": "skill",
-									"name": "Two-Handed Axe/Mace",
+									"name": {
+										"compare": "is",
+										"qualifier": "Two-Handed Axe/Mace"
+									},
 									"modifier": -3
 								}
 							],
@@ -33632,16 +38592,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -33756,6 +38725,7 @@
 			"id": "eT2hYlAKFxdycDv8b",
 			"description": "Snaphaunce Pistol",
 			"reference": "LT93",
+			"local_notes": ".45 caliber flintlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -33778,6 +38748,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(20)",
 					"bulk": "-2",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -33785,12 +38756,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Pistol"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -33892,16 +38872,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Staff"
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -2
 						}
 					],
@@ -33928,16 +38917,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Staff"
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -2
 						}
 					],
@@ -33964,16 +38962,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Staff"
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -2
 						}
 					],
@@ -34020,16 +39027,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -34056,16 +39072,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -34095,18 +39120,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear Thrower",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear Thrower"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Harpoon",
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Harpoon"
+							},
 							"modifier": -2
 						}
 					],
@@ -34153,16 +39193,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -34189,16 +39238,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -34228,18 +39286,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Spear Thrower",
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear Thrower"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Harpoon",
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Harpoon"
+							},
 							"modifier": -2
 						}
 					],
@@ -34303,7 +39376,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -34331,12 +39407,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Shuriken"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shuriken"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Throwing",
+							"name": {
+								"compare": "is",
+								"qualifier": "Throwing"
+							},
 							"modifier": -2
 						}
 					],
@@ -34424,12 +39509,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						}
 					],
@@ -34556,7 +39650,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Sling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Sling"
+							}
 						}
 					],
 					"calc": {
@@ -34601,7 +39698,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -34629,12 +39729,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Shuriken"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Shuriken"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Throwing",
+							"name": {
+								"compare": "is",
+								"qualifier": "Throwing"
+							},
 							"modifier": -2
 						}
 					],
@@ -34682,21 +39791,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -34723,31 +39844,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche"
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Jitte/Sai",
+							"name": {
+								"compare": "is",
+								"qualifier": "Jitte/Sai"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Knife",
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Smallsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Smallsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -34816,12 +39955,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear Thrower"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear Thrower"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						}
 					],
@@ -34910,7 +40058,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Bow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Bow"
+							}
 						}
 					],
 					"calc": {
@@ -35111,6 +40262,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(20)",
 					"bulk": "-8",
+					"recoil": "3",
 					"defaults": [
 						{
 							"type": "dx",
@@ -35118,13 +40270,22 @@
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Gunner",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -35180,12 +40341,13 @@
 			"id": "eke2A4uq0LU-VWWzI",
 			"description": "Tantsutsu",
 			"reference": "LT93",
+			"local_notes": ".70 caliber matchlock; uses serpentine powder.",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
 				"Missile Weapon"
 			],
-			"base_value": "610",
+			"base_value": "122",
 			"base_weight": "4.5 lb",
 			"weapons": [
 				{
@@ -35202,6 +40364,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(45)",
 					"bulk": "-5",
+					"recoil": "3",
 					"defaults": [
 						{
 							"type": "dx",
@@ -35209,12 +40372,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Pistol"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Pistol"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -35225,8 +40397,8 @@
 			],
 			"quantity": 1,
 			"calc": {
-				"value": 610,
-				"extended_value": 610,
+				"value": 122,
+				"extended_value": 122,
 				"weight": "4.5 lb",
 				"extended_weight": "4.5 lb"
 			}
@@ -35253,7 +40425,7 @@
 			"id": "enxEQxvu3l4PJ3rWB",
 			"description": "Ten-Eyed Gonne",
 			"reference": "LT91",
-			"local_notes": "Bullet; Range and damage increase from the first to the fifth bullet on each end. The five lines show the increase.  After  one end is fully discharged, start over at the lowest values for the other end. Reloading the inner rounds takes 60 seconds per round rather than 30.",
+			"local_notes": ".87 caliber. Range and damage increase from the first to the fifth bullet on each end. After one end is fully discharged, flip it and start over for the other end. Reloading the inner rounds takes *60* seconds per round rather than 30.",
 			"tech_level": "3",
 			"legality_class": "2",
 			"tags": [
@@ -35270,12 +40442,13 @@
 						"base": "2d"
 					},
 					"strength": "11†",
-					"usage": "First Shot",
+					"usage": "1st Shot",
 					"accuracy": "1",
 					"range": "50/510",
 					"rate_of_fire": "1",
 					"shots": "10(30i)",
 					"bulk": "-7",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -35283,12 +40456,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Gonne"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gonne"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -4
 						}
 					],
@@ -35303,10 +40485,13 @@
 						"type": "pi++",
 						"base": "2d+1"
 					},
-					"usage": "Second Shot",
+					"strength": "11†",
+					"usage": "2nd Shot",
 					"accuracy": "1",
 					"range": "60/590",
 					"rate_of_fire": "1",
+					"bulk": "-7",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -35314,12 +40499,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Gonne"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gonne"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -4
 						}
 					],
@@ -35334,10 +40528,13 @@
 						"type": "pi++",
 						"base": "2d+2"
 					},
-					"usage": "Third Shot",
+					"strength": "11†",
+					"usage": "3rd Shot",
 					"accuracy": "1",
 					"range": "65/630",
 					"rate_of_fire": "1",
+					"bulk": "-7",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -35345,12 +40542,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Gonne"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gonne"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -4
 						}
 					],
@@ -35365,10 +40571,13 @@
 						"type": "pi++",
 						"base": "2d+2"
 					},
-					"usage": "Fourth Shot",
+					"strength": "11†",
+					"usage": "4th Shot",
 					"accuracy": "1",
 					"range": "65/650",
 					"rate_of_fire": "1",
+					"bulk": "-7",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -35376,12 +40585,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Gonne"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gonne"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -4
 						}
 					],
@@ -35396,10 +40614,13 @@
 						"type": "pi++",
 						"base": "2d+3"
 					},
-					"usage": "Fifth Shot",
+					"strength": "11†",
+					"usage": "5th Shot",
 					"accuracy": "1",
 					"range": "65/660",
 					"rate_of_fire": "1",
+					"bulk": "-7",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -35407,12 +40628,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Gonne"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Gonne"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -4
 						}
 					],
@@ -35433,6 +40663,7 @@
 			"id": "eR0fxLNLai2FOHu7t",
 			"description": "Teppo",
 			"reference": "LT92",
+			"local_notes": ".47 caliber matchlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -35455,6 +40686,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-5",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -35462,12 +40694,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Musket"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -35532,21 +40773,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -35573,21 +40826,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -35614,16 +40879,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -35650,16 +40924,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -35707,16 +40990,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Flail"
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -3
 						}
 					],
@@ -35764,21 +41056,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -35805,21 +41109,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -35866,16 +41182,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							},
 							"modifier": -3
 						}
 					],
@@ -35902,21 +41227,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -35946,8 +41283,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -4
 						}
 					],
@@ -35996,12 +41339,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Dart"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Dart"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Throwing",
+							"name": {
+								"compare": "is",
+								"qualifier": "Throwing"
+							},
 							"modifier": -2
 						}
 					],
@@ -36051,8 +41403,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Stick"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Stick"
+							}
 						}
 					],
 					"calc": {
@@ -36098,31 +41456,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -36149,31 +41525,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -36200,16 +41594,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -36236,16 +41639,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -36292,31 +41704,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -36343,31 +41773,49 @@
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Rapier",
+							"name": {
+								"compare": "is",
+								"qualifier": "Rapier"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Saber",
+							"name": {
+								"compare": "is",
+								"qualifier": "Saber"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -2
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -36414,16 +41862,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -36450,16 +41907,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -36522,7 +41988,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Brawling"
+							"name": {
+								"compare": "is",
+								"qualifier": "Brawling"
+							}
 						}
 					],
 					"calc": {
@@ -36547,11 +42016,17 @@
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa"
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -36577,11 +42052,17 @@
 						},
 						{
 							"type": "skill",
-							"name": "Tonfa"
+							"name": {
+								"compare": "is",
+								"qualifier": "Tonfa"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -36740,8 +42221,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						}
 					],
 					"calc": {
@@ -36792,8 +42279,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						}
 					],
 					"calc": {
@@ -36844,8 +42337,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						}
 					],
 					"calc": {
@@ -36914,8 +42413,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Catapult"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Catapult"
+							}
 						}
 					],
 					"calc": {
@@ -36998,16 +42503,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -37035,16 +42549,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Staff",
+							"name": {
+								"compare": "is",
+								"qualifier": "Staff"
+							},
 							"modifier": -2
 						}
 					],
@@ -37112,7 +42635,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Bow"
+							"name": {
+								"compare": "is",
+								"qualifier": "Bow"
+							}
 						}
 					],
 					"calc": {
@@ -37176,16 +42702,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -37212,16 +42747,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Sword"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Sword"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Broadsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Broadsword"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -4
 						}
 					],
@@ -37268,16 +42812,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -37305,16 +42858,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -37375,6 +42937,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(60)",
 					"bulk": "-12",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "iq",
@@ -37382,8 +42945,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Artillery",
-							"specialization": "Cannon"
+							"name": {
+								"compare": "is",
+								"qualifier": "Artillery"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Cannon"
+							}
 						}
 					],
 					"calc": {
@@ -37476,7 +43045,7 @@
 			"id": "edCOPZI0HlMPYn3ed",
 			"description": "Wall Gun",
 			"reference": "LT92",
-			"local_notes": "Normally used with a tripod mount.",
+			"local_notes": "1.06 caliber wheellock. Normally used with a tripod mount.",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -37499,6 +43068,7 @@
 					"rate_of_fire": "1",
 					"shots": "1(40)",
 					"bulk": "-7",
+					"recoil": "3",
 					"defaults": [
 						{
 							"type": "dx",
@@ -37506,18 +43076,35 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Musket"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
 					"calc": {
 						"damage": "5d+1 pi++"
 					}
+				}
+			],
+			"modifiers": [
+				{
+					"id": "fPkU7aIFU6FE8T0EV",
+					"name": "Backup matchlock",
+					"cost": "+25",
+					"disabled": true
 				}
 			],
 			"quantity": 1,
@@ -37613,21 +43200,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Axe/Mace"
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Axe/Mace"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Polearm",
+							"name": {
+								"compare": "is",
+								"qualifier": "Polearm"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -4
 						}
 					],
@@ -37728,16 +43327,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Flail"
+							"name": {
+								"compare": "is",
+								"qualifier": "Flail"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Axe/Mace",
+							"name": {
+								"compare": "is",
+								"qualifier": "Axe/Mace"
+							},
 							"modifier": -4
 						},
 						{
 							"type": "skill",
-							"name": "Two-Handed Flail",
+							"name": {
+								"compare": "is",
+								"qualifier": "Two-Handed Flail"
+							},
 							"modifier": -3
 						}
 					],
@@ -37760,7 +43368,10 @@
 						},
 						{
 							"type": "skill",
-							"name": "Garrote"
+							"name": {
+								"compare": "is",
+								"qualifier": "Garrote"
+							}
 						}
 					],
 					"calc": {
@@ -37807,16 +43418,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -37864,16 +43484,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -37921,16 +43550,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -37978,16 +43616,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -38035,16 +43682,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -38092,16 +43748,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -38149,16 +43814,25 @@
 						},
 						{
 							"type": "skill",
-							"name": "Whip"
+							"name": {
+								"compare": "is",
+								"qualifier": "Whip"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Kusari",
+							"name": {
+								"compare": "is",
+								"qualifier": "Kusari"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Monowire Whip",
+							"name": {
+								"compare": "is",
+								"qualifier": "Monowire Whip"
+							},
 							"modifier": -3
 						}
 					],
@@ -38509,6 +44183,7 @@
 			"id": "eMM2x0c5BYnpcGNh2",
 			"description": "Winged Tiger Gun",
 			"reference": "LT92",
+			"local_notes": ".55 caliber matchlock",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [
@@ -38531,6 +44206,7 @@
 					"rate_of_fire": "1",
 					"shots": "3(60i)",
 					"bulk": "-5",
+					"recoil": "2",
 					"defaults": [
 						{
 							"type": "dx",
@@ -38538,12 +44214,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
-							"specialization": "Musket"
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Guns",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
 							"modifier": -2
 						}
 					],
@@ -38939,21 +44624,33 @@
 						},
 						{
 							"type": "skill",
-							"name": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Force Sword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Force Sword"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Main-Gauche",
+							"name": {
+								"compare": "is",
+								"qualifier": "Main-Gauche"
+							},
 							"modifier": -3
 						},
 						{
 							"type": "skill",
-							"name": "Shortsword",
+							"name": {
+								"compare": "is",
+								"qualifier": "Shortsword"
+							},
 							"modifier": -3
 						}
 					],
@@ -38982,8 +44679,14 @@
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Knife"
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Knife"
+							}
 						}
 					],
 					"calc": {
@@ -39033,12 +44736,21 @@
 						},
 						{
 							"type": "skill",
-							"name": "Spear Thrower"
+							"name": {
+								"compare": "is",
+								"qualifier": "Spear Thrower"
+							}
 						},
 						{
 							"type": "skill",
-							"name": "Thrown Weapon",
-							"specialization": "Spear",
+							"name": {
+								"compare": "is",
+								"qualifier": "Thrown Weapon"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Spear"
+							},
 							"modifier": -4
 						}
 					],

--- a/Library/Low Tech/Low Tech Equipment.eqp
+++ b/Library/Low Tech/Low Tech Equipment.eqp
@@ -11249,7 +11249,7 @@
 			"id": "eeoIt6AJrsf9pxzmy",
 			"description": "Duck’s Foot Pistol",
 			"reference": "LT93",
-			"local_notes": ".40 caliber flintlock. ",
+			"local_notes": ".40 caliber flintlock. Hits one target at up to 2 yards, or one target and three bystanders at 3+ yards.",
 			"tech_level": "4",
 			"legality_class": "2",
 			"tags": [

--- a/Library/Low Tech/Low Tech Equipment.eqp
+++ b/Library/Low Tech/Low Tech Equipment.eqp
@@ -5345,6 +5345,72 @@
 			}
 		},
 		{
+			"id": "eT_f8WXR8mRNOpLSl",
+			"description": "Buccaneer Fusil",
+			"reference": "LT92",
+			"local_notes": ".64 caliber flintlock",
+			"tech_level": "4",
+			"legality_class": "2",
+			"tags": [
+				"Missile Weapon"
+			],
+			"base_value": "150",
+			"base_weight": "7.5 lb",
+			"weapons": [
+				{
+					"id": "W3hYAnNy6LbS07aXN",
+					"sv": 1,
+					"damage": {
+						"type": "pi++",
+						"base": "3d+1"
+					},
+					"strength": "10†",
+					"usage": "Shoot",
+					"accuracy": "1",
+					"range": "75/750",
+					"rate_of_fire": "1",
+					"shots": "1(40)",
+					"bulk": "-11",
+					"recoil": "4",
+					"defaults": [
+						{
+							"type": "dx",
+							"modifier": -4
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Musket"
+							}
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Guns"
+							},
+							"modifier": -2
+						}
+					],
+					"calc": {
+						"damage": "3d+1 pi++"
+					}
+				}
+			],
+			"quantity": 1,
+			"calc": {
+				"value": 150,
+				"extended_value": 150,
+				"weight": "7.5 lb",
+				"extended_weight": "7.5 lb"
+			}
+		},
+		{
 			"id": "e7bG-Z_K51SfZcVzx",
 			"description": "Bullet-Molding Gear",
 			"reference": "LT96",
@@ -30847,6 +30913,63 @@
 			}
 		},
 		{
+			"id": "Ed-oz5AKkZTV0Io1X",
+			"description": "Puckle Gun Cylinder",
+			"reference": "LT93",
+			"reference_highlight": "cylinder",
+			"local_notes": "Holds 9 bullets. Spares shorten reload to (15).",
+			"tech_level": "4",
+			"tags": [
+				"Ammunition",
+				"Heavy Weapons Accessories"
+			],
+			"base_value": "200",
+			"base_weight": "10 lb",
+			"prereqs": {
+				"type": "prereq_list",
+				"all": true,
+				"prereqs": [
+					{
+						"type": "contained_quantity_prereq",
+						"has": true,
+						"qualifier": {
+							"compare": "at_most",
+							"qualifier": 9
+						}
+					}
+				]
+			},
+			"quantity": 1,
+			"equipped": true,
+			"children": [],
+			"calc": {
+				"value": 200,
+				"extended_value": 200,
+				"weight": "10 lb",
+				"extended_weight": "10 lb"
+			}
+		},
+		{
+			"id": "eZZov_eOFVVwXtnjb",
+			"description": "Puckle Gun Tripod Mount",
+			"reference": "LT93",
+			"reference_highlight": "For Puckle gun",
+			"tech_level": "4",
+			"tags": [
+				"Heavy Weapons Accessories"
+			],
+			"base_value": "380",
+			"base_weight": "20 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 380,
+				"extended_value": 380,
+				"weight": "20 lb",
+				"extended_weight": "20 lb"
+			}
+		},
+		{
 			"id": "eXrjLew_ws9E0wkPB",
 			"description": "Puffer Pistol",
 			"reference": "LT93",
@@ -32221,6 +32344,71 @@
 				"extended_value": 12000,
 				"weight": "8,400 lb",
 				"extended_weight": "8,400 lb"
+			}
+		},
+		{
+			"id": "eDP0QnXWi8PKDdBjP",
+			"description": "Rocket",
+			"reference": "LT87",
+			"local_notes": "Treated as ranged Wild Swing (-5, max skill 9). Travel time up to 3s.",
+			"tech_level": "3",
+			"tags": [
+				"Heavy Weapons"
+			],
+			"base_value": "23",
+			"base_weight": "1.15 lb",
+			"weapons": [
+				{
+					"id": "WAd5_TDslv9AXFyLs",
+					"sv": 1,
+					"damage": {
+						"type": "cr ex",
+						"base": "2d+2"
+					},
+					"strength": "6M",
+					"usage": "Launch",
+					"range": "810",
+					"rate_of_fire": "1",
+					"shots": "1(15)",
+					"bulk": "-5",
+					"recoil": "1",
+					"defaults": [
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"specialization": {
+								"compare": "is",
+								"qualifier": "Rocket"
+							}
+						},
+						{
+							"type": "skill",
+							"name": {
+								"compare": "is",
+								"qualifier": "Gunner"
+							},
+							"modifier": -4
+						},
+						{
+							"type": "dx",
+							"modifier": -4
+						}
+					],
+					"calc": {
+						"damage": "2d+2 cr ex"
+					}
+				}
+			],
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 23,
+				"extended_value": 23,
+				"weight": "1.15 lb",
+				"extended_weight": "1.15 lb"
 			}
 		},
 		{
@@ -40395,10 +40583,31 @@
 					}
 				}
 			],
+			"modifiers": [
+				{
+					"id": "fQm4yeMpV0VNTQ5p5",
+					"name": "Fine",
+					"local_notes": "Ornate",
+					"cost_type": "to_base_cost",
+					"cost": "+4 CF",
+					"features": [
+						{
+							"type": "conditional_modifier",
+							"situation": "to Merchant skill rolls made as Influence rolls on collectors and potential buyers.",
+							"amount": 2
+						},
+						{
+							"type": "reaction_bonus",
+							"situation": "from collectors and potential buyers.",
+							"amount": 2
+						}
+					]
+				}
+			],
 			"quantity": 1,
 			"calc": {
-				"value": 122,
-				"extended_value": 122,
+				"value": 610,
+				"extended_value": 610,
 				"weight": "4.5 lb",
 				"extended_weight": "4.5 lb"
 			}
@@ -43131,6 +43340,26 @@
 				"extended_value": 6,
 				"weight": "0.3 lb",
 				"extended_weight": "0.3 lb"
+			}
+		},
+		{
+			"id": "elMaGyB7HWNTv_zPh",
+			"description": "Wall Gun Tripod Mount",
+			"reference": "LT93",
+			"reference_highlight": "For wall gun",
+			"tech_level": "4",
+			"tags": [
+				"Heavy Weapons Accessories"
+			],
+			"base_value": "260",
+			"base_weight": "7.5 lb",
+			"quantity": 1,
+			"equipped": true,
+			"calc": {
+				"value": 260,
+				"extended_value": 260,
+				"weight": "7.5 lb",
+				"extended_weight": "7.5 lb"
 			}
 		},
 		{


### PR DESCRIPTION
> Whoops! 7000 lines of automatic formatting changes! ...Sorry about that, tried separating them out into their own commit but got brick-walled by merge errors. At least they're only in commit 1.

Based on LT84-96.

A full changelog would be about as long as the actual (non-automatic😅) line count, but here's the rundown:

### Commit 1

- Added Recoil to every gun. (It matters in my heart.)
  - Also added ST/Bulk and RoF wherever missing. (Multi-profile and multi-projectile weapons respectively.)
- Noted caliber and lock type for every handheld gun. (Helps in searching, and I think the extra line gives guns well-deserved gravitas.)
- Trimmed `words words words` from notes fields and weapon usage names that were overly long. (see: Ten-Eyed Gonne's notes; Crouching Tiger Gun's weapon usages)
- Fixed typos, and a wrong stat or two.

### Commit 2
- Added a few missing items.
- Fixed wrong Tantsutsu cost (`$610` → `$122 +4 CF [Ornate]`) with appropriate modifier.

Hope I didn't miss anything. Enjoy!