### PR TITLE
Updated scripting on High-Tech Scopes, utilizing new Substitutions.

### DIFF
--- a/Library/High Tech/High Tech Equipment.eqp
+++ b/Library/High Tech/High Tech Equipment.eqp
@@ -34415,60 +34415,69 @@
 			"id": "eyPjJiwnhI80yrneq",
 			"description": "Fixed-Power Scope",
 			"reference": "HT156",
-			"local_notes": "<script>isNaN(\"@Acc [1-5]@\")?\"@Acc [1-5]@\":signedValue(\"@Acc [1-5]@\")</script> Acc<script>if (Math.abs(~~\"@Acc [1-5]@\")>2) {\", -1 Bulk\"} else {\"\"}</script>; \nMagnification <script>2 ** ~~\"@Acc [1-5]@\"</script>×",
+			"local_notes": "@Acc|+1|+2|+3|+4|+5@ Acc<script>if (\"@Acc|+1|+2|+3|+4|+5@\">2) {\", -1 Bulk\"} else {\"\"}</script>; Magnification <script>2 ** \"@Acc|+1|+2|+3|+4|+5@\"</script>×",
 			"tech_level": "5",
 			"tags": [
 				"Firearm Accessories"
 			],
-			"base_value": "Math.max(Math.abs(~~\"@Acc [1-5]@\"),1)*100",
+			"base_value": "~~\"@Acc|+1|+2|+3|+4|+5@\"*100",
 			"base_weight": "3 lb",
+			"replacements": {
+				"Acc|+1|+2|+3|+4|+5": "+1"
+			},
 			"quantity": 1,
 			"calc": {
 				"value": 100,
 				"extended_value": 100,
 				"weight": "3 lb",
 				"extended_weight": "3 lb",
-				"resolved_notes": "@Acc [1-5]@ Acc; \nMagnification 1×"
+				"resolved_notes": "+1 Acc; Magnification 2×"
 			}
 		},
 		{
 			"id": "erbhKAhDnf5S_4w-F",
 			"description": "Fixed-Power Scope",
 			"reference": "HT156",
-			"local_notes": "<script>isNaN(\"@Acc [1-5]@\")?\"@Acc [1-5]@\":signedValue(\"@Acc [1-5]@\")</script> Acc<script>if (Math.abs(~~\"@Acc [1-5]@\")>2) {\", -1 Bulk\"} else {\"\"}</script>; \nMagnification <script>2 ** ~~\"@Acc [1-5]@\"</script>×",
+			"local_notes": "@Acc|+1|+2|+3|+4|+5@ Acc<script>if (\"@Acc|+1|+2|+3|+4|+5@\">2) {\", -1 Bulk\"} else {\"\"}</script>; Magnification <script>2 ** \"@Acc|+1|+2|+3|+4|+5@\"</script>×",
 			"tech_level": "6",
 			"tags": [
 				"Firearm Accessories"
 			],
-			"base_value": "Math.max(Math.abs(~~\"@Acc [1-5]@\"),1)*125",
+			"base_value": "~~\"@Acc|+1|+2|+3|+4|+5@\"*125",
 			"base_weight": "1.5 lb",
+			"replacements": {
+				"Acc|+1|+2|+3|+4|+5": "+1"
+			},
 			"quantity": 1,
 			"calc": {
 				"value": 125,
 				"extended_value": 125,
 				"weight": "1.5 lb",
 				"extended_weight": "1.5 lb",
-				"resolved_notes": "@Acc [1-5]@ Acc; \nMagnification 1×"
+				"resolved_notes": "+1 Acc; Magnification 2×"
 			}
 		},
 		{
 			"id": "e-EMLXiFK40X8TOH1",
 			"description": "Fixed-Power Scope",
 			"reference": "HT156",
-			"local_notes": "<script>isNaN(\"@Acc [1-5]@\")?\"@Acc [1-5]@\":signedValue(\"@Acc [1-5]@\")</script> Acc<script>if (Math.abs(~~\"@Acc [1-5]@\")>2) {\", -1 Bulk\"} else {\"\"}</script>; \nMagnification <script>2 ** ~~\"@Acc [1-5]@\"</script>×",
+			"local_notes": "@Acc|+1|+2|+3|+4|+5@ Acc<script>if (\"@Acc|+1|+2|+3|+4|+5@\">2) {\", -1 Bulk\"} else {\"\"}</script>; Magnification <script>2 ** \"@Acc|+1|+2|+3|+4|+5@\"</script>×",
 			"tech_level": "7",
 			"tags": [
 				"Firearm Accessories"
 			],
-			"base_value": "Math.max(Math.abs(~~\"@Acc [1-5]@\"),1)*150",
+			"base_value": "~~\"@Acc|+1|+2|+3|+4|+5@\"*150",
 			"base_weight": "1 lb",
+			"replacements": {
+				"Acc|+1|+2|+3|+4|+5": "+1"
+			},
 			"quantity": 1,
 			"calc": {
 				"value": 150,
 				"extended_value": 150,
 				"weight": "1 lb",
 				"extended_weight": "1 lb",
-				"resolved_notes": "@Acc [1-5]@ Acc; \nMagnification 1×"
+				"resolved_notes": "+1 Acc; Magnification 2×"
 			}
 		},
 		{
@@ -106347,40 +106356,48 @@
 			"id": "ehP9A3CGu5GXVvL5n",
 			"description": "Variable-Power Scope",
 			"reference": "HT156",
-			"local_notes": "<script>isNaN(\"@Acc 1 [0-5]@\")?\"@Acc 1 [0-5]@\":signedValue(\"@Acc 1 [0-5]@\")</script>,\n<script>isNaN(\"@Acc 2 [0-5]@\")?\"@Acc 2 [0-5]@\":signedValue(\"@Acc 2 [0-5]@\")</script>, or\n<script>isNaN(\"@Acc 3 [0-5]@\")?\"@Acc 3 [0-5]@\":signedValue(\"@Acc 3 [0-5]@\")</script> Acc; <script>if (Math.max(Math.abs(~~\"@Acc 1 [0-5]@\"),Math.abs(~~\"@Acc 2 [0-5]@\"),Math.abs(~~\"@Acc 3 [0-5]@\"))>2) {\"-1 Bulk;\"} else {\"\"}</script>\nMagnification <script>(2 ** Math.min(Math.trunc(\"@Acc 1 [0-5]@\")||Infinity,Math.trunc(\"@Acc 2 [0-5]@\")||Infinity,Math.trunc(\"@Acc 3 [0-5]@\")||Infinity)-1 || 0.5)+1</script>-<script>(2 ** Math.max(Math.trunc(\"@Acc 1 [0-5]@\")||-Infinity,Math.trunc(\"@Acc 2 [0-5]@\")||-Infinity,Math.trunc(\"@Acc 3 [0-5]@\")||-Infinity)-1 || 0.5)+1</script>×",
+			"local_notes": "<script>const list = Array(\"@Acc 1|+0|+1|+2|+3|+4|+5@\", \"@Acc 2|+0|+1|+2|+3|+4|+5@\", \"@Acc 3|+0|+1|+2|+3|+4|+5@\").filter( value => !isNaN(value) );\nlist.slice(0,-1).join(', ') + (list.length > 1 ? \" or \" : '') + list.slice(-1)\n</script> Acc; <script>if (Math.max(~~\"@Acc 1|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 2|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 3|+0|+1|+2|+3|+4|+5@\")>2) {\"-1 Bulk;\"} else {\"\"}\n</script>\nMagnification <script>const low = 2 ** Math.min(~~\"@Acc 1|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 2|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 3|+0|+1|+2|+3|+4|+5@\");\nlow-1 ? low : 1.5\n</script>–<script>\nconst high = 2 ** Math.max(~~\"@Acc 1|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 2|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 3|+0|+1|+2|+3|+4|+5@\");\nhigh-1 ? high : 1.5\n</script>×",
 			"tech_level": "7",
 			"tags": [
 				"Firearm Accessories"
 			],
-			"base_value": "Math.max(Math.abs(~~\"@Acc 1 [0-5]@\"),Math.abs(~~\"@Acc 2 [0-5]@\"),Math.abs(~~\"@Acc 3 [0-5]@\"),1)*200",
+			"base_value": "Math.max(~~\"@Acc 1|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 2|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 3|+0|+1|+2|+3|+4|+5@\", 1) * 200",
 			"base_weight": "1.5 lb",
+			"replacements": {
+				"Acc 1|+0|+1|+2|+3|+4|+5": "+0",
+				"Acc 2|+0|+1|+2|+3|+4|+5": "+1"
+			},
 			"quantity": 1,
 			"calc": {
 				"value": 200,
 				"extended_value": 200,
 				"weight": "1.5 lb",
 				"extended_weight": "1.5 lb",
-				"resolved_notes": "@Acc 1 [0-5]@,\n@Acc 2 [0-5]@, or\n@Acc 3 [0-5]@ Acc; \nMagnification Infinity-0×"
+				"resolved_notes": "+0 or +1 Acc; \nMagnification 1.5–2×"
 			}
 		},
 		{
 			"id": "eei18zqcAi9KjgAIt",
 			"description": "Variable-Power Scope",
 			"reference": "HT156",
-			"local_notes": "<script>isNaN(\"@Acc 1 [0-5]@\")?\"@Acc 1 [0-5]@\":signedValue(\"@Acc 1 [0-5]@\")</script>,\n<script>isNaN(\"@Acc 2 [0-5]@\")?\"@Acc 2 [0-5]@\":signedValue(\"@Acc 2 [0-5]@\")</script>, or\n<script>isNaN(\"@Acc 3 [0-5]@\")?\"@Acc 3 [0-5]@\":signedValue(\"@Acc 3 [0-5]@\")</script> Acc; <script>if (Math.max(Math.abs(~~\"@Acc 1 [0-5]@\"),Math.abs(~~\"@Acc 2 [0-5]@\"),Math.abs(~~\"@Acc 3 [0-5]@\"))>2) {\"-1 Bulk;\"} else {\"\"}</script>\nMagnification <script>(2 ** Math.min(Math.trunc(\"@Acc 1 [0-5]@\")||Infinity,Math.trunc(\"@Acc 2 [0-5]@\")||Infinity,Math.trunc(\"@Acc 3 [0-5]@\")||Infinity)-1 || 0.5)+1</script>-<script>(2 ** Math.max(Math.trunc(\"@Acc 1 [0-5]@\")||-Infinity,Math.trunc(\"@Acc 2 [0-5]@\")||-Infinity,Math.trunc(\"@Acc 3 [0-5]@\")||-Infinity)-1 || 0.5)+1</script>×",
+			"local_notes": "<script>const list = Array(\"@Acc 1|+0|+1|+2|+3|+4|+5@\", \"@Acc 2|+0|+1|+2|+3|+4|+5@\", \"@Acc 3|+0|+1|+2|+3|+4|+5@\").filter( value => !isNaN(value) );\nlist.slice(0,-1).join(', ') + (list.length > 1 ? \" or \" : '') + list.slice(-1)\n</script> Acc; <script>if (Math.max(~~\"@Acc 1|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 2|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 3|+0|+1|+2|+3|+4|+5@\")>2) {\"-1 Bulk;\"} else {\"\"}\n</script>\nMagnification <script>const low = 2 ** Math.min(~~\"@Acc 1|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 2|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 3|+0|+1|+2|+3|+4|+5@\");\nlow-1 ? low : 1.5\n</script>–<script>\nconst high = 2 ** Math.max(~~\"@Acc 1|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 2|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 3|+0|+1|+2|+3|+4|+5@\");\nhigh-1 ? high : 1.5\n</script>×",
 			"tech_level": "8",
 			"tags": [
 				"Firearm Accessories"
 			],
-			"base_value": "Math.max(Math.abs(~~\"@Acc 1 [0-5]@\"),Math.abs(~~\"@Acc 2 [0-5]@\"),Math.abs(~~\"@Acc 3 [0-5]@\"),1)*250",
+			"base_value": "Math.max(~~\"@Acc 1|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 2|+0|+1|+2|+3|+4|+5@\", ~~\"@Acc 3|+0|+1|+2|+3|+4|+5@\", 1)*250",
 			"base_weight": "1 lb",
+			"replacements": {
+				"Acc 1|+0|+1|+2|+3|+4|+5": "+0",
+				"Acc 2|+0|+1|+2|+3|+4|+5": "+1"
+			},
 			"quantity": 1,
 			"calc": {
 				"value": 250,
 				"extended_value": 250,
 				"weight": "1 lb",
 				"extended_weight": "1 lb",
-				"resolved_notes": "@Acc 1 [0-5]@,\n@Acc 2 [0-5]@, or\n@Acc 3 [0-5]@ Acc; \nMagnification Infinity-0×"
+				"resolved_notes": "+0 or +1 Acc; \nMagnification 1.5–2×"
 			}
 		},
 		{


### PR DESCRIPTION
Version 2.0 of #463

Previously, the scripts here were comically bulky to galvanize against inputs outside the expected 0-5 range (including non-numbers); now that GCS supports limiting `@substitutions@` to a dropdown, most of this clunky safety bloat is no longer necessary.

In short, this PR changes the code from;

> `if (@Acc@ is a number, and is not a NaN, and is not something ridiculous, and please please please don't break the script) then (doMath) else (NukeEverything)`

to:

> `remember @Acc|1|2|3|4|5@ is a number, then doMath, then makeItPretty<3`

Regarding that last part, Variable-Power Scopes now display only set Acc values, hiding un-set ones. Works in any combination, and breaks _only slightly_ if none are set;

<img width="544" height="179" alt="image" src="https://github.com/user-attachments/assets/ce323a22-4194-4032-a696-30d25712b041" />

> Roll of Honor:
_@​LeeSaferite_ for making this possible with their amazing _richardwilkes/gcs​#1113_
_[Negative-Magnification Scope](https://github.com/user-attachments/assets/8512b88e-de65-4279-a211-6acc3408690f)_, brutally murdered but never forgotten ;(
