### PR TITLE
Cycle TID values for duplicate records

### DIFF
--- a/Library/Aliens/Sparrials/Animals/Chiora - Tamed.gcs
+++ b/Library/Aliens/Sparrials/Animals/Chiora - Tamed.gcs
@@ -583,7 +583,7 @@
 	],
 	"traits": [
 		{
-			"id": "tL2LFozYkmkTGVo40",
+			"id": "tYIIifKTzgZCPP0UX",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -612,7 +612,7 @@
 			}
 		},
 		{
-			"id": "tEc-6q036gEXysBCo",
+			"id": "ts1sCVfyYqgrS2YU7",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -723,7 +723,7 @@
 			}
 		},
 		{
-			"id": "t5Lhwqhj30RDFX9Dd",
+			"id": "tXKc5hEh2dSqA-Eco",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -952,7 +952,7 @@
 			}
 		},
 		{
-			"id": "tB2eNRr-hp3nkALPr",
+			"id": "tu2MqNXWvV2u4uxpW",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1029,7 +1029,7 @@
 	],
 	"skills": [
 		{
-			"id": "s09ifzh6AxsS8oGIY",
+			"id": "sfqlNJEgdKto87h2Y",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1066,7 +1066,7 @@
 			}
 		},
 		{
-			"id": "svFzDmMUZlZYKcv9C",
+			"id": "sFRn8WXKpd6-OXbGt",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1106,7 +1106,7 @@
 			}
 		},
 		{
-			"id": "suVEnewuBdPVjljX9",
+			"id": "sHZlZtDV5a9xb-ioJ",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Aliens/Sparrials/Animals/Chiora - Wild.gcs
+++ b/Library/Aliens/Sparrials/Animals/Chiora - Wild.gcs
@@ -583,7 +583,7 @@
 	],
 	"traits": [
 		{
-			"id": "tL2LFozYkmkTGVo40",
+			"id": "tkezzLvXhMHF2TKrq",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -612,7 +612,7 @@
 			}
 		},
 		{
-			"id": "tEc-6q036gEXysBCo",
+			"id": "tplzodfCtqXF3uvTw",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -723,7 +723,7 @@
 			}
 		},
 		{
-			"id": "t5Lhwqhj30RDFX9Dd",
+			"id": "tzU_R5E-r9H9FbId9",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -954,7 +954,7 @@
 			}
 		},
 		{
-			"id": "tB2eNRr-hp3nkALPr",
+			"id": "tUAdf2KPwaPBYEKDz",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1031,7 +1031,7 @@
 	],
 	"skills": [
 		{
-			"id": "s09ifzh6AxsS8oGIY",
+			"id": "sfo9LcDQ6If6D0oG_",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1068,7 +1068,7 @@
 			}
 		},
 		{
-			"id": "svFzDmMUZlZYKcv9C",
+			"id": "sgT-VhSNLhdhZ7ARy",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1108,7 +1108,7 @@
 			}
 		},
 		{
-			"id": "suVEnewuBdPVjljX9",
+			"id": "sggsg0rfxoX2lBxEx",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Dungeon Fantasy RPG/Classes/Scout.gct
+++ b/Library/Dungeon Fantasy RPG/Classes/Scout.gct
@@ -875,7 +875,7 @@
 									}
 								},
 								{
-									"id": "tdP0zMkulgqEqwWaz",
+									"id": "t2GTlQRRA3_GOnwkE",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Martial Arts/Martial Arts Traits.adq",

--- a/Library/Dungeon Fantasy RPG/Classes/Thief.gct
+++ b/Library/Dungeon Fantasy RPG/Classes/Thief.gct
@@ -604,7 +604,7 @@
 									}
 								},
 								{
-									"id": "tNR6WXBZPsaTF8CpI",
+									"id": "tINp3CLUBJYwwKny8",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 20/Demon-Slayer.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 20/Demon-Slayer.gct
@@ -15,7 +15,7 @@
 					"name": "Attributes",
 					"children": [
 						{
-							"id": "tJeSN7v41E4jwyqEt",
+							"id": "tlb08NI5U2A7Evxi4",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set\\Basic Set Traits.adq",
@@ -176,7 +176,7 @@
 					"name": "Secondary Characteristics",
 					"children": [
 						{
-							"id": "tN1-akCWAHGchslJP",
+							"id": "tHGjEUT4871uFaMaK",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set\\Basic Set Traits.adq",
@@ -1069,7 +1069,7 @@
 									}
 								},
 								{
-									"id": "tusdlmBkzDELlz6oV",
+									"id": "tSn1scP-spaRw91Yw",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1198,7 +1198,7 @@
 									}
 								},
 								{
-									"id": "tlAXU-ZKWyE3u6BQt",
+									"id": "t1E74fenax_34Lsnw",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1303,7 +1303,7 @@
 									"name": "Luck OR Extraordinary Luck",
 									"children": [
 										{
-											"id": "tNhGxsnF5p9CmYgzU",
+											"id": "tvSD7-F_mY92ekqyo",
 											"source": {
 												"library": "richardwilkes/gcs_master_library",
 												"path": "Basic Set\\Basic Set Traits.adq",
@@ -1360,7 +1360,7 @@
 											}
 										},
 										{
-											"id": "tHXJ5rsnhTc3j3A7r",
+											"id": "tA6bzjRs9xIfkS-qn",
 											"source": {
 												"library": "richardwilkes/gcs_master_library",
 												"path": "Basic Set\\Basic Set Traits.adq",
@@ -1422,7 +1422,7 @@
 									}
 								},
 								{
-									"id": "tIJxyBbSz9DG_lhSg",
+									"id": "thrRRFr4w2s0uwV9F",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1601,7 +1601,7 @@
 									}
 								},
 								{
-									"id": "tdQlvVrCiD-rFzvZ2",
+									"id": "tEmVbI3iSf119wt0m",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1654,7 +1654,7 @@
 									}
 								},
 								{
-									"id": "tkbW-Is12ncIHy8N0",
+									"id": "t5hYq8z8RxFblJFks",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1817,7 +1817,7 @@
 					"name": "Class Disadvantages (-45 points)",
 					"children": [
 						{
-							"id": "ttulAseBHSyHX_jBv",
+							"id": "terVXM41Mh8oGbEsL",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set\\Basic Set Traits.adq",
@@ -1859,7 +1859,7 @@
 							"name": "Another -15 points chosen from more severe Obsession or",
 							"children": [
 								{
-									"id": "tvAB6FMoi47iMaJlp",
+									"id": "tlMut8PHxF-BopGTL",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1883,7 +1883,7 @@
 									"name": "Disciplines of Faith (Ritualism OR Mysticism)",
 									"children": [
 										{
-											"id": "tZorqQx5twB9x3DsS",
+											"id": "ttJZGj1nYf4LnFNQ8",
 											"source": {
 												"library": "richardwilkes/gcs_master_library",
 												"path": "Basic Set\\Basic Set Traits.adq",
@@ -1901,7 +1901,7 @@
 											}
 										},
 										{
-											"id": "tALr8O9cwzFPXUF9G",
+											"id": "tiUGA9T84poSd9Cz9",
 											"source": {
 												"library": "richardwilkes/gcs_master_library",
 												"path": "Basic Set\\Basic Set Traits.adq",
@@ -1924,7 +1924,7 @@
 									}
 								},
 								{
-									"id": "tbQ6dKsRxG17U1JRL",
+									"id": "tM6mCNa7gN2m0L_qW",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2000,7 +2000,7 @@
 									}
 								},
 								{
-									"id": "tnJtgJs7AAVcHkPcZ",
+									"id": "tkH5D0TrCzD_3-9SK",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2222,7 +2222,7 @@
 									}
 								},
 								{
-									"id": "tOw6sPHtXnz0qUF0t",
+									"id": "tT9u305Yhs5SRjPkq",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2313,7 +2313,7 @@
 									}
 								},
 								{
-									"id": "tjN8X-ojcvFN6lq3H",
+									"id": "tUwlfpt4PyUds9cwv",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2333,7 +2333,7 @@
 									}
 								},
 								{
-									"id": "tI1GMRuvCFTUYp_-G",
+									"id": "treZs4MEVbJClP9lN",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2354,7 +2354,7 @@
 									}
 								},
 								{
-									"id": "tD9fzBm8oKgAvCiic",
+									"id": "t1v0qdF2Z1PkNnYdN",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2379,7 +2379,7 @@
 									}
 								},
 								{
-									"id": "tZ5bBpqrTSKLJPp9_",
+									"id": "tXH2zT-xwL31jOyD8",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2411,7 +2411,7 @@
 									}
 								},
 								{
-									"id": "t6wBJ0HBnO3IVd3Nk",
+									"id": "t9T_QrGHhowTlb2O5",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2431,7 +2431,7 @@
 									}
 								},
 								{
-									"id": "t7ixb6PZ1iEAXi2UT",
+									"id": "toTk-pGAVqcKvS3NP",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2491,7 +2491,7 @@
 									}
 								},
 								{
-									"id": "tUJfdaTn3jwXlYXUO",
+									"id": "tyHk5bcSFVnHFH6E5",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2516,7 +2516,7 @@
 									}
 								},
 								{
-									"id": "t94kJKq-cT-AwxPVH",
+									"id": "tLSbVqws9JiKsd6bW",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2825,7 +2825,7 @@
 					},
 					"children": [
 						{
-							"id": "sNwSWi6krlHGNNtZX",
+							"id": "sUxLxtULq_OZqEbo5",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set\\Basic Set Skills.skl",
@@ -2848,7 +2848,7 @@
 							"points": 8
 						},
 						{
-							"id": "sBnxoIz0lVvPs9INL",
+							"id": "s8_s47E15mjkuXCFX",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set\\Basic Set Skills.skl",
@@ -3387,7 +3387,7 @@
 									]
 								},
 								{
-									"id": "sZQwQRtqawxWAyL2G",
+									"id": "sOHsfifn_1IhNBg6h",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Skills.skl",
@@ -3438,7 +3438,7 @@
 					"points": 2
 				},
 				{
-					"id": "sJnRG-IjTkBTqrYrJ",
+					"id": "sa7ilA9Nh7VSUKFi7",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -3582,7 +3582,7 @@
 			},
 			"children": [
 				{
-					"id": "sE2bLbjL6mvgcx2p6",
+					"id": "saM_wpFCAJYCMqTWY",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -3615,7 +3615,7 @@
 					"points": 1
 				},
 				{
-					"id": "sGsF9oT7_VmtqxO7V",
+					"id": "szWSnmnAsphZy7y-S",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -3651,7 +3651,7 @@
 					"points": 1
 				},
 				{
-					"id": "sMzk9Q_yFLgJRGndL",
+					"id": "sNmQrpdMyZZiR6Png",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -3677,7 +3677,7 @@
 					"points": 1
 				},
 				{
-					"id": "sYapXattHEyn95c8Z",
+					"id": "s0c5-AHfiVwfxl-cD",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -3742,7 +3742,7 @@
 					"points": 1
 				},
 				{
-					"id": "s6NsJxxwW7aPfhaTF",
+					"id": "sGULYkNMCjI6YJqYu",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -3794,7 +3794,7 @@
 					"points": 1
 				},
 				{
-					"id": "susjFjzsiqW_et5Rr",
+					"id": "sZPYtG0HI8omk5hW7",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -3822,7 +3822,7 @@
 					"points": 1
 				},
 				{
-					"id": "smjqk8ksyIhAg7lQu",
+					"id": "sOt0a9-lekDKvhs_V",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -4000,7 +4000,7 @@
 					"points": 1
 				},
 				{
-					"id": "s26ojyJDkJdTQlQ5X",
+					"id": "sz7c04NFSkZJ9Lo5Q",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",

--- a/Library/Dungeon Fantasy/Dungeon Fantasy 20/Undead-Slayer.gct
+++ b/Library/Dungeon Fantasy/Dungeon Fantasy 20/Undead-Slayer.gct
@@ -15,7 +15,7 @@
 					"name": "Attributes",
 					"children": [
 						{
-							"id": "tJeSN7v41E4jwyqEt",
+							"id": "tyATt7M_4iqhk56LM",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set\\Basic Set Traits.adq",
@@ -176,7 +176,7 @@
 					"name": "Secondary Characteristics",
 					"children": [
 						{
-							"id": "tN1-akCWAHGchslJP",
+							"id": "tZpVSeUB0cxTxHTd3",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set\\Basic Set Traits.adq",
@@ -797,7 +797,7 @@
 									}
 								},
 								{
-									"id": "tusdlmBkzDELlz6oV",
+									"id": "t_InOE0rlIzpVIgz9",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -929,7 +929,7 @@
 									}
 								},
 								{
-									"id": "tlAXU-ZKWyE3u6BQt",
+									"id": "tuvrBdpPa6lXuCz-g",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1002,7 +1002,7 @@
 									}
 								},
 								{
-									"id": "tNhGxsnF5p9CmYgzU",
+									"id": "t3R5ZXn75_rutBKHw",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1059,7 +1059,7 @@
 									}
 								},
 								{
-									"id": "tHXJ5rsnhTc3j3A7r",
+									"id": "tRJYlCigea4PgRO2H",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1137,7 +1137,7 @@
 									}
 								},
 								{
-									"id": "tIJxyBbSz9DG_lhSg",
+									"id": "t03KTKTb3Rsbb9hUE",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1324,7 +1324,7 @@
 									}
 								},
 								{
-									"id": "tdQlvVrCiD-rFzvZ2",
+									"id": "thU6PYD8i8pDityS4",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1413,7 +1413,7 @@
 									}
 								},
 								{
-									"id": "tkbW-Is12ncIHy8N0",
+									"id": "tfGO2VxqPWOdrNK_X",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1578,7 +1578,7 @@
 					"name": "Class Disadvantages (-50 points)",
 					"children": [
 						{
-							"id": "ttulAseBHSyHX_jBv",
+							"id": "tyYNZoHOP_kG1giBE",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set\\Basic Set Traits.adq",
@@ -1620,7 +1620,7 @@
 							"name": "Another -20 points chosen from more severe Obsession or",
 							"children": [
 								{
-									"id": "tvAB6FMoi47iMaJlp",
+									"id": "tZmmNVNvhUxBsyx24",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1640,7 +1640,7 @@
 									}
 								},
 								{
-									"id": "tZorqQx5twB9x3DsS",
+									"id": "tK-ATLzBizIYfFtr0",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1658,7 +1658,7 @@
 									}
 								},
 								{
-									"id": "tALr8O9cwzFPXUF9G",
+									"id": "tmqlcBmwrOpCmmeR6",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1676,7 +1676,7 @@
 									}
 								},
 								{
-									"id": "tbQ6dKsRxG17U1JRL",
+									"id": "tmi7S0Iuh-xKf-aK7",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1696,7 +1696,7 @@
 									}
 								},
 								{
-									"id": "tnJtgJs7AAVcHkPcZ",
+									"id": "tKBtr1Kt_PnWYuRsj",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1894,7 +1894,7 @@
 									}
 								},
 								{
-									"id": "tOw6sPHtXnz0qUF0t",
+									"id": "tq8r3RWfpKBR2ldYR",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1937,7 +1937,7 @@
 							"name": "A further -20 points chosen from the previous list or",
 							"children": [
 								{
-									"id": "tjN8X-ojcvFN6lq3H",
+									"id": "tCuuMYWsB_G2He_wG",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1957,7 +1957,7 @@
 									}
 								},
 								{
-									"id": "tI1GMRuvCFTUYp_-G",
+									"id": "tPU6cniH15eDVV9za",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -1978,7 +1978,7 @@
 									}
 								},
 								{
-									"id": "tD9fzBm8oKgAvCiic",
+									"id": "td2VdKOhxYBBCNMOK",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2003,7 +2003,7 @@
 									}
 								},
 								{
-									"id": "tZ5bBpqrTSKLJPp9_",
+									"id": "tzMXQTHbEl5LbLTJ2",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2035,7 +2035,7 @@
 									}
 								},
 								{
-									"id": "t6wBJ0HBnO3IVd3Nk",
+									"id": "tO-w7ILiYQ-mgIaR8",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2055,7 +2055,7 @@
 									}
 								},
 								{
-									"id": "t7ixb6PZ1iEAXi2UT",
+									"id": "tZ3Xg8uhVAQbxJsUR",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2115,7 +2115,7 @@
 									}
 								},
 								{
-									"id": "tUJfdaTn3jwXlYXUO",
+									"id": "tcxrgMAiJbAmhGVk4",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2140,7 +2140,7 @@
 									}
 								},
 								{
-									"id": "t94kJKq-cT-AwxPVH",
+									"id": "tvrR8KI0LxdndCoEL",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Traits.adq",
@@ -2391,7 +2391,7 @@
 					},
 					"children": [
 						{
-							"id": "sNwSWi6krlHGNNtZX",
+							"id": "sCqBCY6NkZgPYfELD",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set\\Basic Set Skills.skl",
@@ -2414,7 +2414,7 @@
 							"points": 4
 						},
 						{
-							"id": "sBnxoIz0lVvPs9INL",
+							"id": "sWF_L3G-oqR1tUeWa",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set\\Basic Set Skills.skl",
@@ -2827,7 +2827,7 @@
 									]
 								},
 								{
-									"id": "sZQwQRtqawxWAyL2G",
+									"id": "sxfFT-xzFdlkMVMOA",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set\\Basic Set Skills.skl",
@@ -2880,7 +2880,7 @@
 					"points": 1
 				},
 				{
-					"id": "sJnRG-IjTkBTqrYrJ",
+					"id": "swFWFWsSJ07Ss8yxx",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -2971,7 +2971,7 @@
 			},
 			"children": [
 				{
-					"id": "sE2bLbjL6mvgcx2p6",
+					"id": "sC85JUOmrtQbSont8",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -3004,7 +3004,7 @@
 					"points": 1
 				},
 				{
-					"id": "sGsF9oT7_VmtqxO7V",
+					"id": "sWKfg1SXa1kYWYOff",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -3107,7 +3107,7 @@
 					"points": 1
 				},
 				{
-					"id": "sMzk9Q_yFLgJRGndL",
+					"id": "s92KjgRqGUkG-WHns",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -3133,7 +3133,7 @@
 					"points": 1
 				},
 				{
-					"id": "sYapXattHEyn95c8Z",
+					"id": "s5wN6aispo_AjTFxK",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -3215,7 +3215,7 @@
 					"points": 1
 				},
 				{
-					"id": "s6NsJxxwW7aPfhaTF",
+					"id": "sZABeEoWTXrOVu-Ei",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -3267,7 +3267,7 @@
 					"points": 1
 				},
 				{
-					"id": "susjFjzsiqW_et5Rr",
+					"id": "sClHAMFfgFUtF0LW1",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -3295,7 +3295,7 @@
 					"points": 1
 				},
 				{
-					"id": "smjqk8ksyIhAg7lQu",
+					"id": "sg8l23mSoHYW9rcZe",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",
@@ -3535,7 +3535,7 @@
 					"points": 1
 				},
 				{
-					"id": "s26ojyJDkJdTQlQ5X",
+					"id": "sZDsVXQzapXrgIZrb",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set\\Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Ash Creatures/Ascended Sleeper.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Ash Creatures/Ascended Sleeper.gcs
@@ -1159,7 +1159,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mq0hmwFi7oami6HoT",
+							"id": "mFiLlX7wigI9CCs53",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
@@ -2154,7 +2154,7 @@
 							"levels": 3
 						},
 						{
-							"id": "mm248u5Ys_Q4kUlrS",
+							"id": "mqoFs85WQBOcVAGFY",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -2186,7 +2186,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "tt-WYlq5uLRgosUtj",
+					"id": "t6UwfHbuElBFRSa9V",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2552,7 +2552,7 @@
 					}
 				},
 				{
-					"id": "ttKH9VnHI-331gvT1",
+					"id": "tUWVFQPMa1EaRjn44",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2975,7 +2975,7 @@
 					}
 				},
 				{
-					"id": "tfXQeD2jbjNtGrNsg",
+					"id": "tTSalkBCH62Ox68xf",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3065,7 +3065,7 @@
 					}
 				},
 				{
-					"id": "t-7e8rQXD7homgOyO",
+					"id": "tgh05aLRjzMVrE3e7",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3084,7 +3084,7 @@
 					}
 				},
 				{
-					"id": "tLukhPwDUJKf_Yq7R",
+					"id": "tjKWfZ6OC0EJWEjSf",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3103,7 +3103,7 @@
 					}
 				},
 				{
-					"id": "tLbp0wMQkBdeZ7nLf",
+					"id": "tEp8OGmNXzBV8gUma",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3301,7 +3301,7 @@
 					}
 				},
 				{
-					"id": "ti24MKG1nwlN8cMsM",
+					"id": "t3MJ8CpOkEuVd_2Fr",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3322,7 +3322,7 @@
 					}
 				},
 				{
-					"id": "t7QTNTZ_SGNzjHtJy",
+					"id": "tBmCfTZzPgEV4zg6N",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3392,7 +3392,7 @@
 					}
 				},
 				{
-					"id": "toW3GykETXFs7syLL",
+					"id": "tm1exYAPlqJKNEjse",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3455,7 +3455,7 @@
 					}
 				},
 				{
-					"id": "tzkpIr3GLUKWNfJX8",
+					"id": "tltHEUGPaX_VskjFt",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Ash Creatures/Ash Ghoul.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Ash Creatures/Ash Ghoul.gcs
@@ -2154,7 +2154,7 @@
 							"levels": 3
 						},
 						{
-							"id": "mm248u5Ys_Q4kUlrS",
+							"id": "mbBRICZaUI0-aUoPy",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -2186,7 +2186,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "tt-WYlq5uLRgosUtj",
+					"id": "tpSPi8YMCHWEsJy4O",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2552,7 +2552,7 @@
 					}
 				},
 				{
-					"id": "ttKH9VnHI-331gvT1",
+					"id": "tpVqqxy2nQbLX6Iyo",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2975,7 +2975,7 @@
 					}
 				},
 				{
-					"id": "tfXQeD2jbjNtGrNsg",
+					"id": "tBDdncDJyRlZuK8T4",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3065,7 +3065,7 @@
 					}
 				},
 				{
-					"id": "t-7e8rQXD7homgOyO",
+					"id": "t8mzs5QGb9RExTSZn",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3084,7 +3084,7 @@
 					}
 				},
 				{
-					"id": "tLukhPwDUJKf_Yq7R",
+					"id": "tdSf0aCIFpXoA8tQK",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3103,7 +3103,7 @@
 					}
 				},
 				{
-					"id": "tLbp0wMQkBdeZ7nLf",
+					"id": "tO3_jN12ngZp7SAql",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3245,7 +3245,7 @@
 					}
 				},
 				{
-					"id": "ti24MKG1nwlN8cMsM",
+					"id": "trALFD9tJ2hCO4hlD",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3266,7 +3266,7 @@
 					}
 				},
 				{
-					"id": "t7QTNTZ_SGNzjHtJy",
+					"id": "tWwGNv3k-caTn0czf",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3336,7 +3336,7 @@
 					}
 				},
 				{
-					"id": "toW3GykETXFs7syLL",
+					"id": "t865TQoJno0ui3rVg",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3399,7 +3399,7 @@
 					}
 				},
 				{
-					"id": "tzkpIr3GLUKWNfJX8",
+					"id": "tBj5a5ZJ3niwonWz4",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3469,7 +3469,7 @@
 	],
 	"skills": [
 		{
-			"id": "snH7vtw76EQWHj5u4",
+			"id": "s9KLt8mZOXmDKzi5i",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -3701,7 +3701,7 @@
 			}
 		},
 		{
-			"id": "syeWm89jeM2Vx2tGr",
+			"id": "sio3Fm0PM7bcyPu7C",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Ash Creatures/Ash Slave.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Ash Creatures/Ash Slave.gcs
@@ -1457,7 +1457,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mq0hmwFi7oami6HoT",
+							"id": "m03zRoNjiJafrnd_F",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
@@ -1810,7 +1810,7 @@
 							"levels": 3
 						},
 						{
-							"id": "mm248u5Ys_Q4kUlrS",
+							"id": "mhY9rCJ0Yx8drgdOS",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -1842,7 +1842,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "tt-WYlq5uLRgosUtj",
+					"id": "tDXxJ1GazeiCfwuaK",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2208,7 +2208,7 @@
 					}
 				},
 				{
-					"id": "ttKH9VnHI-331gvT1",
+					"id": "tQINRUNDU-iPPcNZz",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2631,7 +2631,7 @@
 					}
 				},
 				{
-					"id": "tfXQeD2jbjNtGrNsg",
+					"id": "tJvkCNOM5wBQNc193",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2721,7 +2721,7 @@
 					}
 				},
 				{
-					"id": "t-7e8rQXD7homgOyO",
+					"id": "tGF0AMeFniZNntOux",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2740,7 +2740,7 @@
 					}
 				},
 				{
-					"id": "tLukhPwDUJKf_Yq7R",
+					"id": "tkZRP2iZIG5ljLMiP",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2759,7 +2759,7 @@
 					}
 				},
 				{
-					"id": "tLbp0wMQkBdeZ7nLf",
+					"id": "t48p8ToMyAnNiinYt",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2901,7 +2901,7 @@
 					}
 				},
 				{
-					"id": "ti24MKG1nwlN8cMsM",
+					"id": "tSOuTzCUHBJcUY6SQ",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2922,7 +2922,7 @@
 					}
 				},
 				{
-					"id": "t7QTNTZ_SGNzjHtJy",
+					"id": "toljsS8kqzHO50uFB",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2992,7 +2992,7 @@
 					}
 				},
 				{
-					"id": "toW3GykETXFs7syLL",
+					"id": "tCevVQAEsqhz_xnrT",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3055,7 +3055,7 @@
 					}
 				},
 				{
-					"id": "tzkpIr3GLUKWNfJX8",
+					"id": "tWfyF63E-FD-h6RRE",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3125,7 +3125,7 @@
 	],
 	"skills": [
 		{
-			"id": "snH7vtw76EQWHj5u4",
+			"id": "sNhedHooB13Osknqc",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -3202,7 +3202,7 @@
 			}
 		},
 		{
-			"id": "syeWm89jeM2Vx2tGr",
+			"id": "sFajj9Rn6YmORxSnO",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Ash Creatures/Ash Vampire.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Ash Creatures/Ash Vampire.gcs
@@ -2866,7 +2866,7 @@
 							"levels": 3
 						},
 						{
-							"id": "mm248u5Ys_Q4kUlrS",
+							"id": "mWSJbIKwaYl0-5YeT",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -3045,7 +3045,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "ttKH9VnHI-331gvT1",
+					"id": "tDDtaE5beThf72hJ2",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3490,7 +3490,7 @@
 					}
 				},
 				{
-					"id": "tfXQeD2jbjNtGrNsg",
+					"id": "tazQHCjo_G15znrLU",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3580,7 +3580,7 @@
 					}
 				},
 				{
-					"id": "t-7e8rQXD7homgOyO",
+					"id": "txCnzZ0Y5kzb_mtOm",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3599,7 +3599,7 @@
 					}
 				},
 				{
-					"id": "tLukhPwDUJKf_Yq7R",
+					"id": "tgufZZvieUWWS5zf1",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3713,7 +3713,7 @@
 					}
 				},
 				{
-					"id": "tLbp0wMQkBdeZ7nLf",
+					"id": "tLD5lMiAEuFFhYqa3",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -4116,7 +4116,7 @@
 					}
 				},
 				{
-					"id": "t7QTNTZ_SGNzjHtJy",
+					"id": "t10PgGBMsHxTdgHyl",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -4186,7 +4186,7 @@
 					}
 				},
 				{
-					"id": "toW3GykETXFs7syLL",
+					"id": "tl2KLUM0bNFf7Uk3L",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -4293,7 +4293,7 @@
 					}
 				},
 				{
-					"id": "tzkpIr3GLUKWNfJX8",
+					"id": "tGeqLjklVLorZe1rP",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Ash Creatures/Ash Zombie.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Ash Creatures/Ash Zombie.gcs
@@ -999,7 +999,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "tiG82bjwByzttGTco",
+					"id": "tfz-dExSJa4bRLZ2F",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1365,7 +1365,7 @@
 					}
 				},
 				{
-					"id": "tYfMINyzLE9Xb_km7",
+					"id": "tV_qWVl1Bazxax3Sb",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1788,7 +1788,7 @@
 					}
 				},
 				{
-					"id": "t1pZHy8gdOnyC9pBM",
+					"id": "tp4oOofhnBnkZ1gVN",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1878,7 +1878,7 @@
 					}
 				},
 				{
-					"id": "tJgWR9H_wo89aXAmB",
+					"id": "tzyK5A92UA4Mau1YJ",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1897,7 +1897,7 @@
 					}
 				},
 				{
-					"id": "tR_D2UT6q8jjTZUQ8",
+					"id": "tvcyJNr91bwqHDLZx",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2079,7 +2079,7 @@
 					}
 				},
 				{
-					"id": "tI_iWjhUIG2-bnYS-",
+					"id": "tOv7JsX6uTFH6zoxi",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2149,7 +2149,7 @@
 					}
 				},
 				{
-					"id": "tTKxQm8NwYNVB5PhQ",
+					"id": "t_ipCK9AZ_fjF3S60",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2263,7 +2263,7 @@
 			}
 		},
 		{
-			"id": "snH7vtw76EQWHj5u4",
+			"id": "s22a_-JPZvpsThuYW",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2300,7 +2300,7 @@
 			}
 		},
 		{
-			"id": "syeWm89jeM2Vx2tGr",
+			"id": "sc-KVJbTGHhPdX22S",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Ash Creatures/Corprus Stalker.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Ash Creatures/Corprus Stalker.gcs
@@ -742,7 +742,7 @@
 			}
 		},
 		{
-			"id": "tiG82bjwByzttGTco",
+			"id": "tW3W42FDGMLpk00JE",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1108,7 +1108,7 @@
 			}
 		},
 		{
-			"id": "tYfMINyzLE9Xb_km7",
+			"id": "ty8iHpo4yFvdNRatd",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1370,7 +1370,7 @@
 			}
 		},
 		{
-			"id": "t1pZHy8gdOnyC9pBM",
+			"id": "t-QjjjKUYE4o_IxP4",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1460,7 +1460,7 @@
 			}
 		},
 		{
-			"id": "tJgWR9H_wo89aXAmB",
+			"id": "twOIXSY8FVmrWqt2n",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1479,7 +1479,7 @@
 			}
 		},
 		{
-			"id": "tR_D2UT6q8jjTZUQ8",
+			"id": "tU-aT235WonccmPkN",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1589,7 +1589,7 @@
 			}
 		},
 		{
-			"id": "tI_iWjhUIG2-bnYS-",
+			"id": "tbwcJjZ-C8JnqRe_z",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1659,7 +1659,7 @@
 			}
 		},
 		{
-			"id": "tTKxQm8NwYNVB5PhQ",
+			"id": "tTIIluTwhnHP5UKHS",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1724,7 +1724,7 @@
 	],
 	"skills": [
 		{
-			"id": "snH7vtw76EQWHj5u4",
+			"id": "s92icVbkUy4o8u8gD",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1798,7 +1798,7 @@
 			}
 		},
 		{
-			"id": "syeWm89jeM2Vx2tGr",
+			"id": "s1UWEfNQcfC04TTwu",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Ash Creatures/Lame Corprus.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Ash Creatures/Lame Corprus.gcs
@@ -604,7 +604,7 @@
 	],
 	"traits": [
 		{
-			"id": "tiG82bjwByzttGTco",
+			"id": "taIcgeK2xwtPNHGTX",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -970,7 +970,7 @@
 			}
 		},
 		{
-			"id": "tYfMINyzLE9Xb_km7",
+			"id": "tRW3ymucy5a6hsa1X",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1232,7 +1232,7 @@
 			}
 		},
 		{
-			"id": "t1pZHy8gdOnyC9pBM",
+			"id": "t_nl0WBOYxDUNMrbj",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1322,7 +1322,7 @@
 			}
 		},
 		{
-			"id": "tJgWR9H_wo89aXAmB",
+			"id": "tYatSERVRQMV-AA-Z",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1341,7 +1341,7 @@
 			}
 		},
 		{
-			"id": "tR_D2UT6q8jjTZUQ8",
+			"id": "ta3nuIRlf6-YjLrwP",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1519,7 +1519,7 @@
 			}
 		},
 		{
-			"id": "tI_iWjhUIG2-bnYS-",
+			"id": "tWi8vtOa-DCQq4x9F",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1589,7 +1589,7 @@
 			}
 		},
 		{
-			"id": "tTKxQm8NwYNVB5PhQ",
+			"id": "tc3GtjmU1Y0Iya2Gk",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1654,7 +1654,7 @@
 	],
 	"skills": [
 		{
-			"id": "snH7vtw76EQWHj5u4",
+			"id": "sVysOtB2K0Mv8jFN7",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1691,7 +1691,7 @@
 			}
 		},
 		{
-			"id": "syeWm89jeM2Vx2tGr",
+			"id": "s0rdEl9llJJrqAG_c",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Alit.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Alit.gcs
@@ -1037,7 +1037,7 @@
 			}
 		},
 		{
-			"id": "tvwRzrZ5IHxcLZzCE",
+			"id": "tOGsuZigkgEMH_vN8",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1088,7 +1088,7 @@
 			}
 		},
 		{
-			"id": "tEwPzSoPpbymmLDW3",
+			"id": "t34P1h0weMk_JJEms",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Chaurus Hunter.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Chaurus Hunter.gcs
@@ -858,7 +858,7 @@
 					"cost_adj": "-10%"
 				},
 				{
-					"id": "ma0ajmulgjWswj11N",
+					"id": "mLy4_7bJ-dx3TIPO9",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -914,7 +914,7 @@
 			}
 		},
 		{
-			"id": "toiUUBUa_NPoqSZng",
+			"id": "tWsDcNLBeIL-QmoL7",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1280,7 +1280,7 @@
 			}
 		},
 		{
-			"id": "tdcH_Cv11ytqcJsYb",
+			"id": "tFyOd3cScmZQRG9OX",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1340,7 +1340,7 @@
 			}
 		},
 		{
-			"id": "twmEiLy4TSfH1OH_I",
+			"id": "t4WK41lcRNTLtnwbY",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1414,7 +1414,7 @@
 			}
 		},
 		{
-			"id": "tViYrcTmm81NksCgQ",
+			"id": "t_xwXkauKMV9Mlz4C",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1658,7 +1658,7 @@
 			}
 		},
 		{
-			"id": "t0EouG8ByYrjTWHrC",
+			"id": "t3EnAjd7gye7CTWMb",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1872,7 +1872,7 @@
 			}
 		},
 		{
-			"id": "t2YvKK0RGzffXNLT4",
+			"id": "tx6Fcc_hZw2SlDsvE",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2128,7 +2128,7 @@
 			}
 		},
 		{
-			"id": "tJrzAvdawijZerHgm",
+			"id": "tOQKlTe3J8Ugd3Vp_",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2459,7 +2459,7 @@
 	],
 	"skills": [
 		{
-			"id": "sgsLbX9l1-SDsyywQ",
+			"id": "smkdMsaWhivO0TqSh",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2582,7 +2582,7 @@
 			}
 		},
 		{
-			"id": "sGGen1VmeZQaGVQEP",
+			"id": "sIDrlzdvtwvPgxNzw",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2660,7 +2660,7 @@
 			}
 		},
 		{
-			"id": "sJQF7SD_AjMVCElmL",
+			"id": "sNg0VjyXHIlgOUwVF",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Chaurus Reaper.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Chaurus Reaper.gcs
@@ -858,7 +858,7 @@
 					"cost_adj": "-10%"
 				},
 				{
-					"id": "ma0ajmulgjWswj11N",
+					"id": "m0G2ER6GvqUxxN53d",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -914,7 +914,7 @@
 			}
 		},
 		{
-			"id": "toiUUBUa_NPoqSZng",
+			"id": "tK6defUHKUlqAKsw4",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1280,7 +1280,7 @@
 			}
 		},
 		{
-			"id": "tdcH_Cv11ytqcJsYb",
+			"id": "trYzWFf4P00uVVZpA",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1414,7 +1414,7 @@
 			}
 		},
 		{
-			"id": "tViYrcTmm81NksCgQ",
+			"id": "ttueaG4vafkHztimV",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1658,7 +1658,7 @@
 			}
 		},
 		{
-			"id": "t0EouG8ByYrjTWHrC",
+			"id": "tGNzXb8lTlnRrcJuK",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1709,7 +1709,7 @@
 			}
 		},
 		{
-			"id": "t2YvKK0RGzffXNLT4",
+			"id": "tC2zOfpxVhI0NlCfv",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1958,7 +1958,7 @@
 			}
 		},
 		{
-			"id": "tJrzAvdawijZerHgm",
+			"id": "tN01D7Ry3wMJkk3W3",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2289,7 +2289,7 @@
 	],
 	"skills": [
 		{
-			"id": "sgsLbX9l1-SDsyywQ",
+			"id": "sVYXDbkmaST_lT6Tn",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2366,7 +2366,7 @@
 			}
 		},
 		{
-			"id": "sGGen1VmeZQaGVQEP",
+			"id": "sG16hixJHc68RiiaI",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2444,7 +2444,7 @@
 			}
 		},
 		{
-			"id": "sJQF7SD_AjMVCElmL",
+			"id": "sIWAxkNlpcudPXNmh",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Chaurus.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Chaurus.gcs
@@ -858,7 +858,7 @@
 					"cost_adj": "-10%"
 				},
 				{
-					"id": "ma0ajmulgjWswj11N",
+					"id": "md-SsBYjLWyvQJxt2",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -914,7 +914,7 @@
 			}
 		},
 		{
-			"id": "toiUUBUa_NPoqSZng",
+			"id": "tiYLaDfC_brLNVX1F",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1280,7 +1280,7 @@
 			}
 		},
 		{
-			"id": "tdcH_Cv11ytqcJsYb",
+			"id": "t8wAWvngS_GqObS_R",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1340,7 +1340,7 @@
 			}
 		},
 		{
-			"id": "twmEiLy4TSfH1OH_I",
+			"id": "tKq0siFoQXpmOrk3P",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1414,7 +1414,7 @@
 			}
 		},
 		{
-			"id": "tViYrcTmm81NksCgQ",
+			"id": "tx1TSNI0lvR6vfc8D",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1658,7 +1658,7 @@
 			}
 		},
 		{
-			"id": "t0EouG8ByYrjTWHrC",
+			"id": "t1C2DK7vzBEXIpYAg",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1709,7 +1709,7 @@
 			}
 		},
 		{
-			"id": "t2YvKK0RGzffXNLT4",
+			"id": "tgwFP91U4NZTUIEc4",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1965,7 +1965,7 @@
 			}
 		},
 		{
-			"id": "tJrzAvdawijZerHgm",
+			"id": "t-1hE7kV3Y1eqPD6d",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2296,7 +2296,7 @@
 	],
 	"skills": [
 		{
-			"id": "sgsLbX9l1-SDsyywQ",
+			"id": "sLEAJQenX0Fngi21B",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2373,7 +2373,7 @@
 			}
 		},
 		{
-			"id": "sGGen1VmeZQaGVQEP",
+			"id": "sq-EvjR2hT60V8qrF",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2451,7 +2451,7 @@
 			}
 		},
 		{
-			"id": "sJQF7SD_AjMVCElmL",
+			"id": "sO6MyLDqUTuLqnHy7",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Giant Rat.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Giant Rat.gcs
@@ -552,7 +552,7 @@
 	],
 	"traits": [
 		{
-			"id": "teGVuICCMAVEx3kBM",
+			"id": "twWBkejLcylbKfCcq",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Guar, Pack.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Guar, Pack.gcs
@@ -848,7 +848,7 @@
 			}
 		},
 		{
-			"id": "t5F-jLCioV-Gn3Q4i",
+			"id": "t4kCzHTPsZhtyfvuF",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -899,7 +899,7 @@
 			}
 		},
 		{
-			"id": "tPML1Wc4f_oRzPRyl",
+			"id": "tF3kyq0fshZIDDmO-",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -928,7 +928,7 @@
 			}
 		},
 		{
-			"id": "tbGiG53J-wFz8Di5q",
+			"id": "tstzDKzYaS3bItGmH",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1221,7 +1221,7 @@
 	],
 	"skills": [
 		{
-			"id": "s8YMMNv_OX_4D1QD5",
+			"id": "s2kG4JGsaZipaNOLl",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Guar, Wild.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Guar, Wild.gcs
@@ -922,7 +922,7 @@
 			}
 		},
 		{
-			"id": "t5F-jLCioV-Gn3Q4i",
+			"id": "tu-fHvy8MtB0wJ8HV",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -973,7 +973,7 @@
 			}
 		},
 		{
-			"id": "tPML1Wc4f_oRzPRyl",
+			"id": "tc_bqJM612pdHLL7X",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1002,7 +1002,7 @@
 			}
 		},
 		{
-			"id": "tbGiG53J-wFz8Di5q",
+			"id": "t5-B1UCKvvX-WHqH3",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1296,7 +1296,7 @@
 	],
 	"skills": [
 		{
-			"id": "s8YMMNv_OX_4D1QD5",
+			"id": "sLLdYeH5XiLu_mbFd",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Kagouti.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Kagouti.gcs
@@ -1037,7 +1037,7 @@
 			}
 		},
 		{
-			"id": "tvwRzrZ5IHxcLZzCE",
+			"id": "tFfx8XgoWi5rsZAeu",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1088,7 +1088,7 @@
 			}
 		},
 		{
-			"id": "tEwPzSoPpbymmLDW3",
+			"id": "tcYBTt3ONSyEcjns5",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Kwama Queen.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Kwama Queen.gcs
@@ -929,7 +929,7 @@
 			}
 		},
 		{
-			"id": "txgJcg1Ls1Za0XA9T",
+			"id": "tds-8uUx4Xo8Rkxqk",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1296,7 +1296,7 @@
 	],
 	"skills": [
 		{
-			"id": "swLYHOu0bgNm7zm_7",
+			"id": "sWiSoR7DCfKJk1K_G",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Kwama Warrior.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Kwama Warrior.gcs
@@ -1323,7 +1323,7 @@
 			}
 		},
 		{
-			"id": "txgJcg1Ls1Za0XA9T",
+			"id": "tYfl6ntrGZrnBrARJ",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1600,7 +1600,7 @@
 	],
 	"skills": [
 		{
-			"id": "swLYHOu0bgNm7zm_7",
+			"id": "s_-hRsHtaqzJ4iL_9",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1677,7 +1677,7 @@
 			}
 		},
 		{
-			"id": "sCtyir3yYWv4nbPvX",
+			"id": "sCn9_HBJ7kpjNPQlW",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Kwama Worker.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Kwama Worker.gcs
@@ -907,7 +907,7 @@
 			}
 		},
 		{
-			"id": "txgJcg1Ls1Za0XA9T",
+			"id": "t7oU-4FfPWbUSC5O_",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1255,7 +1255,7 @@
 	],
 	"skills": [
 		{
-			"id": "swLYHOu0bgNm7zm_7",
+			"id": "sCH4QipQoSDInzrgU",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1292,7 +1292,7 @@
 			}
 		},
 		{
-			"id": "sCtyir3yYWv4nbPvX",
+			"id": "sBMBccpkc-8SqJKta",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Netch, Betty.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Netch, Betty.gcs
@@ -958,7 +958,7 @@
 			}
 		},
 		{
-			"id": "tH96hljtotid3Cixz",
+			"id": "tlajEfAqY8jwmUBNH",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1121,7 +1121,7 @@
 			}
 		},
 		{
-			"id": "tnjBxTpWgaPO9N03l",
+			"id": "teeWOUuCBEo-mTQss",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1159,7 +1159,7 @@
 			}
 		},
 		{
-			"id": "tD_QSzzSNCS0dR9o7",
+			"id": "tduysKqakiRQGqWEC",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1277,7 +1277,7 @@
 	],
 	"skills": [
 		{
-			"id": "sGNGuNNjNLYOumYeI",
+			"id": "sCdFqJ_u96zN4dfOW",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Netch, Bull.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Netch, Bull.gcs
@@ -1236,7 +1236,7 @@
 			}
 		},
 		{
-			"id": "tH96hljtotid3Cixz",
+			"id": "tz4Xc_4bQ6dNQyend",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1399,7 +1399,7 @@
 			}
 		},
 		{
-			"id": "tnjBxTpWgaPO9N03l",
+			"id": "twhrQknVVMTdFU1Tj",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1437,7 +1437,7 @@
 			}
 		},
 		{
-			"id": "tD_QSzzSNCS0dR9o7",
+			"id": "t_lNDx3jgy9H6uinN",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1555,7 +1555,7 @@
 	],
 	"skills": [
 		{
-			"id": "sGNGuNNjNLYOumYeI",
+			"id": "sUUSL97oBqNFz4UMg",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Skeever.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Beasts/Skeever.gcs
@@ -550,7 +550,7 @@
 	],
 	"traits": [
 		{
-			"id": "teGVuICCMAVEx3kBM",
+			"id": "tUwFpEpFu886AC7CU",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Atronach, Flame.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Atronach, Flame.gcs
@@ -2352,7 +2352,7 @@
 			}
 		},
 		{
-			"id": "tqv-JMkQZYAft_vGI",
+			"id": "tqLTt8cykKao5VQPE",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2533,7 +2533,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "t2_f26RARh3pC-yg2",
+					"id": "tXIfpZy0rVJFINdJF",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2973,7 +2973,7 @@
 					}
 				},
 				{
-					"id": "tJvDsknz8mC0YSQap",
+					"id": "tsjBU6IKZmH7hhlOf",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3001,7 +3001,7 @@
 					}
 				},
 				{
-					"id": "trgRfgjTagofr-LQy",
+					"id": "t3dEeDzJ6DmrX3c8S",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3107,7 +3107,7 @@
 					}
 				},
 				{
-					"id": "tXMp5gve0la24ay98",
+					"id": "tfIAmlOu2lJ4nPEDY",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3148,7 +3148,7 @@
 	],
 	"skills": [
 		{
-			"id": "sktK6JhA-PmL6AJPM",
+			"id": "sbrchUWzSI9GaL3e0",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -3185,7 +3185,7 @@
 			}
 		},
 		{
-			"id": "sPVlnTx-_uH4z-5zr",
+			"id": "sALKP7tsvv-7CbR6e",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Atronach, Frost.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Atronach, Frost.gcs
@@ -1549,7 +1549,7 @@
 			}
 		},
 		{
-			"id": "tqv-JMkQZYAft_vGI",
+			"id": "tfmyGuVqUrb0L8gNQ",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1767,7 +1767,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "t2_f26RARh3pC-yg2",
+					"id": "tX9cmw0J26qCx3RRb",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2207,7 +2207,7 @@
 					}
 				},
 				{
-					"id": "tJvDsknz8mC0YSQap",
+					"id": "tziz6pl5mwm6qjoOU",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2235,7 +2235,7 @@
 					}
 				},
 				{
-					"id": "trgRfgjTagofr-LQy",
+					"id": "teaektuQJnY8sZdWN",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2341,7 +2341,7 @@
 					}
 				},
 				{
-					"id": "tXMp5gve0la24ay98",
+					"id": "t0lqU5_n95Ak3EP-e",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2382,7 +2382,7 @@
 	],
 	"skills": [
 		{
-			"id": "sktK6JhA-PmL6AJPM",
+			"id": "sg2CyGCn1V1pDiZ0K",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Atronach, Storm.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Atronach, Storm.gcs
@@ -2213,7 +2213,7 @@
 			}
 		},
 		{
-			"id": "tqv-JMkQZYAft_vGI",
+			"id": "tg01zcU-zl7c2nS4l",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2310,7 +2310,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "t2_f26RARh3pC-yg2",
+					"id": "tZqo7HmCjEhEHbZhY",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2750,7 +2750,7 @@
 					}
 				},
 				{
-					"id": "tJvDsknz8mC0YSQap",
+					"id": "tYZRdfWfYbVj5txE4",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2778,7 +2778,7 @@
 					}
 				},
 				{
-					"id": "trgRfgjTagofr-LQy",
+					"id": "tIcPdLfw6DfkS8gai",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2884,7 +2884,7 @@
 					}
 				},
 				{
-					"id": "tXMp5gve0la24ay98",
+					"id": "tXhBKJ8VqvSA9DOBY",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2925,7 +2925,7 @@
 	],
 	"skills": [
 		{
-			"id": "sktK6JhA-PmL6AJPM",
+			"id": "sqJoSYzPwtUEdSFmX",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Clannfear.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Clannfear.gcs
@@ -1048,7 +1048,7 @@
 			}
 		},
 		{
-			"id": "tMZqaphIe4wg4zF_a",
+			"id": "twjGEj65sk8AdtOcn",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1086,7 +1086,7 @@
 			}
 		},
 		{
-			"id": "tGW4OIq7zTNgavde1",
+			"id": "t3kdpLoiwmGGUrYQe",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1129,7 +1129,7 @@
 			}
 		},
 		{
-			"id": "tZPUlNowo7FBejuuA",
+			"id": "tphkqCYHlEg2FBM6k",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1293,7 +1293,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "trz68C8R9bV_rpkBn",
+					"id": "tCSMpnEYgVgqQRkM2",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1659,7 +1659,7 @@
 					}
 				},
 				{
-					"id": "ttKFfx0T1VEdwRotx",
+					"id": "tOzonbh8MUWlivL-P",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1733,7 +1733,7 @@
 					}
 				},
 				{
-					"id": "tcZD9etoByQodkiPf",
+					"id": "tr1UCVYeLCxCtSxVr",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1761,7 +1761,7 @@
 					}
 				},
 				{
-					"id": "t1tNm4XFLyAE_32Km",
+					"id": "tqLKBEWr7-v6CaAA8",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1867,7 +1867,7 @@
 					}
 				},
 				{
-					"id": "t7Xnoc-gqnZUVwGH7",
+					"id": "taMPTOgBV3UofU9Mb",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1950,7 +1950,7 @@
 			}
 		},
 		{
-			"id": "seUZuVwr9XE-i8LEE",
+			"id": "swuyRuCQdTTdsvI7l",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Daedroth.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Daedroth.gcs
@@ -1504,7 +1504,7 @@
 			}
 		},
 		{
-			"id": "tMZqaphIe4wg4zF_a",
+			"id": "tBa7URfkmxqf04CLD",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1542,7 +1542,7 @@
 			}
 		},
 		{
-			"id": "tGW4OIq7zTNgavde1",
+			"id": "tv53M4kZSXtzEhZtW",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1895,7 +1895,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "trz68C8R9bV_rpkBn",
+					"id": "tVbqGk6_IfTOgLUep",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2335,7 +2335,7 @@
 					}
 				},
 				{
-					"id": "tcZD9etoByQodkiPf",
+					"id": "tSewD02Q-8VBS-SFQ",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2363,7 +2363,7 @@
 					}
 				},
 				{
-					"id": "t1tNm4XFLyAE_32Km",
+					"id": "tCtpCx1exMemZ-Mwh",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2469,7 +2469,7 @@
 					}
 				},
 				{
-					"id": "t7Xnoc-gqnZUVwGH7",
+					"id": "tpCRL2NyY9CX4EeF9",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2510,7 +2510,7 @@
 	],
 	"skills": [
 		{
-			"id": "seUZuVwr9XE-i8LEE",
+			"id": "sklaJF2oEJ9YhEMAA",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Dremora Lord.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Dremora Lord.gcs
@@ -901,7 +901,7 @@
 			}
 		},
 		{
-			"id": "tnbR_nRAqmVl8RDNN",
+			"id": "tUwUO8dWBahtCVNPp",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -920,7 +920,7 @@
 			}
 		},
 		{
-			"id": "t0vFn5skHht1Rmdc4",
+			"id": "tS--DjixaYHztFDrC",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -940,7 +940,7 @@
 			}
 		},
 		{
-			"id": "td-lJQJdDJ1lPn23e",
+			"id": "twT3eyrcPrUV-jA3H",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1231,7 +1231,7 @@
 			}
 		},
 		{
-			"id": "tcA3VA4nN18o2wyF_",
+			"id": "tPSqoGzlbnI4POlk4",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1260,7 +1260,7 @@
 			}
 		},
 		{
-			"id": "tiTpVLZssAaBtt5xo",
+			"id": "tpjWqq7QEc58GLnMy",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1297,7 +1297,7 @@
 			}
 		},
 		{
-			"id": "tyau5w12XSuTpzQL1",
+			"id": "ttGq8Z98P6_dTkzAv",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1384,7 +1384,7 @@
 			}
 		},
 		{
-			"id": "t6Y_M6x4nzfCIjPfN",
+			"id": "ti2cD1GiQH05GiUHx",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1504,7 +1504,7 @@
 			}
 		},
 		{
-			"id": "tfjMhkIo-RXjBtxd6",
+			"id": "tar0bbaTuLt7phZoq",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1593,7 +1593,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "t7z2_M4Miiey00lYs",
+					"id": "tq0nePBlQhQ-YisNR",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1959,7 +1959,7 @@
 					}
 				},
 				{
-					"id": "tsswVwYrhahvzOLKd",
+					"id": "tNy8dmaTWNd61ydsG",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2033,7 +2033,7 @@
 					}
 				},
 				{
-					"id": "tJTW-Z049fmBtb1F2",
+					"id": "tff3VfMkiNEzx9lQD",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2061,7 +2061,7 @@
 					}
 				},
 				{
-					"id": "tFmYjVzRSoa9K_-VK",
+					"id": "tb4Xxe7NqfBsENLIU",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2167,7 +2167,7 @@
 					}
 				},
 				{
-					"id": "ttyVx43izx32OzHaq",
+					"id": "tsSh8I4XnfLLHcPs2",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2208,7 +2208,7 @@
 	],
 	"skills": [
 		{
-			"id": "stKXjIUSbJ9jM9maZ",
+			"id": "seBufRTSFL9WMfWeP",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2489,7 +2489,7 @@
 			}
 		},
 		{
-			"id": "s1cb8qWuPhjc97VxL",
+			"id": "sw089ut1OqanMiQLS",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Dremora.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Dremora.gcs
@@ -901,7 +901,7 @@
 			}
 		},
 		{
-			"id": "tnbR_nRAqmVl8RDNN",
+			"id": "tD0p9bVlr6RN0mkaP",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -920,7 +920,7 @@
 			}
 		},
 		{
-			"id": "t0vFn5skHht1Rmdc4",
+			"id": "tmuxkwW5VX4-rZqmG",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -940,7 +940,7 @@
 			}
 		},
 		{
-			"id": "td-lJQJdDJ1lPn23e",
+			"id": "tEWB4-OyNTRe5sf1A",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1231,7 +1231,7 @@
 			}
 		},
 		{
-			"id": "tcA3VA4nN18o2wyF_",
+			"id": "tCQQQuU3Sd_0Q6oUC",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1260,7 +1260,7 @@
 			}
 		},
 		{
-			"id": "tiTpVLZssAaBtt5xo",
+			"id": "tyZKMEhZXXUXdphO9",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1297,7 +1297,7 @@
 			}
 		},
 		{
-			"id": "tyau5w12XSuTpzQL1",
+			"id": "tstch9pKja_1JYsaz",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1384,7 +1384,7 @@
 			}
 		},
 		{
-			"id": "t6Y_M6x4nzfCIjPfN",
+			"id": "tmhfCm7Bng4JcwAXY",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1504,7 +1504,7 @@
 			}
 		},
 		{
-			"id": "tfjMhkIo-RXjBtxd6",
+			"id": "tM2nepyK86FRVMlws",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1593,7 +1593,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "t7z2_M4Miiey00lYs",
+					"id": "tO9ATNQYrv8yQDwjz",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1959,7 +1959,7 @@
 					}
 				},
 				{
-					"id": "tsswVwYrhahvzOLKd",
+					"id": "tE7LObL7x0dF47kjD",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2033,7 +2033,7 @@
 					}
 				},
 				{
-					"id": "tJTW-Z049fmBtb1F2",
+					"id": "ti9eAu3r70-zVqhdf",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2061,7 +2061,7 @@
 					}
 				},
 				{
-					"id": "tFmYjVzRSoa9K_-VK",
+					"id": "t2G9BWapp9iMPmkH1",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2167,7 +2167,7 @@
 					}
 				},
 				{
-					"id": "ttyVx43izx32OzHaq",
+					"id": "tfBO8N1bweDC9KWPG",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2208,7 +2208,7 @@
 	],
 	"skills": [
 		{
-			"id": "stKXjIUSbJ9jM9maZ",
+			"id": "shQcxuMxUrUUUpavk",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2456,7 +2456,7 @@
 			}
 		},
 		{
-			"id": "s1cb8qWuPhjc97VxL",
+			"id": "slQLfCcuVc5gVIp5w",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Hunger.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Hunger.gcs
@@ -1913,7 +1913,7 @@
 			}
 		},
 		{
-			"id": "tZPUlNowo7FBejuuA",
+			"id": "tv-EMLiFvuMK2I5UC",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2118,7 +2118,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "trz68C8R9bV_rpkBn",
+					"id": "tTs9O-laBDn6UKwoK",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2484,7 +2484,7 @@
 					}
 				},
 				{
-					"id": "ttKFfx0T1VEdwRotx",
+					"id": "tsIP35zdJW4u1O2Qp",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2558,7 +2558,7 @@
 					}
 				},
 				{
-					"id": "tcZD9etoByQodkiPf",
+					"id": "trj2SoxcZQbKoOu7V",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2586,7 +2586,7 @@
 					}
 				},
 				{
-					"id": "t1tNm4XFLyAE_32Km",
+					"id": "taOfbCVNmzWg0U5Io",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2692,7 +2692,7 @@
 					}
 				},
 				{
-					"id": "t7Xnoc-gqnZUVwGH7",
+					"id": "tobnvHeKCuBTUPg_z",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2733,7 +2733,7 @@
 	],
 	"skills": [
 		{
-			"id": "seUZuVwr9XE-i8LEE",
+			"id": "sWL5GLrgLizeorJVz",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Scamp.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Scamp.gcs
@@ -1392,7 +1392,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "t2_f26RARh3pC-yg2",
+					"id": "tuJ_-k6bbzVXDs-S8",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1832,7 +1832,7 @@
 					}
 				},
 				{
-					"id": "tJvDsknz8mC0YSQap",
+					"id": "tmEa4pMCvw_zXN_BE",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1860,7 +1860,7 @@
 					}
 				},
 				{
-					"id": "trgRfgjTagofr-LQy",
+					"id": "tGXpZABur2j7xOy8H",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1966,7 +1966,7 @@
 					}
 				},
 				{
-					"id": "tXMp5gve0la24ay98",
+					"id": "tnqt7XVipjz2DhSjs",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2007,7 +2007,7 @@
 	],
 	"skills": [
 		{
-			"id": "sktK6JhA-PmL6AJPM",
+			"id": "soHJvq8BxLh1zrXCR",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2044,7 +2044,7 @@
 			}
 		},
 		{
-			"id": "sPVlnTx-_uH4z-5zr",
+			"id": "sNtInWcr35tdPs818",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Spider Daedra.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Spider Daedra.gcs
@@ -1759,7 +1759,7 @@
 			}
 		},
 		{
-			"id": "tkPDRopJ981oCwN14",
+			"id": "trq_OEWOc7K7xn3Qf",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2305,7 +2305,7 @@
 			}
 		},
 		{
-			"id": "tWCELiw3neK5SQveb",
+			"id": "tA2SOEwJCbh5TV74i",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2380,7 +2380,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "t4KS3YwlwguDv-pvA",
+					"id": "tCwQffWeOvu50092c",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2746,7 +2746,7 @@
 					}
 				},
 				{
-					"id": "tf7JQLn_Bo7CP22rA",
+					"id": "t4CpkNBYsLZoJXhIx",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2820,7 +2820,7 @@
 					}
 				},
 				{
-					"id": "tPqNxAFYf-Nu_ynVU",
+					"id": "t1rXYkaNlz5xuuppH",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2848,7 +2848,7 @@
 					}
 				},
 				{
-					"id": "tSakcDjmEyJcZ9cXY",
+					"id": "tR97pz3P_L5GaFZLW",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2954,7 +2954,7 @@
 					}
 				},
 				{
-					"id": "tBOW92ddyaRGKMiZa",
+					"id": "tYxrlO_UjimFZkP1Y",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2995,7 +2995,7 @@
 	],
 	"skills": [
 		{
-			"id": "snriu3LAu708LqROa",
+			"id": "sqnYRWJTbpSmevQXL",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -3110,7 +3110,7 @@
 			}
 		},
 		{
-			"id": "sssqqdWiXxC19xukY",
+			"id": "s0HYQ5ANqNABHFcAF",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Spiderling.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Daedra/Spiderling.gcs
@@ -1483,7 +1483,7 @@
 			}
 		},
 		{
-			"id": "tkPDRopJ981oCwN14",
+			"id": "tTNddnOneZHQY33TX",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1936,7 +1936,7 @@
 			}
 		},
 		{
-			"id": "tWCELiw3neK5SQveb",
+			"id": "t2XbB06e0oAjQI-0i",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2011,7 +2011,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "t4KS3YwlwguDv-pvA",
+					"id": "tjV4IoaeDAFqnn2S3",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2377,7 +2377,7 @@
 					}
 				},
 				{
-					"id": "tf7JQLn_Bo7CP22rA",
+					"id": "tAlZ5pMU3i97ue4Rl",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2451,7 +2451,7 @@
 					}
 				},
 				{
-					"id": "tPqNxAFYf-Nu_ynVU",
+					"id": "tO-Vi50RzGLDWSGEX",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2479,7 +2479,7 @@
 					}
 				},
 				{
-					"id": "tSakcDjmEyJcZ9cXY",
+					"id": "tCzrRbQo3OU7vaPsn",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2585,7 +2585,7 @@
 					}
 				},
 				{
-					"id": "tBOW92ddyaRGKMiZa",
+					"id": "taMLFi-HHlpTWSvF5",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2626,7 +2626,7 @@
 	],
 	"skills": [
 		{
-			"id": "snriu3LAu708LqROa",
+			"id": "sgaAvzmW5LrgpLdAt",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2741,7 +2741,7 @@
 			}
 		},
 		{
-			"id": "sssqqdWiXxC19xukY",
+			"id": "sl_KQdJ0SCdwFFFIu",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Dragons/Dragon, Ancient.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Dragons/Dragon, Ancient.gcs
@@ -865,7 +865,7 @@
 							"cost_adj": "-10%"
 						},
 						{
-							"id": "mvgpRDCj2GnvKaZNc",
+							"id": "mr-VlcPymAUT7H5zS",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -1206,7 +1206,7 @@
 							"cost_adj": "-10%"
 						},
 						{
-							"id": "mazsk4jdjP8T9w_sF",
+							"id": "mwBe878kj1ux8TSdU",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -1445,7 +1445,7 @@
 							"cost_adj": "-10%"
 						},
 						{
-							"id": "mfPW-gfdMTtYti3p6",
+							"id": "mf0i2Le30lfwzcnTW",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -2486,7 +2486,7 @@
 					}
 				},
 				{
-					"id": "tSCP_UKXwu5ruRUCw",
+					"id": "tjkxWfBXnTItv01Bj",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3325,7 +3325,7 @@
 			}
 		},
 		{
-			"id": "s7Kdubd9Oa-5Ylsu_",
+			"id": "sNoTyviVk_VBpMdop",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -3362,7 +3362,7 @@
 			}
 		},
 		{
-			"id": "s5f45l1N7KfkRAGkv",
+			"id": "sDoxE5MRudACwSzuG",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Dragons/Dragon, Elder.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Dragons/Dragon, Elder.gcs
@@ -865,7 +865,7 @@
 							"cost_adj": "-10%"
 						},
 						{
-							"id": "mvgpRDCj2GnvKaZNc",
+							"id": "mKLydR1URNqruUAgo",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -1206,7 +1206,7 @@
 							"cost_adj": "-10%"
 						},
 						{
-							"id": "mazsk4jdjP8T9w_sF",
+							"id": "mK_hj0SxpW0oJUtPV",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -1445,7 +1445,7 @@
 							"cost_adj": "-10%"
 						},
 						{
-							"id": "mfPW-gfdMTtYti3p6",
+							"id": "maAmaRyyEl_rxXYqF",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -2529,7 +2529,7 @@
 					}
 				},
 				{
-					"id": "tSCP_UKXwu5ruRUCw",
+					"id": "tkviEcnYPlfdoG6jx",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3368,7 +3368,7 @@
 			}
 		},
 		{
-			"id": "s7Kdubd9Oa-5Ylsu_",
+			"id": "s9BZ3RdVA7yd8d84v",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -3405,7 +3405,7 @@
 			}
 		},
 		{
-			"id": "s5f45l1N7KfkRAGkv",
+			"id": "sozcxQO7Bfqq-dE5i",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Dragons/Dragon.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Dragons/Dragon.gcs
@@ -865,7 +865,7 @@
 							"cost_adj": "-10%"
 						},
 						{
-							"id": "mvgpRDCj2GnvKaZNc",
+							"id": "mPMdFPdN8cNN7KDCb",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -1206,7 +1206,7 @@
 							"cost_adj": "-10%"
 						},
 						{
-							"id": "mazsk4jdjP8T9w_sF",
+							"id": "mvqZH9TB8FFdT4ukK",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -1445,7 +1445,7 @@
 							"cost_adj": "-10%"
 						},
 						{
-							"id": "mfPW-gfdMTtYti3p6",
+							"id": "mRWPaIGzEAEEj8nuU",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -2529,7 +2529,7 @@
 					}
 				},
 				{
-					"id": "tSCP_UKXwu5ruRUCw",
+					"id": "tRC1donsMO5XB2p7A",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -2685,7 +2685,7 @@
 					}
 				},
 				{
-					"id": "t8D6Yy76LDaykLhMw",
+					"id": "tUgPvxfj7uOALnYSW",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3368,7 +3368,7 @@
 			}
 		},
 		{
-			"id": "s7Kdubd9Oa-5Ylsu_",
+			"id": "sQPgMHS744IFYBWNS",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -3405,7 +3405,7 @@
 			}
 		},
 		{
-			"id": "s5f45l1N7KfkRAGkv",
+			"id": "sEgwAyronJ1JbJVdN",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Dwemer Automata/Centurion Sphere.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Dwemer Automata/Centurion Sphere.gcs
@@ -2120,7 +2120,7 @@
 	],
 	"skills": [
 		{
-			"id": "sJmX8LXiRGfdWBHSA",
+			"id": "sFNnGiSjzPwBjI1tp",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Dwemer Automata/Centurion Spider.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Dwemer Automata/Centurion Spider.gcs
@@ -2048,7 +2048,7 @@
 	],
 	"skills": [
 		{
-			"id": "sJmX8LXiRGfdWBHSA",
+			"id": "s22z-lWHMFt_FWy9L",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Dwemer Automata/Steam Centurion.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Dwemer Automata/Steam Centurion.gcs
@@ -2716,7 +2716,7 @@
 	],
 	"skills": [
 		{
-			"id": "sJmX8LXiRGfdWBHSA",
+			"id": "sIsrS3vPWGQsb4CiT",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Falmer/Falmer Nightprowler.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Falmer/Falmer Nightprowler.gcs
@@ -603,7 +603,7 @@
 	],
 	"traits": [
 		{
-			"id": "tAL6Z2_8Xo33gry24",
+			"id": "tnGyoWSLIpkZYCrA0",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1583,7 +1583,7 @@
 			}
 		},
 		{
-			"id": "sa5sUX2K6lTIpNnSY",
+			"id": "sD9WfQJ1rFwVfvl7a",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1664,7 +1664,7 @@
 			}
 		},
 		{
-			"id": "sMjXldmwIGxltrxBY",
+			"id": "sP0p5ynPftg-pkcwS",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1757,7 +1757,7 @@
 			}
 		},
 		{
-			"id": "safiiO-7TAWHopYCP",
+			"id": "s7UveF943wZkPtHEf",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1836,7 +1836,7 @@
 			}
 		},
 		{
-			"id": "sITWHGmC12hJ6suDg",
+			"id": "s50aqCS38gE040uPs",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2510,7 +2510,7 @@
 					}
 				},
 				{
-					"id": "EbQih0yJZRL_sdaAb",
+					"id": "ES3NXb73Y2dYHhT98",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Equipment.eqp",
@@ -2529,7 +2529,7 @@
 					"equipped": true,
 					"children": [
 						{
-							"id": "eqCgPQ2NOMv6yjCki",
+							"id": "egzilZK8vrnvXRMg7",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Equipment.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Falmer/Falmer Shaman.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Falmer/Falmer Shaman.gcs
@@ -603,7 +603,7 @@
 	],
 	"traits": [
 		{
-			"id": "tAL6Z2_8Xo33gry24",
+			"id": "tKPfxYt6rtFFwehRz",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1691,7 +1691,7 @@
 			}
 		},
 		{
-			"id": "sa5sUX2K6lTIpNnSY",
+			"id": "sw68ZBPxbEJ5XZ6H3",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1812,7 +1812,7 @@
 			}
 		},
 		{
-			"id": "sITWHGmC12hJ6suDg",
+			"id": "sEuJXjg4z0_pbQaA3",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Falmer/Falmer Spellsword.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Falmer/Falmer Spellsword.gcs
@@ -603,7 +603,7 @@
 	],
 	"traits": [
 		{
-			"id": "tAL6Z2_8Xo33gry24",
+			"id": "tRvIeoZ0CLaTmqQyf",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1652,7 +1652,7 @@
 			}
 		},
 		{
-			"id": "sa5sUX2K6lTIpNnSY",
+			"id": "snwmYWy407howAx3p",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1788,7 +1788,7 @@
 			}
 		},
 		{
-			"id": "sITWHGmC12hJ6suDg",
+			"id": "s3DrN_E6FENQf6xx0",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Falmer/Falmer Warmonger.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Falmer/Falmer Warmonger.gcs
@@ -603,7 +603,7 @@
 	],
 	"traits": [
 		{
-			"id": "tAL6Z2_8Xo33gry24",
+			"id": "trB8DWBJVpGEcdTE8",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1620,7 +1620,7 @@
 			}
 		},
 		{
-			"id": "sa5sUX2K6lTIpNnSY",
+			"id": "s3rSPWbR31wErahgj",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1701,7 +1701,7 @@
 			}
 		},
 		{
-			"id": "sMjXldmwIGxltrxBY",
+			"id": "sWxKFZZJ5iobIbuFi",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1827,7 +1827,7 @@
 			}
 		},
 		{
-			"id": "safiiO-7TAWHopYCP",
+			"id": "sKPr1Az7wTEoJDwTQ",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1906,7 +1906,7 @@
 			}
 		},
 		{
-			"id": "sITWHGmC12hJ6suDg",
+			"id": "s-Wy7l-oD5QdS5feC",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2618,7 +2618,7 @@
 					}
 				},
 				{
-					"id": "EbQih0yJZRL_sdaAb",
+					"id": "Es2nNhf-Tv8EHdiab",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Equipment.eqp",
@@ -2637,7 +2637,7 @@
 					"equipped": true,
 					"children": [
 						{
-							"id": "eqCgPQ2NOMv6yjCki",
+							"id": "eqsWgCjnGnFGi76Au",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Equipment.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Falmer/Falmer.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Falmer/Falmer.gcs
@@ -603,7 +603,7 @@
 	],
 	"traits": [
 		{
-			"id": "tAL6Z2_8Xo33gry24",
+			"id": "tplSPwIzSqngPbyl4",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1583,7 +1583,7 @@
 			}
 		},
 		{
-			"id": "sa5sUX2K6lTIpNnSY",
+			"id": "secB5eXvAQy8OPTNu",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1664,7 +1664,7 @@
 			}
 		},
 		{
-			"id": "sMjXldmwIGxltrxBY",
+			"id": "sU7zbloilh158tW8Z",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1757,7 +1757,7 @@
 			}
 		},
 		{
-			"id": "safiiO-7TAWHopYCP",
+			"id": "sXAp8l93WjfoaDx61",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1836,7 +1836,7 @@
 			}
 		},
 		{
-			"id": "sITWHGmC12hJ6suDg",
+			"id": "sXJ5b-T7LxSBg_irk",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2510,7 +2510,7 @@
 					}
 				},
 				{
-					"id": "EbQih0yJZRL_sdaAb",
+					"id": "E08e_3Ar8bV8ZTiwT",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Equipment.eqp",
@@ -2529,7 +2529,7 @@
 					"equipped": true,
 					"children": [
 						{
-							"id": "eqCgPQ2NOMv6yjCki",
+							"id": "eaxJ2_RFVm8iDBwh1",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Equipment.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Goblins/Goblin Berserker.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Goblins/Goblin Berserker.gcs
@@ -1444,7 +1444,7 @@
 			}
 		},
 		{
-			"id": "scK9WnVrJcdWUHQkQ",
+			"id": "sgXVyZw4Opmc1jGqR",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1478,7 +1478,7 @@
 			}
 		},
 		{
-			"id": "sKp6c_z83jfzTlIH_",
+			"id": "snTtnF_R5tdHNhQ52",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1564,7 +1564,7 @@
 			}
 		},
 		{
-			"id": "sDplziMp8ArXI9hLR",
+			"id": "so055wBoXHhvFX98E",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1599,7 +1599,7 @@
 			}
 		},
 		{
-			"id": "smxwpudhdOcxHhWNM",
+			"id": "sKvCI_CUuydbe0W1k",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2201,7 +2201,7 @@
 			}
 		},
 		{
-			"id": "EQ_eIs_EavdPl5_-V",
+			"id": "EatZ_p_Na1aFe-GKA",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Equipment.eqp",
@@ -2220,7 +2220,7 @@
 			"equipped": true,
 			"children": [
 				{
-					"id": "ewri99jjDKlcaOw7U",
+					"id": "eTlu0sf_nnJBa0Nm8",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Equipment.eqp",
@@ -2270,7 +2270,7 @@
 			"equipped": true,
 			"children": [
 				{
-					"id": "eV2z4SXOV7N93kUkH",
+					"id": "e5xJA81ELdhA7LjCR",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2304,7 +2304,7 @@
 					}
 				},
 				{
-					"id": "eE_tnicmNN88kVucn",
+					"id": "evjjwVbakaBl8osBP",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2359,7 +2359,7 @@
 					}
 				},
 				{
-					"id": "eB0XlSw-eE5f09K4o",
+					"id": "eSn4rZPAa9XAOTzRX",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2393,7 +2393,7 @@
 					}
 				},
 				{
-					"id": "epU4BY6z7XhlZvtut",
+					"id": "eGUjZqaLVHAiXX0_p",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2427,7 +2427,7 @@
 					}
 				},
 				{
-					"id": "eDE3JyQMpNEoDpgW1",
+					"id": "e3AWlbjADJojo4V9T",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2461,7 +2461,7 @@
 					}
 				},
 				{
-					"id": "eczAMmqI4iegejA-X",
+					"id": "eLw7Ch9Y6Y11FjhnZ",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Goblins/Goblin Shaman.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Goblins/Goblin Shaman.gcs
@@ -1450,7 +1450,7 @@
 	],
 	"skills": [
 		{
-			"id": "sKp6c_z83jfzTlIH_",
+			"id": "surjqL3-jKcJORzP8",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1571,7 +1571,7 @@
 			}
 		},
 		{
-			"id": "smxwpudhdOcxHhWNM",
+			"id": "sBZ_aklovXETEDo0f",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2170,7 +2170,7 @@
 			"equipped": true,
 			"children": [
 				{
-					"id": "eV2z4SXOV7N93kUkH",
+					"id": "ecJXjxsFGLuDrj94J",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2204,7 +2204,7 @@
 					}
 				},
 				{
-					"id": "eE_tnicmNN88kVucn",
+					"id": "ea7BCz2kHFzR3DVlX",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2259,7 +2259,7 @@
 					}
 				},
 				{
-					"id": "eB0XlSw-eE5f09K4o",
+					"id": "eRLnStCMftSIMG4g6",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2293,7 +2293,7 @@
 					}
 				},
 				{
-					"id": "epU4BY6z7XhlZvtut",
+					"id": "eLrFw7e1EcSqa1p8r",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2327,7 +2327,7 @@
 					}
 				},
 				{
-					"id": "eDE3JyQMpNEoDpgW1",
+					"id": "ePR7IY0-29KqIL99j",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2361,7 +2361,7 @@
 					}
 				},
 				{
-					"id": "eczAMmqI4iegejA-X",
+					"id": "exrRxKzyt6l0nbfMe",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Goblins/Goblin Warlord.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Goblins/Goblin Warlord.gcs
@@ -825,7 +825,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "tw2u-kenELfCf2cIC",
+					"id": "tU4i7yTxNi-nK4wHa",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1220,7 +1220,7 @@
 					}
 				},
 				{
-					"id": "tcRBmfAUvH1pdv1yt",
+					"id": "t8GPIwno9CNDULw1o",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1241,7 +1241,7 @@
 					}
 				},
 				{
-					"id": "twVJEYPWCDhHYQ_2K",
+					"id": "tiG_UOtPZStBba_04",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1281,7 +1281,7 @@
 					}
 				},
 				{
-					"id": "tCdB1P3sRKIpHspzR",
+					"id": "tIYGKl39SmGdKLAKB",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1377,7 +1377,7 @@
 	],
 	"skills": [
 		{
-			"id": "scK9WnVrJcdWUHQkQ",
+			"id": "sL5ccPZlZw_LxikL5",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1411,7 +1411,7 @@
 			}
 		},
 		{
-			"id": "sKp6c_z83jfzTlIH_",
+			"id": "sySHVryhFUe--gFdy",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1497,7 +1497,7 @@
 			}
 		},
 		{
-			"id": "sf0FCM06TcNGJxhrD",
+			"id": "sFNT97Pca5mKjMVBB",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1600,7 +1600,7 @@
 			}
 		},
 		{
-			"id": "sDplziMp8ArXI9hLR",
+			"id": "sPuVvYJHuTPPtPuzY",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1635,7 +1635,7 @@
 			}
 		},
 		{
-			"id": "smxwpudhdOcxHhWNM",
+			"id": "s22jKP28n1d1KXYN1",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2236,7 +2236,7 @@
 			}
 		},
 		{
-			"id": "EQ_eIs_EavdPl5_-V",
+			"id": "Eu6pp4FfFyziZ6qQg",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Equipment.eqp",
@@ -2255,7 +2255,7 @@
 			"equipped": true,
 			"children": [
 				{
-					"id": "ewri99jjDKlcaOw7U",
+					"id": "eYOer-ta_fVlsMOlU",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Equipment.eqp",
@@ -2305,7 +2305,7 @@
 			"equipped": true,
 			"children": [
 				{
-					"id": "eV2z4SXOV7N93kUkH",
+					"id": "el75nKfSVhrgH0y8b",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2339,7 +2339,7 @@
 					}
 				},
 				{
-					"id": "eE_tnicmNN88kVucn",
+					"id": "edzUIZ8rCl1911kil",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2394,7 +2394,7 @@
 					}
 				},
 				{
-					"id": "eB0XlSw-eE5f09K4o",
+					"id": "erQLqo7J3IzxS_06K",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2428,7 +2428,7 @@
 					}
 				},
 				{
-					"id": "epU4BY6z7XhlZvtut",
+					"id": "eArt1T7HABDXC1Oaw",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2462,7 +2462,7 @@
 					}
 				},
 				{
-					"id": "eDE3JyQMpNEoDpgW1",
+					"id": "erhl0M4DmxcDliJAt",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2496,7 +2496,7 @@
 					}
 				},
 				{
-					"id": "eczAMmqI4iegejA-X",
+					"id": "eMHMRdP43bWy4P2M8",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Goblins/Goblin.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Goblins/Goblin.gcs
@@ -604,7 +604,7 @@
 	],
 	"traits": [
 		{
-			"id": "t2LgLffsIYfnbKTtq",
+			"id": "tgGH6z5iASdhqIyIy",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -625,7 +625,7 @@
 			}
 		},
 		{
-			"id": "ttSgrLHaqq769BWsV",
+			"id": "tifNs_4YDVs10e87d",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1362,7 +1362,7 @@
 	],
 	"skills": [
 		{
-			"id": "scK9WnVrJcdWUHQkQ",
+			"id": "sFwso4xov9DH_dq9d",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1396,7 +1396,7 @@
 			}
 		},
 		{
-			"id": "sKp6c_z83jfzTlIH_",
+			"id": "sHy-0AYEubij1j2ZE",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1482,7 +1482,7 @@
 			}
 		},
 		{
-			"id": "sDplziMp8ArXI9hLR",
+			"id": "sGp71K8B9URFdB6vj",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1517,7 +1517,7 @@
 			}
 		},
 		{
-			"id": "smxwpudhdOcxHhWNM",
+			"id": "sdf8_5oAmOWFyJR8t",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1929,7 +1929,7 @@
 			}
 		},
 		{
-			"id": "EQ_eIs_EavdPl5_-V",
+			"id": "EMl1h0cn0mZGykBX9",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Equipment.eqp",
@@ -1948,7 +1948,7 @@
 			"equipped": true,
 			"children": [
 				{
-					"id": "ewri99jjDKlcaOw7U",
+					"id": "eGXrLQIhurwqQWSfn",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Equipment.eqp",
@@ -1998,7 +1998,7 @@
 			"equipped": true,
 			"children": [
 				{
-					"id": "eV2z4SXOV7N93kUkH",
+					"id": "exRJsQAYVoeYEqlbM",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2032,7 +2032,7 @@
 					}
 				},
 				{
-					"id": "eE_tnicmNN88kVucn",
+					"id": "etPkFx28eopVv24yS",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2087,7 +2087,7 @@
 					}
 				},
 				{
-					"id": "eB0XlSw-eE5f09K4o",
+					"id": "esl3Ued0sEBoIQbKM",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2121,7 +2121,7 @@
 					}
 				},
 				{
-					"id": "epU4BY6z7XhlZvtut",
+					"id": "e3Bt8MJBueSjnPJm2",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2155,7 +2155,7 @@
 					}
 				},
 				{
-					"id": "eDE3JyQMpNEoDpgW1",
+					"id": "e9AhmwqhwPI7gBQP_",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2189,7 +2189,7 @@
 					}
 				},
 				{
-					"id": "eczAMmqI4iegejA-X",
+					"id": "elDrzftY4KzRKB3gF",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Minotaur Lord.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Minotaur Lord.gcs
@@ -604,7 +604,7 @@
 	],
 	"traits": [
 		{
-			"id": "teX7HbXitVO3vcFbf",
+			"id": "tqL33yakJGHCYhKP7",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -744,7 +744,7 @@
 			}
 		},
 		{
-			"id": "tQeKPIdSBDs-aGnCi",
+			"id": "tC0dRwRQde2Ov3zKr",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -773,7 +773,7 @@
 			}
 		},
 		{
-			"id": "tmMcg1HZYTYF89Vpg",
+			"id": "t2k_29BIXOF1B68DS",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1139,7 +1139,7 @@
 			}
 		},
 		{
-			"id": "tofq-F9Hebk0YnsK0",
+			"id": "tt2SG77r8sGW3sXeO",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1158,7 +1158,7 @@
 			}
 		},
 		{
-			"id": "ttrjH8Jbgk2ZUGOUV",
+			"id": "tyA3wSL9mwQWADioN",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1299,7 +1299,7 @@
 			}
 		},
 		{
-			"id": "tbA8zq8QYg7m0eIcQ",
+			"id": "tdc6V5sUSpL5-U8_s",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1637,7 +1637,7 @@
 			}
 		},
 		{
-			"id": "tN17HP7ACGRri5woV",
+			"id": "tPndFiMe6QgyU-rFZ",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1917,7 +1917,7 @@
 			}
 		},
 		{
-			"id": "tzU2FnAFn4LcxwKrx",
+			"id": "tVLqmW7MYACMzGqnI",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2177,7 +2177,7 @@
 			}
 		},
 		{
-			"id": "t-1FDrKAZXxOnC2pH",
+			"id": "tTT9qQzjOd6Eb0YbZ",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2207,7 +2207,7 @@
 	],
 	"skills": [
 		{
-			"id": "sSn9FC1DlVAcOhepf",
+			"id": "srC8NG2gfdW4aDMP8",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2244,7 +2244,7 @@
 			}
 		},
 		{
-			"id": "skPEPAvvBDwVp7JkS",
+			"id": "sED0jak1J3BTsweTL",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2333,7 +2333,7 @@
 			}
 		},
 		{
-			"id": "saOBWdfN1-GudBvf4",
+			"id": "sK8bIrasfL6mjAm9x",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Minotaur.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Minotaur.gcs
@@ -604,7 +604,7 @@
 	],
 	"traits": [
 		{
-			"id": "teX7HbXitVO3vcFbf",
+			"id": "tG5u1RnCIvED9OdLf",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -744,7 +744,7 @@
 			}
 		},
 		{
-			"id": "tQeKPIdSBDs-aGnCi",
+			"id": "tVXuznkWHAoXj4R8M",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -773,7 +773,7 @@
 			}
 		},
 		{
-			"id": "tmMcg1HZYTYF89Vpg",
+			"id": "t5z_kJlZ6vxXCoozZ",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1139,7 +1139,7 @@
 			}
 		},
 		{
-			"id": "tofq-F9Hebk0YnsK0",
+			"id": "tU1kCfSVk2waSfN7I",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1158,7 +1158,7 @@
 			}
 		},
 		{
-			"id": "ttrjH8Jbgk2ZUGOUV",
+			"id": "t8Be-vHS4Audfqaa-",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1299,7 +1299,7 @@
 			}
 		},
 		{
-			"id": "tbA8zq8QYg7m0eIcQ",
+			"id": "t-6tF0GZvjMZYv7nX",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1637,7 +1637,7 @@
 			}
 		},
 		{
-			"id": "tN17HP7ACGRri5woV",
+			"id": "tKsj4pG1w7JIZglri",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1880,7 +1880,7 @@
 			}
 		},
 		{
-			"id": "tzU2FnAFn4LcxwKrx",
+			"id": "tJhDGzRy1P8MunFs4",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2140,7 +2140,7 @@
 			}
 		},
 		{
-			"id": "t-1FDrKAZXxOnC2pH",
+			"id": "tLpxk5uP2hABA4ANC",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2170,7 +2170,7 @@
 	],
 	"skills": [
 		{
-			"id": "sSn9FC1DlVAcOhepf",
+			"id": "s0cSKkyeHvB5AGS1i",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2207,7 +2207,7 @@
 			}
 		},
 		{
-			"id": "skPEPAvvBDwVp7JkS",
+			"id": "sV4RvfZjBh1GBntgP",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2296,7 +2296,7 @@
 			}
 		},
 		{
-			"id": "saOBWdfN1-GudBvf4",
+			"id": "snmr8k7yQM96qD_Vo",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Spriggan Matron.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Spriggan Matron.gcs
@@ -3066,7 +3066,7 @@
 	],
 	"skills": [
 		{
-			"id": "sV0Y_Bx7wAthKM8gL",
+			"id": "sHuThTvinr5e71IMA",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -3143,7 +3143,7 @@
 			}
 		},
 		{
-			"id": "s0NhbMis4ZcmNCDg3",
+			"id": "sFdJSO8dB2yOWKr5z",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Spriggan.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Spriggan.gcs
@@ -3041,7 +3041,7 @@
 	],
 	"skills": [
 		{
-			"id": "sV0Y_Bx7wAthKM8gL",
+			"id": "s3x_-5Gw_Kfm2q4v5",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -3118,7 +3118,7 @@
 			}
 		},
 		{
-			"id": "s0NhbMis4ZcmNCDg3",
+			"id": "sdRyCASTaRR5sqD15",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Troll, Frost.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Troll, Frost.gcs
@@ -1702,7 +1702,7 @@
 	],
 	"skills": [
 		{
-			"id": "sBEVJh0tuTPpVBEFn",
+			"id": "seiAsKsUv7O0z9PlB",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1776,7 +1776,7 @@
 			}
 		},
 		{
-			"id": "svu9HoV13BZOsZwx4",
+			"id": "sJtoUwtBaPXHnFyhW",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1854,7 +1854,7 @@
 			}
 		},
 		{
-			"id": "sPJp4AL1ddq9ZsU-3",
+			"id": "sZQJ70XHMr4UZFOYa",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Troll.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Monsters/Troll.gcs
@@ -1702,7 +1702,7 @@
 	],
 	"skills": [
 		{
-			"id": "sBEVJh0tuTPpVBEFn",
+			"id": "sQAO6e--l3GwLKzy0",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1771,7 +1771,7 @@
 			}
 		},
 		{
-			"id": "svu9HoV13BZOsZwx4",
+			"id": "sVXbkCjKPmFoeZSsU",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1849,7 +1849,7 @@
 			}
 		},
 		{
-			"id": "sPJp4AL1ddq9ZsU-3",
+			"id": "sJg08c1ooJIQWRxeP",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Riekling/Riekling Chieftain.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Riekling/Riekling Chieftain.gcs
@@ -1398,7 +1398,7 @@
 	],
 	"skills": [
 		{
-			"id": "scK9WnVrJcdWUHQkQ",
+			"id": "sYN2eIBK_9nLsWGsw",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1432,7 +1432,7 @@
 			}
 		},
 		{
-			"id": "sKp6c_z83jfzTlIH_",
+			"id": "sDUO4pIhC1S7wc4_w",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1571,7 +1571,7 @@
 			}
 		},
 		{
-			"id": "sf0FCM06TcNGJxhrD",
+			"id": "sHMdW-XqaJJrHz7d7",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1716,7 +1716,7 @@
 			}
 		},
 		{
-			"id": "sDplziMp8ArXI9hLR",
+			"id": "sqXFNzg9i3XC_YDUH",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1751,7 +1751,7 @@
 			}
 		},
 		{
-			"id": "smxwpudhdOcxHhWNM",
+			"id": "s5ObeYhSxoHUl7iUt",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2352,7 +2352,7 @@
 			}
 		},
 		{
-			"id": "EQ_eIs_EavdPl5_-V",
+			"id": "E7HrDMlVMT2S-HAMT",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Equipment.eqp",
@@ -2371,7 +2371,7 @@
 			"equipped": true,
 			"children": [
 				{
-					"id": "ewri99jjDKlcaOw7U",
+					"id": "eYWCbW_F2lJhudgHY",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Equipment.eqp",
@@ -2421,7 +2421,7 @@
 			"equipped": true,
 			"children": [
 				{
-					"id": "eV2z4SXOV7N93kUkH",
+					"id": "eYVEHbOt_7xMlyUMz",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2455,7 +2455,7 @@
 					}
 				},
 				{
-					"id": "eE_tnicmNN88kVucn",
+					"id": "elnHdVfwrCqLWVr8y",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2510,7 +2510,7 @@
 					}
 				},
 				{
-					"id": "eB0XlSw-eE5f09K4o",
+					"id": "e-x77xkJ87LyNS1QQ",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2544,7 +2544,7 @@
 					}
 				},
 				{
-					"id": "epU4BY6z7XhlZvtut",
+					"id": "e3b2MV73IfFQbNpVa",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2578,7 +2578,7 @@
 					}
 				},
 				{
-					"id": "eDE3JyQMpNEoDpgW1",
+					"id": "exUkcY9zlNHpsOxl1",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2612,7 +2612,7 @@
 					}
 				},
 				{
-					"id": "eczAMmqI4iegejA-X",
+					"id": "e_PCYTa04hWjF6IZr",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Riekling/Riekling Raider.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Riekling/Riekling Raider.gcs
@@ -604,7 +604,7 @@
 	],
 	"traits": [
 		{
-			"id": "t2LgLffsIYfnbKTtq",
+			"id": "tJq_fnC0z6QzTpXUV",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -733,7 +733,7 @@
 			"container_type": "ancestry",
 			"children": [
 				{
-					"id": "tw2u-kenELfCf2cIC",
+					"id": "t1fKndvGy7GQ4oweJ",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1128,7 +1128,7 @@
 					}
 				},
 				{
-					"id": "tcRBmfAUvH1pdv1yt",
+					"id": "tSnnXBUvWrox0H_JK",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1149,7 +1149,7 @@
 					}
 				},
 				{
-					"id": "twVJEYPWCDhHYQ_2K",
+					"id": "t7Ni__3ca1P0CUovq",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1189,7 +1189,7 @@
 					}
 				},
 				{
-					"id": "tCdB1P3sRKIpHspzR",
+					"id": "tdseQpgTklWDtc67W",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1306,7 +1306,7 @@
 	],
 	"skills": [
 		{
-			"id": "scK9WnVrJcdWUHQkQ",
+			"id": "ssJuMVN6cZxhTDRig",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1340,7 +1340,7 @@
 			}
 		},
 		{
-			"id": "sKp6c_z83jfzTlIH_",
+			"id": "s5VOPfL8C4oDGuqPm",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1521,7 +1521,7 @@
 			}
 		},
 		{
-			"id": "sDplziMp8ArXI9hLR",
+			"id": "sfuKBTo2QfiNw0G_e",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1556,7 +1556,7 @@
 			}
 		},
 		{
-			"id": "smxwpudhdOcxHhWNM",
+			"id": "spsmHrB-xctg8o3YW",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1968,7 +1968,7 @@
 			}
 		},
 		{
-			"id": "EQ_eIs_EavdPl5_-V",
+			"id": "EHJYYcn0hG9ZpRWF0",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Equipment.eqp",
@@ -1987,7 +1987,7 @@
 			"equipped": true,
 			"children": [
 				{
-					"id": "ewri99jjDKlcaOw7U",
+					"id": "eRJguXIfIEBawG3oo",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Equipment.eqp",
@@ -2037,7 +2037,7 @@
 			"equipped": true,
 			"children": [
 				{
-					"id": "eV2z4SXOV7N93kUkH",
+					"id": "evSMYp8OKRIOFRYwm",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2071,7 +2071,7 @@
 					}
 				},
 				{
-					"id": "eE_tnicmNN88kVucn",
+					"id": "eSN1-oEEBk5bdfDe1",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2126,7 +2126,7 @@
 					}
 				},
 				{
-					"id": "eB0XlSw-eE5f09K4o",
+					"id": "eNZl6fdevWtThXzsu",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2160,7 +2160,7 @@
 					}
 				},
 				{
-					"id": "epU4BY6z7XhlZvtut",
+					"id": "ewcDykSd3sE1RqJcd",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2194,7 +2194,7 @@
 					}
 				},
 				{
-					"id": "eDE3JyQMpNEoDpgW1",
+					"id": "e6yMfS6h47ZGYupS3",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2228,7 +2228,7 @@
 					}
 				},
 				{
-					"id": "eczAMmqI4iegejA-X",
+					"id": "e8ykS9FgbWmHcpqCu",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Riekling/Riekling.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Riekling/Riekling.gcs
@@ -604,7 +604,7 @@
 	],
 	"traits": [
 		{
-			"id": "t2LgLffsIYfnbKTtq",
+			"id": "tn0t_Nn6B6QJXfHQI",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -625,7 +625,7 @@
 			}
 		},
 		{
-			"id": "ttSgrLHaqq769BWsV",
+			"id": "tDqwej2RvNIbBUtDo",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -1383,7 +1383,7 @@
 	],
 	"skills": [
 		{
-			"id": "scK9WnVrJcdWUHQkQ",
+			"id": "sx8WpXMkyaIzadOLk",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1417,7 +1417,7 @@
 			}
 		},
 		{
-			"id": "sKp6c_z83jfzTlIH_",
+			"id": "s2A45czJOCoOv3cMD",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1503,7 +1503,7 @@
 			}
 		},
 		{
-			"id": "sDplziMp8ArXI9hLR",
+			"id": "sOYe_Mb6aG6rJW-20",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1538,7 +1538,7 @@
 			}
 		},
 		{
-			"id": "smxwpudhdOcxHhWNM",
+			"id": "sWffJd4TCOuat8322",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -1950,7 +1950,7 @@
 			}
 		},
 		{
-			"id": "EQ_eIs_EavdPl5_-V",
+			"id": "E5EdLxLg1qy2yPsV1",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Equipment.eqp",
@@ -1969,7 +1969,7 @@
 			"equipped": true,
 			"children": [
 				{
-					"id": "ewri99jjDKlcaOw7U",
+					"id": "emK8aY-Arc33TPvqQ",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Equipment.eqp",
@@ -2019,7 +2019,7 @@
 			"equipped": true,
 			"children": [
 				{
-					"id": "eV2z4SXOV7N93kUkH",
+					"id": "eFSQqc7zmimROVakb",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2053,7 +2053,7 @@
 					}
 				},
 				{
-					"id": "eE_tnicmNN88kVucn",
+					"id": "ebOuNvemXnDa1xJSn",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2108,7 +2108,7 @@
 					}
 				},
 				{
-					"id": "eB0XlSw-eE5f09K4o",
+					"id": "exSxwzWttgVs95oqK",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2142,7 +2142,7 @@
 					}
 				},
 				{
-					"id": "epU4BY6z7XhlZvtut",
+					"id": "eVQvIMuzvGtDqUtkM",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2176,7 +2176,7 @@
 					}
 				},
 				{
-					"id": "eDE3JyQMpNEoDpgW1",
+					"id": "eTZz3tPmdyd0M4R-B",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",
@@ -2210,7 +2210,7 @@
 					}
 				},
 				{
-					"id": "eczAMmqI4iegejA-X",
+					"id": "emhqzSuvaf2Ou8lZ9",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Instant Armor.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Bonelord.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Bonelord.gcs
@@ -3377,7 +3377,7 @@
 	],
 	"skills": [
 		{
-			"id": "sB6YaN-cLiPAshuZe",
+			"id": "sOXJpkWT06_C35gfc",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Bonewalker, Greater.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Bonewalker, Greater.gcs
@@ -1335,7 +1335,7 @@
 			}
 		},
 		{
-			"id": "tp0M6zAaIZ5Ab3wx2",
+			"id": "tTeZNqgWh7kBjMejB",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -3168,7 +3168,7 @@
 	],
 	"skills": [
 		{
-			"id": "sWykYBEAewpy0XQD6",
+			"id": "sj_xhkcXv2atQLnZS",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Bonewalker.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Bonewalker.gcs
@@ -1336,7 +1336,7 @@
 			}
 		},
 		{
-			"id": "tp0M6zAaIZ5Ab3wx2",
+			"id": "txt973ABYJnF-M42j",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -3094,7 +3094,7 @@
 	],
 	"skills": [
 		{
-			"id": "sWykYBEAewpy0XQD6",
+			"id": "sPjBem_IjyFyroLJW",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Draugr Overlord.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Draugr Overlord.gcs
@@ -604,7 +604,7 @@
 	],
 	"traits": [
 		{
-			"id": "t4ePnCzmgKnJscYRH",
+			"id": "tHJxIVh8tGFZvOKez",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2289,7 +2289,7 @@
 	],
 	"skills": [
 		{
-			"id": "sNQFHX1MjGmzibDu2",
+			"id": "sZUOWiQ-FW-7IzS8g",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2326,7 +2326,7 @@
 			}
 		},
 		{
-			"id": "sqjDz5SMPyBHpWhQa",
+			"id": "sPbse3Y7-gG3jGf0K",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2679,7 +2679,7 @@
 			}
 		},
 		{
-			"id": "san9HkqnAB6VGwQs7",
+			"id": "sqkmtxrxWYYHPztzv",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -3741,7 +3741,7 @@
 							}
 						},
 						{
-							"id": "E-8KYQuh0tF3nSDmC",
+							"id": "E9hDPsURQj4bd_wHm",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Equipment.eqp",
@@ -3760,7 +3760,7 @@
 							"equipped": true,
 							"children": [
 								{
-									"id": "edqQVmkQY6Esm-GFE",
+									"id": "eCFuQwpyrA_K_YzgC",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set/Basic Set Equipment.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Draugr, Greater.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Draugr, Greater.gcs
@@ -604,7 +604,7 @@
 	],
 	"traits": [
 		{
-			"id": "t4ePnCzmgKnJscYRH",
+			"id": "thQbROlR2Q1n-e3Fl",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Traits.adq",
@@ -2289,7 +2289,7 @@
 	],
 	"skills": [
 		{
-			"id": "sNQFHX1MjGmzibDu2",
+			"id": "sxVbyqsu4Kvj6cgfB",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2326,7 +2326,7 @@
 			}
 		},
 		{
-			"id": "sqjDz5SMPyBHpWhQa",
+			"id": "sgq4gkXHQbsC1p1T4",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2679,7 +2679,7 @@
 			}
 		},
 		{
-			"id": "san9HkqnAB6VGwQs7",
+			"id": "sbzyYMeO2KBkvAIDK",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -3741,7 +3741,7 @@
 							}
 						},
 						{
-							"id": "E-8KYQuh0tF3nSDmC",
+							"id": "E5xyUUPBSkJoAFqiS",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Equipment.eqp",
@@ -3760,7 +3760,7 @@
 							"equipped": true,
 							"children": [
 								{
-									"id": "edqQVmkQY6Esm-GFE",
+									"id": "ecf_Z168UPMnd4gcL",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set/Basic Set Equipment.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Draugr.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Draugr.gcs
@@ -2289,7 +2289,7 @@
 	],
 	"skills": [
 		{
-			"id": "sNQFHX1MjGmzibDu2",
+			"id": "sLEi0cwyahJi4ZHkw",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2326,7 +2326,7 @@
 			}
 		},
 		{
-			"id": "sqjDz5SMPyBHpWhQa",
+			"id": "s1P753V8C_yqBg_FQ",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2679,7 +2679,7 @@
 			}
 		},
 		{
-			"id": "san9HkqnAB6VGwQs7",
+			"id": "sP6RfKGuFY65IQp9x",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -3741,7 +3741,7 @@
 							}
 						},
 						{
-							"id": "E-8KYQuh0tF3nSDmC",
+							"id": "ElQZ_G4p217jCYRbl",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Equipment.eqp",
@@ -3760,7 +3760,7 @@
 							"equipped": true,
 							"children": [
 								{
-									"id": "edqQVmkQY6Esm-GFE",
+									"id": "eXlTtnSE6NoCsM0R3",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set/Basic Set Equipment.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Ghost, Greater.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Ghost, Greater.gcs
@@ -1443,7 +1443,7 @@
 					}
 				},
 				{
-					"id": "t6QwnAoZ5nj8UCttV",
+					"id": "tmEfPWYokG7g1HlPj",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1892,7 +1892,7 @@
 	],
 	"skills": [
 		{
-			"id": "shdBiu8MnVjHXagZw",
+			"id": "sJ0IuxoEWRzs28jv2",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Ghost.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Ghost.gcs
@@ -1443,7 +1443,7 @@
 					}
 				},
 				{
-					"id": "t6QwnAoZ5nj8UCttV",
+					"id": "to8EsDHEEySyTuvTO",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -1892,7 +1892,7 @@
 	],
 	"skills": [
 		{
-			"id": "shdBiu8MnVjHXagZw",
+			"id": "s3vkdpjMEiSkLdfZd",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Lich.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Lich.gcs
@@ -2319,7 +2319,7 @@
 	],
 	"skills": [
 		{
-			"id": "sB6YaN-cLiPAshuZe",
+			"id": "sUdabqMtdFkUGyVOB",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -3790,7 +3790,7 @@
 			],
 			"modifiers": [
 				{
-					"id": "fyuQbacq2m5SLKSI9",
+					"id": "fAgZBfKVEezHiPaTW",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Equipment Modifiers.eqm",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Skeletal Dragon.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Skeletal Dragon.gcs
@@ -866,7 +866,7 @@
 							"cost_adj": "-10%"
 						},
 						{
-							"id": "mazsk4jdjP8T9w_sF",
+							"id": "mQzi2UIwiAHefEaeM",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Limitation Modifiers.adm",
@@ -2036,7 +2036,7 @@
 					}
 				},
 				{
-					"id": "t8D6Yy76LDaykLhMw",
+					"id": "t7uuJpSQJ_MWxIZL7",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Basic Set/Basic Set Traits.adq",
@@ -3307,7 +3307,7 @@
 			}
 		},
 		{
-			"id": "s7Kdubd9Oa-5Ylsu_",
+			"id": "s8aiPrAvqHn6TUJLE",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Skeleton Champion.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Skeleton Champion.gcs
@@ -2464,7 +2464,7 @@
 	],
 	"skills": [
 		{
-			"id": "sB6YaN-cLiPAshuZe",
+			"id": "sfpYvC85sz3xb_P25",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2501,7 +2501,7 @@
 			}
 		},
 		{
-			"id": "sMFBcTyC5VRRUe2vK",
+			"id": "sloF9cIVuNAP7Ga8n",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2854,7 +2854,7 @@
 			}
 		},
 		{
-			"id": "sFmF_8t3DjZny6WoF",
+			"id": "seyw0FiSvWNGtAXVC",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -4006,7 +4006,7 @@
 							}
 						},
 						{
-							"id": "EZHjJ5Toh3_59FMmC",
+							"id": "ERLR1fmqMeeM7K1H6",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Equipment.eqp",
@@ -4025,7 +4025,7 @@
 							"equipped": true,
 							"children": [
 								{
-									"id": "esPKXTGa9W-h9ydH5",
+									"id": "e-TEddxEMDpFloDee",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set/Basic Set Equipment.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Skeleton Hero.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Skeleton Hero.gcs
@@ -2465,7 +2465,7 @@
 	],
 	"skills": [
 		{
-			"id": "sB6YaN-cLiPAshuZe",
+			"id": "s5ie0E79FbzJiO2DT",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2502,7 +2502,7 @@
 			}
 		},
 		{
-			"id": "sMFBcTyC5VRRUe2vK",
+			"id": "sWKKEuv1lAi8MOO1Q",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2855,7 +2855,7 @@
 			}
 		},
 		{
-			"id": "sFmF_8t3DjZny6WoF",
+			"id": "sk8_B3qurtNxqZ5jM",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -4007,7 +4007,7 @@
 							}
 						},
 						{
-							"id": "EZHjJ5Toh3_59FMmC",
+							"id": "E1tW9Fu7L2l3ZAW5P",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Equipment.eqp",
@@ -4026,7 +4026,7 @@
 							"equipped": true,
 							"children": [
 								{
-									"id": "esPKXTGa9W-h9ydH5",
+									"id": "ehBFe3MhQbar9NCem",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Basic Set/Basic Set Equipment.eqp",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Skeleton War-Wizard.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Skeleton War-Wizard.gcs
@@ -2573,7 +2573,7 @@
 	],
 	"skills": [
 		{
-			"id": "sB6YaN-cLiPAshuZe",
+			"id": "sD-BLGYkRvCcMrxEP",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -3285,7 +3285,7 @@
 			],
 			"modifiers": [
 				{
-					"id": "fyuQbacq2m5SLKSI9",
+					"id": "fbT3gpzzInJ46Dq6q",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Low Tech/Low Tech Equipment Modifiers.eqm",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Skeleton.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Skeleton.gcs
@@ -2464,7 +2464,7 @@
 	],
 	"skills": [
 		{
-			"id": "sB6YaN-cLiPAshuZe",
+			"id": "sJgQD2G3WE2srCMWe",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2501,7 +2501,7 @@
 			}
 		},
 		{
-			"id": "sMFBcTyC5VRRUe2vK",
+			"id": "srnC1hvHcRpqIptru",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Wisp.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Wisp.gcs
@@ -1059,7 +1059,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mgXpDRRZYvW2TftcN",
+							"id": "mUOb0D6WCxJanZxwO",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
@@ -2235,7 +2235,7 @@
 			}
 		},
 		{
-			"id": "sTuJEl6d5s8fX8P8i",
+			"id": "sOPupluvhUqN2Rq5h",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Wispmother.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Wispmother.gcs
@@ -1225,7 +1225,7 @@
 							"disabled": true
 						},
 						{
-							"id": "mgXpDRRZYvW2TftcN",
+							"id": "m2za8gFYcV-mLxfFF",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Basic Set/Basic Set Enhancement Modifiers.adm",
@@ -2599,7 +2599,7 @@
 			}
 		},
 		{
-			"id": "sTuJEl6d5s8fX8P8i",
+			"id": "sRzj2gx3DV_CnW4HV",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Zombie, Dread.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Zombie, Dread.gcs
@@ -2059,7 +2059,7 @@
 	],
 	"skills": [
 		{
-			"id": "sOM27gAdUMuyd-DlB",
+			"id": "s6cwmQ6EwB3P0D_fn",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2096,7 +2096,7 @@
 			}
 		},
 		{
-			"id": "skgWQHXK9M2hCNtKW",
+			"id": "stKGMH7o0zK9Z-q8l",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Zombie, Greater.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Zombie, Greater.gcs
@@ -2059,7 +2059,7 @@
 	],
 	"skills": [
 		{
-			"id": "sOM27gAdUMuyd-DlB",
+			"id": "sXZHUd5HYmFxsTq36",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2096,7 +2096,7 @@
 			}
 		},
 		{
-			"id": "skgWQHXK9M2hCNtKW",
+			"id": "sGQrKPs3PRKCeebjL",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Zombie.gcs
+++ b/Library/Home Brew/Ptolemy's Elder Scrolls/Elder Scrolls Bestiary/Undead/Zombie.gcs
@@ -2059,7 +2059,7 @@
 	],
 	"skills": [
 		{
-			"id": "sOM27gAdUMuyd-DlB",
+			"id": "sy86OoHAOrCKLQFuY",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",
@@ -2096,7 +2096,7 @@
 			}
 		},
 		{
-			"id": "skgWQHXK9M2hCNtKW",
+			"id": "sOqtojo7BslFqgmPn",
 			"source": {
 				"library": "richardwilkes/gcs_master_library",
 				"path": "Basic Set/Basic Set Skills.skl",

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/Life-Force Devourer.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/Life-Force Devourer.gct
@@ -68,7 +68,7 @@
 					}
 				},
 				{
-					"id": "tiMOyfmvC751FSzGp",
+					"id": "tho577dgThow5iE-e",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Psionics/Psionics Traits.adq",

--- a/Library/Psionics/Psionic Packages/Psychic Vampirism/System Shock.gct
+++ b/Library/Psionics/Psionic Packages/Psychic Vampirism/System Shock.gct
@@ -254,7 +254,7 @@
 					}
 				},
 				{
-					"id": "tiMOyfmvC751FSzGp",
+					"id": "tr0F_Jc_awYk83q5P",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Psionics/Psionics Traits.adq",

--- a/Library/Psionics/Psionic Packages/Telepathy/Mental Mastery.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Mental Mastery.gct
@@ -379,7 +379,7 @@
 					"container_type": "alternative_abilities",
 					"children": [
 						{
-							"id": "twYs-dNYT0FCvu0Gw",
+							"id": "tVOilIbzlr9Tpsw9n",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Psionics/Psionics Traits.adq",

--- a/Library/Psionics/Psionic Packages/Telepathy/Thought Thief.gct
+++ b/Library/Psionics/Psionic Packages/Telepathy/Thought Thief.gct
@@ -8,7 +8,7 @@
 			"reference": "PSIS32",
 			"children": [
 				{
-					"id": "twYs-dNYT0FCvu0Gw",
+					"id": "tjCHMj8mma4wiYA43",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Psionics/Psionics Traits.adq",

--- a/Library/Psionics/Psionic Packages/Teleportation/Fetching.gct
+++ b/Library/Psionics/Psionic Packages/Teleportation/Fetching.gct
@@ -53,7 +53,7 @@
 			"reference": "PSIS33",
 			"children": [
 				{
-					"id": "s1TlOCwWYlSjTJfNW",
+					"id": "sn-XpchXyOGmLqD-8",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Psionics/Psionics Skills.skl",

--- a/Library/Psionics/Psionic Packages/Teleportation/Hop Other.gct
+++ b/Library/Psionics/Psionic Packages/Teleportation/Hop Other.gct
@@ -151,7 +151,7 @@
 			"reference": "PSIS33",
 			"children": [
 				{
-					"id": "s1TlOCwWYlSjTJfNW",
+					"id": "s4fu2-6xChLmZ01ju",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Psionics/Psionics Skills.skl",

--- a/Library/Psionics/Psionic Packages/Teleportation/Object-Sending.gct
+++ b/Library/Psionics/Psionic Packages/Teleportation/Object-Sending.gct
@@ -72,7 +72,7 @@
 			"reference": "PSIS33",
 			"children": [
 				{
-					"id": "s1TlOCwWYlSjTJfNW",
+					"id": "sIoNzyTLhTyn19ATL",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Psionics/Psionics Skills.skl",

--- a/Library/Psionics/Psionic Packages/Teleportation/Personal Teleportation.gct
+++ b/Library/Psionics/Psionic Packages/Teleportation/Personal Teleportation.gct
@@ -182,7 +182,7 @@
 			"reference": "PSIS33",
 			"children": [
 				{
-					"id": "sppCvJINSp4cpmYgG",
+					"id": "sThqXOmMixC8TqH8b",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Psionics/Psionics Skills.skl",

--- a/Library/Psionics/Psionic Packages/Teleportation/Tele-Dodge.gct
+++ b/Library/Psionics/Psionic Packages/Teleportation/Tele-Dodge.gct
@@ -49,7 +49,7 @@
 			"reference": "PSIS33",
 			"children": [
 				{
-					"id": "sppCvJINSp4cpmYgG",
+					"id": "sHfYeMRWZ0U186EKI",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Psionics/Psionics Skills.skl",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Brute Warrior 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Brute Warrior 2.gct
@@ -87,7 +87,7 @@
 							}
 						},
 						{
-							"id": "t1mgivdAB_u8don8z",
+							"id": "tNN-x7RIXvsKm82Jb",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -325,7 +325,7 @@
 							}
 						},
 						{
-							"id": "tHJProNPwj_wmbmV2",
+							"id": "t_Ad6UQQAANK9pT6y",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -355,7 +355,7 @@
 							}
 						},
 						{
-							"id": "ty-fShq8n4vkH7vNc",
+							"id": "tgU_MdK8zLhTnRWKi",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -384,7 +384,7 @@
 							}
 						},
 						{
-							"id": "t9fgNUMhVSpFrurm-",
+							"id": "tqAu-TjoLcy1W_VMZ",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -405,7 +405,7 @@
 							}
 						},
 						{
-							"id": "tq9er08Lec293FieT",
+							"id": "tIgcVY3Hl1k8aTmDP",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -452,7 +452,7 @@
 							}
 						},
 						{
-							"id": "tYRPY46EgsbF75sNY",
+							"id": "ttsPSseBWzZW-YkEO",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -507,7 +507,7 @@
 							}
 						},
 						{
-							"id": "tBUUsjPYTYU22uLIz",
+							"id": "tvwdoVYHpgQmHX8NY",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -540,7 +540,7 @@
 							}
 						},
 						{
-							"id": "tk2rb6R_LaVFMI4P2",
+							"id": "t2IqKVK5bEODicPFO",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -573,7 +573,7 @@
 							}
 						},
 						{
-							"id": "tN6jfB-tShD0q4863",
+							"id": "tUFhqaGtEVOxLbAVg",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -592,7 +592,7 @@
 							}
 						},
 						{
-							"id": "tZ04_MLkr4NYHMTfr",
+							"id": "tBpL0xBD3a9W1HK7k",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -611,7 +611,7 @@
 							}
 						},
 						{
-							"id": "tD0QkMfQIane23qr2",
+							"id": "tkDjuHX7d0RLAbeN_",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -630,7 +630,7 @@
 							}
 						},
 						{
-							"id": "tYhqDEj8Ke4tNGdL2",
+							"id": "ta7kk-LFAlIn2WfwK",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -771,7 +771,7 @@
 							}
 						},
 						{
-							"id": "tqGytob4FZumMVOBG",
+							"id": "tYgBgMqI1zbMZznL7",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -808,7 +808,7 @@
 							}
 						},
 						{
-							"id": "t7RjlhzYifu0Xt4qq",
+							"id": "tfLBXANTpoe7fu1lk",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -944,7 +944,7 @@
 							}
 						},
 						{
-							"id": "thCOxca0uyoptocOq",
+							"id": "tI07DsQ1HUcTa_UJP",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -970,7 +970,7 @@
 							}
 						},
 						{
-							"id": "tNRrj8WucApFY92mX",
+							"id": "tpXHqMtEwWABybMoS",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -988,7 +988,7 @@
 							}
 						},
 						{
-							"id": "tDKbpuOCNvsX9Z3Sd",
+							"id": "tzGRyeOa9xh_Bm23c",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -2565,7 +2565,7 @@
 			},
 			"children": [
 				{
-					"id": "sAy44EhFdSwL48vNc",
+					"id": "s_FZ8sTVhQYCTjtIx",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2595,7 +2595,7 @@
 					"points": 1
 				},
 				{
-					"id": "srLACHNH2pp4GFZHW",
+					"id": "s6YxT91zUNdT5XgcD",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2625,7 +2625,7 @@
 					"points": 1
 				},
 				{
-					"id": "sheZjJiNTXdq9oEFx",
+					"id": "sBLhmdA35WXKszSZ2",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2655,7 +2655,7 @@
 					"points": 1
 				},
 				{
-					"id": "syc8HWzE-DWCymaRS",
+					"id": "sp6JVyS_EpsnD2uF6",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2688,7 +2688,7 @@
 					"points": 1
 				},
 				{
-					"id": "sVpLg6WhhTmX6yCDr",
+					"id": "sc4MXb_pyLIJnKG3w",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2711,7 +2711,7 @@
 					"points": 1
 				},
 				{
-					"id": "sKArCLyRAjNU7w0y1",
+					"id": "s2ByYTu5XSvLfmH36",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2734,7 +2734,7 @@
 					"points": 1
 				},
 				{
-					"id": "sEk2gc_zFNPmK8ho2",
+					"id": "sNkMs5AijtYi3nzZI",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2781,7 +2781,7 @@
 					"points": 1
 				},
 				{
-					"id": "s0cOZ4lfX4JlpquA1",
+					"id": "sWWqlrT8OI3cZ0GtN",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2862,7 +2862,7 @@
 					"points": 1
 				},
 				{
-					"id": "sx3Yrj7bbgPB93NGy",
+					"id": "s2zgair2Z41vmZy-9",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2895,7 +2895,7 @@
 					"points": 1
 				},
 				{
-					"id": "sav9879ukTfFZNyi6",
+					"id": "sQ4F6LgHsxsbUnHO9",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2920,7 +2920,7 @@
 					"points": 1
 				},
 				{
-					"id": "s3sL0xHql8f1deiLB",
+					"id": "srsSDMfQy811lJ9_F",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2943,7 +2943,7 @@
 					"points": 1
 				},
 				{
-					"id": "sYhKv5PiKI1ySuicF",
+					"id": "sXtDs-kEFnQa3ZcLQ",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2961,7 +2961,7 @@
 					"points": 1
 				},
 				{
-					"id": "seQzxSaGOfTVLLBD0",
+					"id": "sbq-33FOx7ahVaXiz",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2979,7 +2979,7 @@
 					"points": 1
 				},
 				{
-					"id": "sF9DHGYOPNQfZzcvW",
+					"id": "sDMlqZD8p690Hxmsg",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2997,7 +2997,7 @@
 					"points": 1
 				},
 				{
-					"id": "sLQFxhOZX8FumWqEb",
+					"id": "sBzCMe9_HCO1JHkYM",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3014,7 +3014,7 @@
 					"points": 1
 				},
 				{
-					"id": "sG7hzTdkckY_LHbTC",
+					"id": "s9_rsdluNoEpqjMdO",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3031,7 +3031,7 @@
 					"points": 1
 				},
 				{
-					"id": "saJgM1TPGsSTrpuQK",
+					"id": "s34-L0GXqnGLRBcJk",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3049,7 +3049,7 @@
 					"points": 1
 				},
 				{
-					"id": "suqRG5qRjj7nej6Jm",
+					"id": "sUPDrianGrXfBKODf",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3067,7 +3067,7 @@
 					"points": 1
 				},
 				{
-					"id": "stigl1-97zF5OyYak",
+					"id": "syDIaWMvA_HCiMsgd",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3100,7 +3100,7 @@
 					"points": 1
 				},
 				{
-					"id": "sEvsajLKbBkbmq5CQ",
+					"id": "sQ7rgxCog97RqawdP",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3118,7 +3118,7 @@
 					"points": 1
 				},
 				{
-					"id": "smBFgvOTYFXrZMLl_",
+					"id": "sHMjeLcIXGE6DrljE",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3185,7 +3185,7 @@
 					"points": 1
 				},
 				{
-					"id": "sBDJaDEpGS4M4kuqe",
+					"id": "sgjx7zz_hrqW3mrLP",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3223,7 +3223,7 @@
 					"points": 1
 				},
 				{
-					"id": "sDPtC0-vDTmRKEZ1J",
+					"id": "slRVsB1U6NaU65S0C",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3266,7 +3266,7 @@
 					"points": 1
 				},
 				{
-					"id": "sYm6JaZgeblp6huFx",
+					"id": "sXIdx9t-193HTAoj5",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3288,7 +3288,7 @@
 					"points": 1
 				},
 				{
-					"id": "sq7OznlR0GRQZi1jF",
+					"id": "sVD0VTtdeOnDEBGam",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3351,7 +3351,7 @@
 					"points": 1
 				},
 				{
-					"id": "sQrujlXoM31sLcAXf",
+					"id": "sJIYXerbBdhS49Kn8",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3389,7 +3389,7 @@
 					"points": 1
 				},
 				{
-					"id": "sLc-pVcs90mp7MfrE",
+					"id": "sYBZa_bRQRJFrs74Z",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3432,7 +3432,7 @@
 					"points": 1
 				},
 				{
-					"id": "syzYQpGY45HyBtwfm",
+					"id": "s0SwOgj09bW1YN67E",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3480,7 +3480,7 @@
 					"points": 1
 				},
 				{
-					"id": "s7gIHnx1RSEpIK6y9",
+					"id": "shjfMkfHQ6RLANFeU",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3509,7 +3509,7 @@
 					"points": 1
 				},
 				{
-					"id": "swqJ6rA0Y76mRSUtw",
+					"id": "sLN11XJa3hjXctWX6",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3538,7 +3538,7 @@
 					"points": 1
 				},
 				{
-					"id": "senX4uaDPc_xc1FHf",
+					"id": "s2BlIuJfb12du_wJe",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3596,7 +3596,7 @@
 					"points": 1
 				},
 				{
-					"id": "ssl5qTEbQEc4t8nDL",
+					"id": "sMgYyTBwQMFaNp4Ka",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3662,7 +3662,7 @@
 					"points": 1
 				},
 				{
-					"id": "sylhFfo74A9DEwdaO",
+					"id": "sCXA-5YRNK5p1OwqK",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3695,7 +3695,7 @@
 					"points": 1
 				},
 				{
-					"id": "s6RBqyZ5k43l3Xxte",
+					"id": "swZOFwSGSgn_VZsFi",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3757,7 +3757,7 @@
 					"points": 1
 				},
 				{
-					"id": "s27NG3fh2TsxgEeZV",
+					"id": "sGibzQhYWi3LtsxI_",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3788,7 +3788,7 @@
 					"points": 1
 				},
 				{
-					"id": "sL74wClldtA_OpxSE",
+					"id": "sLDvBWqU6Es31QeP5",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3805,7 +3805,7 @@
 					"points": 1
 				},
 				{
-					"id": "s8dHOZvMe5jGOedFu",
+					"id": "sLqies3yjJ9eu8IqZ",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3832,7 +3832,7 @@
 					"points": 1
 				},
 				{
-					"id": "sqKPu1_2YZAnbrqtV",
+					"id": "sSewGocOA3C9yLCrW",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3856,7 +3856,7 @@
 					"points": 1
 				},
 				{
-					"id": "sHQyhWTv2s32IG--e",
+					"id": "s5pUNenJtohTzxBx1",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3880,7 +3880,7 @@
 					"points": 1
 				},
 				{
-					"id": "spWjokfAMfO_VCyJL",
+					"id": "s7vliA0q1uMoujbjs",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3909,7 +3909,7 @@
 					"points": 1
 				},
 				{
-					"id": "silmCCjB3xrbjGiRa",
+					"id": "sVxxii2lUip--eelK",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3939,7 +3939,7 @@
 					"points": 1
 				},
 				{
-					"id": "snNM9QatJB2wG1__M",
+					"id": "s08WuKnrsDNKJ-SxU",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3963,7 +3963,7 @@
 					"points": 1
 				},
 				{
-					"id": "ss544AamEMw1PcqVZ",
+					"id": "sCKPQub3cd9pycgnD",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -3992,7 +3992,7 @@
 					"points": 1
 				},
 				{
-					"id": "sVnXc1t0aVzJWfTEa",
+					"id": "sZKdSWkjCDnUntgV0",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -4027,7 +4027,7 @@
 					"points": 1
 				},
 				{
-					"id": "sj3AzgP-4fPtXqZQX",
+					"id": "siqXL3YNg3t3Md_0a",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -4051,7 +4051,7 @@
 					"points": 1
 				},
 				{
-					"id": "sZvxlsyXzzcVKJUAz",
+					"id": "sLlCCLuLoqNuVlhOI",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -4079,7 +4079,7 @@
 					"points": 1
 				},
 				{
-					"id": "s4HwUUSPAuwoLGm0h",
+					"id": "sdjOx4pC6oZDiyS6U",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -4117,7 +4117,7 @@
 					"points": 1
 				},
 				{
-					"id": "skGgWKWCv4LN9SxZn",
+					"id": "sqtozcPKSi-r4d-tX",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -4193,7 +4193,7 @@
 					"points": 1
 				},
 				{
-					"id": "ssfvubUwcAoB1EAdO",
+					"id": "siHzq5_yYw4XT7p6Y",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -4226,7 +4226,7 @@
 					"points": 1
 				},
 				{
-					"id": "sSkB5WafXTMP75mvj",
+					"id": "sFUSxmUwSdu3L6vSR",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -4264,7 +4264,7 @@
 					"points": 1
 				},
 				{
-					"id": "ssZFNrAV1QeGufDTd",
+					"id": "sLJ4-nJMd8mqoIBS7",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Brute Warrior.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Brute Warrior.gct
@@ -19,7 +19,7 @@
 					},
 					"children": [
 						{
-							"id": "t1mgivdAB_u8don8z",
+							"id": "tHD58pPWFkn90pC9D",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -145,7 +145,7 @@
 							}
 						},
 						{
-							"id": "tHJProNPwj_wmbmV2",
+							"id": "tPK7X949isipRBJXJ",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -175,7 +175,7 @@
 							}
 						},
 						{
-							"id": "ty-fShq8n4vkH7vNc",
+							"id": "tAYXdzYW-YqydJ83_",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -204,7 +204,7 @@
 							}
 						},
 						{
-							"id": "t9fgNUMhVSpFrurm-",
+							"id": "tbYmYCurQwbxxT_7n",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -225,7 +225,7 @@
 							}
 						},
 						{
-							"id": "tq9er08Lec293FieT",
+							"id": "tgmsf1FIjT00I4djB",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -272,7 +272,7 @@
 							}
 						},
 						{
-							"id": "tYRPY46EgsbF75sNY",
+							"id": "tH0oX_Bb5TFdn60ar",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -327,7 +327,7 @@
 							}
 						},
 						{
-							"id": "tBUUsjPYTYU22uLIz",
+							"id": "tPMuU7EV3HZPmaFDg",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -360,7 +360,7 @@
 							}
 						},
 						{
-							"id": "tk2rb6R_LaVFMI4P2",
+							"id": "t7zqpb46xdk4WEX50",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -393,7 +393,7 @@
 							}
 						},
 						{
-							"id": "tN6jfB-tShD0q4863",
+							"id": "tB7cKCu_T3SRZJrHZ",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -412,7 +412,7 @@
 							}
 						},
 						{
-							"id": "tZ04_MLkr4NYHMTfr",
+							"id": "t7i5Ea63Z_J62zpe0",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -431,7 +431,7 @@
 							}
 						},
 						{
-							"id": "tD0QkMfQIane23qr2",
+							"id": "tNRdLI1T8MEJETHJa",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -450,7 +450,7 @@
 							}
 						},
 						{
-							"id": "tYhqDEj8Ke4tNGdL2",
+							"id": "tO0DFAIRZBam4OGur",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -591,7 +591,7 @@
 							}
 						},
 						{
-							"id": "tqGytob4FZumMVOBG",
+							"id": "tP-KvWrvCBE8M1ac6",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -628,7 +628,7 @@
 							}
 						},
 						{
-							"id": "t7RjlhzYifu0Xt4qq",
+							"id": "tmo3PjdL6Eh0MT2Z2",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -764,7 +764,7 @@
 							}
 						},
 						{
-							"id": "thCOxca0uyoptocOq",
+							"id": "t0zvPMUmDk5yQ-hpU",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -790,7 +790,7 @@
 							}
 						},
 						{
-							"id": "tNRrj8WucApFY92mX",
+							"id": "ttKAIVSj2hvvJgWgu",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -808,7 +808,7 @@
 							}
 						},
 						{
-							"id": "tDKbpuOCNvsX9Z3Sd",
+							"id": "tINzHkDn-GUNrkHky",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -898,7 +898,7 @@
 					},
 					"children": [
 						{
-							"id": "syc8HWzE-DWCymaRS",
+							"id": "sxLRZsyEqngM9og7S",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -931,7 +931,7 @@
 							"points": 1
 						},
 						{
-							"id": "stigl1-97zF5OyYak",
+							"id": "sihi3ERR026fvZVa7",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1002,7 +1002,7 @@
 							"points": 1
 						},
 						{
-							"id": "sBDJaDEpGS4M4kuqe",
+							"id": "sGmTfIBKxby1SAtJ2",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1040,7 +1040,7 @@
 							"points": 1
 						},
 						{
-							"id": "sDPtC0-vDTmRKEZ1J",
+							"id": "s1PcuDaunKGyrxE_i",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1179,7 +1179,7 @@
 							"points": 1
 						},
 						{
-							"id": "sQrujlXoM31sLcAXf",
+							"id": "s4NC9hKpw_xmiXg_p",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1217,7 +1217,7 @@
 							"points": 1
 						},
 						{
-							"id": "sLc-pVcs90mp7MfrE",
+							"id": "s1Hn0aD_BkoWJiI5p",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1260,7 +1260,7 @@
 							"points": 1
 						},
 						{
-							"id": "syzYQpGY45HyBtwfm",
+							"id": "sazzuzH7pcAT_0GGb",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1308,7 +1308,7 @@
 							"points": 1
 						},
 						{
-							"id": "senX4uaDPc_xc1FHf",
+							"id": "sB8HpDM9o9Qw_ADyJ",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1409,7 +1409,7 @@
 							"points": 1
 						},
 						{
-							"id": "sylhFfo74A9DEwdaO",
+							"id": "saFGlrE-ivsKkVj9h",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1475,7 +1475,7 @@
 							"points": 1
 						},
 						{
-							"id": "sZvxlsyXzzcVKJUAz",
+							"id": "s7658mfVUALuBnzvO",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1503,7 +1503,7 @@
 							"points": 1
 						},
 						{
-							"id": "s4HwUUSPAuwoLGm0h",
+							"id": "sfRKKjoLNII3t4k9Z",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1541,7 +1541,7 @@
 							"points": 1
 						},
 						{
-							"id": "skGgWKWCv4LN9SxZn",
+							"id": "sMKEq3Z4_DK3ZSFnS",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1579,7 +1579,7 @@
 							"points": 1
 						},
 						{
-							"id": "ssfvubUwcAoB1EAdO",
+							"id": "s2tWPeU-w3ocWyB1F",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1612,7 +1612,7 @@
 							"points": 1
 						},
 						{
-							"id": "sSkB5WafXTMP75mvj",
+							"id": "sbkBI1WCq4X1i44kI",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1663,7 +1663,7 @@
 					},
 					"children": [
 						{
-							"id": "sAy44EhFdSwL48vNc",
+							"id": "seTDKWGAy2oxLqo21",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1693,7 +1693,7 @@
 							"points": 1
 						},
 						{
-							"id": "srLACHNH2pp4GFZHW",
+							"id": "s9HD9n3Gp_VWWe1kX",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1723,7 +1723,7 @@
 							"points": 1
 						},
 						{
-							"id": "sheZjJiNTXdq9oEFx",
+							"id": "s0xAhfib-T0M_cMOU",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1753,7 +1753,7 @@
 							"points": 1
 						},
 						{
-							"id": "sVpLg6WhhTmX6yCDr",
+							"id": "sojSJZ4mbI3ESYIts",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1776,7 +1776,7 @@
 							"points": 1
 						},
 						{
-							"id": "sKArCLyRAjNU7w0y1",
+							"id": "soG_OK5XWHOiV1N1A",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1799,7 +1799,7 @@
 							"points": 1
 						},
 						{
-							"id": "sEk2gc_zFNPmK8ho2",
+							"id": "s2taN1g4Z73h31zdh",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1846,7 +1846,7 @@
 							"points": 1
 						},
 						{
-							"id": "s0cOZ4lfX4JlpquA1",
+							"id": "shMg_zbYMKPqxxkYb",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1879,7 +1879,7 @@
 							"points": 1
 						},
 						{
-							"id": "sx3Yrj7bbgPB93NGy",
+							"id": "s4u0SNK_PlYcF3TSI",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1912,7 +1912,7 @@
 							"points": 1
 						},
 						{
-							"id": "sav9879ukTfFZNyi6",
+							"id": "sqaCkL7DL_F-ANSaJ",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1937,7 +1937,7 @@
 							"points": 1
 						},
 						{
-							"id": "s3sL0xHql8f1deiLB",
+							"id": "sUJg4Q03-X3IHCYWs",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1960,7 +1960,7 @@
 							"points": 1
 						},
 						{
-							"id": "sYhKv5PiKI1ySuicF",
+							"id": "sxu2Ri-j8zw9JGAQf",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1978,7 +1978,7 @@
 							"points": 1
 						},
 						{
-							"id": "seQzxSaGOfTVLLBD0",
+							"id": "sS6xy7J1DxxMhWaIL",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1996,7 +1996,7 @@
 							"points": 1
 						},
 						{
-							"id": "sF9DHGYOPNQfZzcvW",
+							"id": "sb8teUcBdd_9sIF_C",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2014,7 +2014,7 @@
 							"points": 1
 						},
 						{
-							"id": "sLQFxhOZX8FumWqEb",
+							"id": "sf6vobVBrjZzE9leg",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2031,7 +2031,7 @@
 							"points": 1
 						},
 						{
-							"id": "sG7hzTdkckY_LHbTC",
+							"id": "shNq06BpqYJ5MKsuO",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2048,7 +2048,7 @@
 							"points": 1
 						},
 						{
-							"id": "saJgM1TPGsSTrpuQK",
+							"id": "sqWVQAn_NqHx5LvX8",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2066,7 +2066,7 @@
 							"points": 1
 						},
 						{
-							"id": "suqRG5qRjj7nej6Jm",
+							"id": "s_kyyHVpUHzsO63Pi",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2084,7 +2084,7 @@
 							"points": 1
 						},
 						{
-							"id": "sEvsajLKbBkbmq5CQ",
+							"id": "sCjuQ-rv2yWbFtIyz",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2102,7 +2102,7 @@
 							"points": 1
 						},
 						{
-							"id": "smBFgvOTYFXrZMLl_",
+							"id": "s4tI_ZZXYoY_79yDh",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2131,7 +2131,7 @@
 							"points": 1
 						},
 						{
-							"id": "sYm6JaZgeblp6huFx",
+							"id": "sSo1qGJTvJL8iEKOS",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2153,7 +2153,7 @@
 							"points": 1
 						},
 						{
-							"id": "sq7OznlR0GRQZi1jF",
+							"id": "s0vsLdXC50tPL46vK",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2168,7 +2168,7 @@
 							"points": 1
 						},
 						{
-							"id": "s7gIHnx1RSEpIK6y9",
+							"id": "sUrxttridtOiFrj3H",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2197,7 +2197,7 @@
 							"points": 1
 						},
 						{
-							"id": "swqJ6rA0Y76mRSUtw",
+							"id": "s6D1HPMmGsi-A7CjK",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2226,7 +2226,7 @@
 							"points": 1
 						},
 						{
-							"id": "ssl5qTEbQEc4t8nDL",
+							"id": "slFOlv99gKrlqoPGn",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2249,7 +2249,7 @@
 							"points": 1
 						},
 						{
-							"id": "s6RBqyZ5k43l3Xxte",
+							"id": "sdzTeYPb6E5lmQGyn",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2278,7 +2278,7 @@
 							"points": 1
 						},
 						{
-							"id": "s27NG3fh2TsxgEeZV",
+							"id": "sS5DlPt8Pzg0tbwCe",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2309,7 +2309,7 @@
 							"points": 1
 						},
 						{
-							"id": "sL74wClldtA_OpxSE",
+							"id": "scK-Itjjyz1owhqov",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2326,7 +2326,7 @@
 							"points": 1
 						},
 						{
-							"id": "s8dHOZvMe5jGOedFu",
+							"id": "szpx1SSx9L_71r9Xo",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2353,7 +2353,7 @@
 							"points": 1
 						},
 						{
-							"id": "sqKPu1_2YZAnbrqtV",
+							"id": "sWkZx-nY59hSfkS7I",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2377,7 +2377,7 @@
 							"points": 1
 						},
 						{
-							"id": "sHQyhWTv2s32IG--e",
+							"id": "spLzWSxejnlHQjiB9",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2401,7 +2401,7 @@
 							"points": 1
 						},
 						{
-							"id": "spWjokfAMfO_VCyJL",
+							"id": "sOsOgTAVhlPbzmquP",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2430,7 +2430,7 @@
 							"points": 1
 						},
 						{
-							"id": "silmCCjB3xrbjGiRa",
+							"id": "s16CO8Hk6W4sNFOWa",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2460,7 +2460,7 @@
 							"points": 1
 						},
 						{
-							"id": "snNM9QatJB2wG1__M",
+							"id": "s53Zpixprlolj9Gzc",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2484,7 +2484,7 @@
 							"points": 1
 						},
 						{
-							"id": "ss544AamEMw1PcqVZ",
+							"id": "s_q4glhZVeyTkQLQl",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2513,7 +2513,7 @@
 							"points": 1
 						},
 						{
-							"id": "sVnXc1t0aVzJWfTEa",
+							"id": "sGCqMTcWEQRiI9RiO",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2548,7 +2548,7 @@
 							"points": 1
 						},
 						{
-							"id": "sj3AzgP-4fPtXqZQX",
+							"id": "szla3oUj9c4p_lVQh",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -2572,7 +2572,7 @@
 							"points": 1
 						},
 						{
-							"id": "ssZFNrAV1QeGufDTd",
+							"id": "s7jZ9XHDnIf3W3oeU",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Cerebral 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Cerebral 2.gct
@@ -198,7 +198,7 @@
 							}
 						},
 						{
-							"id": "t41st5rlBWjBfJQ7b",
+							"id": "tDeQrgcZKwyhRsik-",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Cerebral.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Cerebral.gct
@@ -198,7 +198,7 @@
 							}
 						},
 						{
-							"id": "t41st5rlBWjBfJQ7b",
+							"id": "tHOWrb4GJFMXkYvDz",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Crusader 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Crusader 2.gct
@@ -425,7 +425,7 @@
 							"points": 1
 						},
 						{
-							"id": "sanasb7gJ7Ab28t7F",
+							"id": "s5iseqE-6ZFqQbT_V",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -937,7 +937,7 @@
 							"points": 1
 						},
 						{
-							"id": "shXy3u_QScCIkVsuj",
+							"id": "svTFP7gM622RT8_sd",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -992,7 +992,7 @@
 							"points": 1
 						},
 						{
-							"id": "sY-AcqQmdE60RNbqn",
+							"id": "sVKnFdGkiz9xH32Rp",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1027,7 +1027,7 @@
 							"points": 1
 						},
 						{
-							"id": "s7yoyySEhRH8bZOYt",
+							"id": "se1pm0zrju3rBBDTO",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1060,7 +1060,7 @@
 							"points": 1
 						},
 						{
-							"id": "s48H6Wh9g3YPCFVMr",
+							"id": "s93zvrmdnS1ZlrREY",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1216,7 +1216,7 @@
 							"points": 1
 						},
 						{
-							"id": "se40tJsgyP7xSFjAv",
+							"id": "s6o6MGprVksp-ux8v",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1263,7 +1263,7 @@
 							"points": 1
 						},
 						{
-							"id": "sNxCHj1QYRv41PT1v",
+							"id": "srdtD5Cmw78a-4-2K",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1292,7 +1292,7 @@
 							"points": 1
 						},
 						{
-							"id": "splkZrKmYNMyHKUIV",
+							"id": "soi0tiANr0OxJrHbc",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1316,7 +1316,7 @@
 							"points": 1
 						},
 						{
-							"id": "s4xPDvdEyu1tGsON6",
+							"id": "sG9WkpWzZfSZyZCc6",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1368,7 +1368,7 @@
 							"points": 1
 						},
 						{
-							"id": "snCvWlWfpsc3ROx7y",
+							"id": "s2NOm8ZLlvtuB6XYC",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1416,7 +1416,7 @@
 							"points": 1
 						},
 						{
-							"id": "sxTXIWd7PdVnv89Fh",
+							"id": "satGUkyvyJkZPy8ZZ",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1445,7 +1445,7 @@
 							"points": 1
 						},
 						{
-							"id": "s_YcCT12OC0Wq8OAg",
+							"id": "sTtWUJbf3kB5x3JeX",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Crusader.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Crusader.gct
@@ -1077,7 +1077,7 @@
 							"points": 1
 						},
 						{
-							"id": "sanasb7gJ7Ab28t7F",
+							"id": "sb501_P3qhf4dzvLZ",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1188,7 +1188,7 @@
 							"points": 1
 						},
 						{
-							"id": "shXy3u_QScCIkVsuj",
+							"id": "skGQQrEZLwaTS7-NE",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1243,7 +1243,7 @@
 							"points": 2
 						},
 						{
-							"id": "sY-AcqQmdE60RNbqn",
+							"id": "sp4MtNmcUtLdEyaVy",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1278,7 +1278,7 @@
 							"points": 1
 						},
 						{
-							"id": "s7yoyySEhRH8bZOYt",
+							"id": "sRYMJNU39bKltMbs7",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1311,7 +1311,7 @@
 							"points": 1
 						},
 						{
-							"id": "s48H6Wh9g3YPCFVMr",
+							"id": "sUqfW1vcMjhdqXpHW",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1467,7 +1467,7 @@
 							"points": 1
 						},
 						{
-							"id": "se40tJsgyP7xSFjAv",
+							"id": "s-czs3W5ZDmJc9jOP",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1514,7 +1514,7 @@
 							"points": 1
 						},
 						{
-							"id": "sNxCHj1QYRv41PT1v",
+							"id": "szSnfoMbw7iXfjrud",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1543,7 +1543,7 @@
 							"points": 1
 						},
 						{
-							"id": "splkZrKmYNMyHKUIV",
+							"id": "s0qKvqNRGLGbY1hyM",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1567,7 +1567,7 @@
 							"points": 1
 						},
 						{
-							"id": "s4xPDvdEyu1tGsON6",
+							"id": "slJCxQpEEeDPlb15M",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1619,7 +1619,7 @@
 							"points": 1
 						},
 						{
-							"id": "snCvWlWfpsc3ROx7y",
+							"id": "sdf_KhZJIJp0XJ-l5",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1667,7 +1667,7 @@
 							"points": 1
 						},
 						{
-							"id": "sxTXIWd7PdVnv89Fh",
+							"id": "sp0RxEkkhkmWUCG4N",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1696,7 +1696,7 @@
 							"points": 1
 						},
 						{
-							"id": "s_YcCT12OC0Wq8OAg",
+							"id": "sTK2D8vWJqObQUsap",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior 2.gct
@@ -6592,7 +6592,7 @@
 			},
 			"children": [
 				{
-					"id": "sMSbWdcR-myBL2oqK",
+					"id": "s0uLY0TiLE6yoK140",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -6623,7 +6623,7 @@
 					"points": 1
 				},
 				{
-					"id": "sav-0_jmO6JCuA9wX",
+					"id": "sjZhuHyZ5wjh54FeS",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -6653,7 +6653,7 @@
 					"points": 1
 				},
 				{
-					"id": "sAVIqTAESbxVuNkEI",
+					"id": "sKa_hBcPHQknPDxXA",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -6683,7 +6683,7 @@
 					"points": 1
 				},
 				{
-					"id": "sbB257PZ1qA_fNfmu",
+					"id": "sTwrzdnIE7rajQoML",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -6769,7 +6769,7 @@
 					"points": 1
 				},
 				{
-					"id": "svTDCEhXiA__3RGkk",
+					"id": "s8N47tjpjCI698Ax6",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -6856,7 +6856,7 @@
 					"points": 1
 				},
 				{
-					"id": "stgHUe4Mi2l4rTKNY",
+					"id": "s3rPY2nwz0K7wxdWu",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -6937,7 +6937,7 @@
 					"points": 1
 				},
 				{
-					"id": "sAwQ_ORxYeFqfqnVt",
+					"id": "sxFRWCnA6nfthe4Lj",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -6970,7 +6970,7 @@
 					"points": 1
 				},
 				{
-					"id": "sRUDxMd8wXUZQSUW1",
+					"id": "sm1uEOdEcOG-sxqPM",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7018,7 +7018,7 @@
 					"points": 1
 				},
 				{
-					"id": "svjkF3q9LWIPXQmfi",
+					"id": "s8TWqbX9BwHHq-GaU",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7036,7 +7036,7 @@
 					"points": 1
 				},
 				{
-					"id": "sHkJ1Z35BNoL4bK-j",
+					"id": "sdxhRF8Tny08qAQmi",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7072,7 +7072,7 @@
 					"points": 1
 				},
 				{
-					"id": "stUUylGolOG0u226d",
+					"id": "sWlqp-p2Y9FsmcKzb",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7089,7 +7089,7 @@
 					"points": 1
 				},
 				{
-					"id": "sn6TeYGGJtNCL-7hH",
+					"id": "sQigQtEuVHzZIrHuN",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7106,7 +7106,7 @@
 					"points": 1
 				},
 				{
-					"id": "s_gPIDM43TSa2P9wJ",
+					"id": "sJsDOuLv3d0vIheqs",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7255,7 +7255,7 @@
 					"points": 1
 				},
 				{
-					"id": "s3WAgyMtDruby8uMq",
+					"id": "smX-37ZkYWcNlBTut",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7398,7 +7398,7 @@
 					"points": 1
 				},
 				{
-					"id": "skIbF7dGz58HmCZpz",
+					"id": "sBY7cN3AzOYDI0-ri",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7415,7 +7415,7 @@
 					"points": 1
 				},
 				{
-					"id": "swP-DWwYtWr5JKJ3A",
+					"id": "s3HGUipJi2fzNfLW9",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7485,7 +7485,7 @@
 					"points": 1
 				},
 				{
-					"id": "sCz1jwQez5N0h9dff",
+					"id": "sy1AAFcN0EZb3DJZE",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7857,7 +7857,7 @@
 					"points": 1
 				},
 				{
-					"id": "scy5GtNxrsEk3oy3r",
+					"id": "sAScbWz1FNgrjQ-Ca",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7888,7 +7888,7 @@
 					"points": 1
 				},
 				{
-					"id": "sewFXFL-P3_t_7OK9",
+					"id": "skDfkK1K3sCP_Fu5r",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7905,7 +7905,7 @@
 					"points": 1
 				},
 				{
-					"id": "s5JI7Nxpjh3Nw7E1p",
+					"id": "sNljbJSCVdOwUszbK",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7932,7 +7932,7 @@
 					"points": 1
 				},
 				{
-					"id": "sI9GJfhv9GoKSNxWQ",
+					"id": "sv4ruqAbt12MpevQF",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7956,7 +7956,7 @@
 					"points": 1
 				},
 				{
-					"id": "s9wVhNWU4hKBpaSlA",
+					"id": "sPcBTEWdCQy4Oqoqd",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7980,7 +7980,7 @@
 					"points": 1
 				},
 				{
-					"id": "scAw2Cl5sORCsUcQU",
+					"id": "sSwFSn3Oq-jfAZKu-",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -8009,7 +8009,7 @@
 					"points": 1
 				},
 				{
-					"id": "sA7gtdXFOlfsDLpJR",
+					"id": "sHvQ9Ip_9zITQyFVW",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -8039,7 +8039,7 @@
 					"points": 1
 				},
 				{
-					"id": "swiIjH9I1hQsVr0wR",
+					"id": "sOK9zC3SWPeFkuxnX",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -8063,7 +8063,7 @@
 					"points": 1
 				},
 				{
-					"id": "sVux6EqLQjBla9ezD",
+					"id": "s2wblHE7-d7cBJ4W-",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -8092,7 +8092,7 @@
 					"points": 1
 				},
 				{
-					"id": "sU-XdTpeiXFjSZm32",
+					"id": "skV-IXbShvEtf9wuN",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -8127,7 +8127,7 @@
 					"points": 1
 				},
 				{
-					"id": "sSJezeFqWqfuDVgXm",
+					"id": "sCwwJhZCt5FOYEd4E",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Finesse Warrior.gct
@@ -7249,7 +7249,7 @@
 					},
 					"children": [
 						{
-							"id": "sMSbWdcR-myBL2oqK",
+							"id": "svxTPwPbhSHuEahRc",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7280,7 +7280,7 @@
 							"points": 1
 						},
 						{
-							"id": "sav-0_jmO6JCuA9wX",
+							"id": "sW7QD9_jGheYZh8U3",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7310,7 +7310,7 @@
 							"points": 1
 						},
 						{
-							"id": "sAVIqTAESbxVuNkEI",
+							"id": "s9n1m3QPXu57fNhe3",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7340,7 +7340,7 @@
 							"points": 1
 						},
 						{
-							"id": "sbB257PZ1qA_fNfmu",
+							"id": "sgq5RpjExY1_13AV7",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7393,7 +7393,7 @@
 							"points": 1
 						},
 						{
-							"id": "svTDCEhXiA__3RGkk",
+							"id": "ssORcf7kBXp0L2DYC",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7480,7 +7480,7 @@
 							"points": 1
 						},
 						{
-							"id": "stgHUe4Mi2l4rTKNY",
+							"id": "sVijBsB96L2m9coAo",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7513,7 +7513,7 @@
 							"points": 1
 						},
 						{
-							"id": "sAwQ_ORxYeFqfqnVt",
+							"id": "sr3LeQrHCIafB3lL6",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7546,7 +7546,7 @@
 							"points": 1
 						},
 						{
-							"id": "sRUDxMd8wXUZQSUW1",
+							"id": "sTGQJMaJ2N11X6hdm",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7594,7 +7594,7 @@
 							"points": 1
 						},
 						{
-							"id": "svjkF3q9LWIPXQmfi",
+							"id": "sex_R25-jB6Nrjdxp",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7612,7 +7612,7 @@
 							"points": 1
 						},
 						{
-							"id": "sHkJ1Z35BNoL4bK-j",
+							"id": "sx_w7R3xEttMxz8hg",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7648,7 +7648,7 @@
 							"points": 1
 						},
 						{
-							"id": "stUUylGolOG0u226d",
+							"id": "syQyWqXXmjW62g9a9",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7665,7 +7665,7 @@
 							"points": 1
 						},
 						{
-							"id": "sn6TeYGGJtNCL-7hH",
+							"id": "s18XwqtAL0E8WEfyt",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7682,7 +7682,7 @@
 							"points": 1
 						},
 						{
-							"id": "s_gPIDM43TSa2P9wJ",
+							"id": "s2eJ1hSP-ddHZCbF3",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7718,7 +7718,7 @@
 							"points": 1
 						},
 						{
-							"id": "s3WAgyMtDruby8uMq",
+							"id": "sxX1LdifQq12Uxvh7",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7733,7 +7733,7 @@
 							"points": 1
 						},
 						{
-							"id": "skIbF7dGz58HmCZpz",
+							"id": "sjKIddxbXx8S_61Ei",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7750,7 +7750,7 @@
 							"points": 1
 						},
 						{
-							"id": "swP-DWwYtWr5JKJ3A",
+							"id": "sOA-WU1Clbza8TLo_",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7772,7 +7772,7 @@
 							"points": 1
 						},
 						{
-							"id": "sCz1jwQez5N0h9dff",
+							"id": "s4pj3z40IIZ93IZMW",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7906,7 +7906,7 @@
 							"points": 1
 						},
 						{
-							"id": "scy5GtNxrsEk3oy3r",
+							"id": "sFQ179fNIquGUBBRB",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7937,7 +7937,7 @@
 							"points": 1
 						},
 						{
-							"id": "sewFXFL-P3_t_7OK9",
+							"id": "sqXRDY-8Ua46OkkRw",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7954,7 +7954,7 @@
 							"points": 1
 						},
 						{
-							"id": "s5JI7Nxpjh3Nw7E1p",
+							"id": "sVPlN2cHN7AWOE-mQ",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -7981,7 +7981,7 @@
 							"points": 1
 						},
 						{
-							"id": "sI9GJfhv9GoKSNxWQ",
+							"id": "sWe-4kl4CxucB4x0j",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -8005,7 +8005,7 @@
 							"points": 1
 						},
 						{
-							"id": "s9wVhNWU4hKBpaSlA",
+							"id": "sPFAop7u4fCdVkgSi",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -8029,7 +8029,7 @@
 							"points": 1
 						},
 						{
-							"id": "scAw2Cl5sORCsUcQU",
+							"id": "smZ_-RQFDyyE4xPyq",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -8058,7 +8058,7 @@
 							"points": 1
 						},
 						{
-							"id": "sA7gtdXFOlfsDLpJR",
+							"id": "sV0zN0WjvIzRZi1Wb",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -8088,7 +8088,7 @@
 							"points": 1
 						},
 						{
-							"id": "swiIjH9I1hQsVr0wR",
+							"id": "sOsQki47YrYsNM7Zp",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -8112,7 +8112,7 @@
 							"points": 1
 						},
 						{
-							"id": "sVux6EqLQjBla9ezD",
+							"id": "sA7XIZNA0g64Sywx-",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -8141,7 +8141,7 @@
 							"points": 1
 						},
 						{
-							"id": "sU-XdTpeiXFjSZm32",
+							"id": "sxrkFu73Z_z7G1eNa",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -8176,7 +8176,7 @@
 							"points": 1
 						},
 						{
-							"id": "sSJezeFqWqfuDVgXm",
+							"id": "sU2lTsv2u84bsbbIj",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Mage 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Mage 2.gct
@@ -119,7 +119,7 @@
 							}
 						},
 						{
-							"id": "tEAm-TATUDcWmpnev",
+							"id": "tTRG3xxZrJUIO_6dp",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Mage.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Mage.gct
@@ -159,7 +159,7 @@
 							}
 						},
 						{
-							"id": "tEAm-TATUDcWmpnev",
+							"id": "tuTqTr0m2TdvmfKRR",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Master Archer 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Master Archer 2.gct
@@ -139,7 +139,7 @@
 									}
 								},
 								{
-									"id": "tdP0zMkulgqEqwWaz",
+									"id": "t4nQgo7PQAmV5VhEz",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Martial Arts/Martial Arts Traits.adq",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Master Archer.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Master Archer.gct
@@ -133,7 +133,7 @@
 									}
 								},
 								{
-									"id": "tdP0zMkulgqEqwWaz",
+									"id": "tw203_CVeu1bQ6O1j",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Martial Arts/Martial Arts Traits.adq",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Outdoorsy 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Outdoorsy 2.gct
@@ -246,7 +246,7 @@
 									}
 								},
 								{
-									"id": "tqznnATovFdxMwXs9",
+									"id": "t0Rs8MQTDG3R3Q3d4",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -517,7 +517,7 @@
 									}
 								},
 								{
-									"id": "t6F7yUWJqbVCL4Rf5",
+									"id": "tVsQy3cp5DnHieKKU",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -722,7 +722,7 @@
 					"points": 1
 				},
 				{
-					"id": "sm9lLtqoctzfXuuA9",
+					"id": "slQbgKcX8Ft5R0noe",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -793,7 +793,7 @@
 					"points": 1
 				},
 				{
-					"id": "sP7qK-snvdvl0ClTy",
+					"id": "sGE0wnN0x7MhZ06cT",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -854,7 +854,7 @@
 					"points": 1
 				},
 				{
-					"id": "sfGPpsU4UOEFPxzvO",
+					"id": "sqkEQLk4wt0FfCdQX",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -918,7 +918,7 @@
 					"points": 1
 				},
 				{
-					"id": "s6f2lxxo7ZSCVZAFl",
+					"id": "spJEUte-hPBk3NncA",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1067,7 +1067,7 @@
 					"points": 1
 				},
 				{
-					"id": "s71zTzoN6g1Hwfn1t",
+					"id": "sXxgHISCMGjUBab8B",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1120,7 +1120,7 @@
 					"points": 1
 				},
 				{
-					"id": "s97pwq4eKwJQZWZHM",
+					"id": "sixfpamjGQ7PAHE7O",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1147,7 +1147,7 @@
 					"points": 1
 				},
 				{
-					"id": "s6h0Y388QIPCR1ZF8",
+					"id": "sMQcSDcNeGxGzY1Qx",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1191,7 +1191,7 @@
 					"points": 1
 				},
 				{
-					"id": "se1xvumLtuhGVcDXz",
+					"id": "spyp97tLT0YAFFijE",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1803,7 +1803,7 @@
 					"points": 1
 				},
 				{
-					"id": "s7P_FWciO8sd4BQKu",
+					"id": "s_LRoxtTXhsnmFRbe",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Outdoorsy.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Outdoorsy.gct
@@ -211,7 +211,7 @@
 									}
 								},
 								{
-									"id": "tqznnATovFdxMwXs9",
+									"id": "tznOR3S0OO9-kIbn9",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -482,7 +482,7 @@
 									}
 								},
 								{
-									"id": "t6F7yUWJqbVCL4Rf5",
+									"id": "txo1MZf7u6gTFSwKp",
 									"source": {
 										"library": "richardwilkes/gcs_master_library",
 										"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -687,7 +687,7 @@
 					"points": 1
 				},
 				{
-					"id": "sm9lLtqoctzfXuuA9",
+					"id": "siYTOdenHm_NnEQzt",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -758,7 +758,7 @@
 					"points": 1
 				},
 				{
-					"id": "sP7qK-snvdvl0ClTy",
+					"id": "s84BVlDbRc0eV6xSz",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -819,7 +819,7 @@
 					"points": 1
 				},
 				{
-					"id": "sfGPpsU4UOEFPxzvO",
+					"id": "sovKBFHaLe3P4u0Na",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -883,7 +883,7 @@
 					"points": 1
 				},
 				{
-					"id": "s6f2lxxo7ZSCVZAFl",
+					"id": "sRhFlTaFfMjFXee5x",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1032,7 +1032,7 @@
 					"points": 1
 				},
 				{
-					"id": "s71zTzoN6g1Hwfn1t",
+					"id": "sqEo-U2tzKN5aFZAt",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1085,7 +1085,7 @@
 					"points": 1
 				},
 				{
-					"id": "s97pwq4eKwJQZWZHM",
+					"id": "sKWU-vlmNh3SviBdw",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1112,7 +1112,7 @@
 					"points": 1
 				},
 				{
-					"id": "s6h0Y388QIPCR1ZF8",
+					"id": "sxZ749r1tRvl1ETnm",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1156,7 +1156,7 @@
 					"points": 1
 				},
 				{
-					"id": "se1xvumLtuhGVcDXz",
+					"id": "syccoFB_NpsQoWCkt",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1768,7 +1768,7 @@
 					"points": 1
 				},
 				{
-					"id": "s7P_FWciO8sd4BQKu",
+					"id": "sbHauAwYh6a5NZEy8",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Physical 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Physical 2.gct
@@ -119,7 +119,7 @@
 							}
 						},
 						{
-							"id": "t58A2QWVL5lqHRvcF",
+							"id": "tIkHiyftJmkCKqDhV",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -174,7 +174,7 @@
 							}
 						},
 						{
-							"id": "tHnQh2wGQWPeX_Zbf",
+							"id": "tERW34FxCn4dIlhK5",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -309,7 +309,7 @@
 							}
 						},
 						{
-							"id": "tv6lGFDIiTk3d02fd",
+							"id": "txHwJtoqqP7oCPNMI",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -340,7 +340,7 @@
 							}
 						},
 						{
-							"id": "tOtpODo8veHFBuupw",
+							"id": "tXE8nTd-EjA9Fpokd",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -420,7 +420,7 @@
 							}
 						},
 						{
-							"id": "tiyi5uKICsaeonV2V",
+							"id": "tRgZkuq_g7jzOUtxu",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -441,7 +441,7 @@
 							}
 						},
 						{
-							"id": "tbpQe8nI5MkFnffxZ",
+							"id": "tdw4o-xklyBvy6-1d",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Physical.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Physical.gct
@@ -178,7 +178,7 @@
 							}
 						},
 						{
-							"id": "t58A2QWVL5lqHRvcF",
+							"id": "tVK_gz0lVoQpwfXAy",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -233,7 +233,7 @@
 							}
 						},
 						{
-							"id": "tHnQh2wGQWPeX_Zbf",
+							"id": "tXxIGyep5bvO3CfQI",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -342,7 +342,7 @@
 							}
 						},
 						{
-							"id": "tv6lGFDIiTk3d02fd",
+							"id": "t06mdumy9ehGqUzGG",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -373,7 +373,7 @@
 							}
 						},
 						{
-							"id": "tOtpODo8veHFBuupw",
+							"id": "tnShNnrK9-vb7l0x-",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -420,7 +420,7 @@
 							}
 						},
 						{
-							"id": "tiyi5uKICsaeonV2V",
+							"id": "tJNnrNcSk1uBhRvbD",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -441,7 +441,7 @@
 							}
 						},
 						{
-							"id": "tbpQe8nI5MkFnffxZ",
+							"id": "tagtAnqtFebOsP48m",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Rogue 2.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Rogue 2.gct
@@ -355,7 +355,7 @@
 							}
 						},
 						{
-							"id": "tmRizvmd91Nziq8aZ",
+							"id": "tdPbyVBmPMiZBKENZ",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -473,7 +473,7 @@
 							}
 						},
 						{
-							"id": "tNR6WXBZPsaTF8CpI",
+							"id": "ttJtr0svbSU2hXwM0",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -870,7 +870,7 @@
 					"points": 1
 				},
 				{
-					"id": "sUzHynZxbyv4__mYe",
+					"id": "sHwPoyb0zOc58wQNj",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1156,7 +1156,7 @@
 					"points": 1
 				},
 				{
-					"id": "sKwkQXyV68WekJF8w",
+					"id": "sVbZO1EK18tyGQtVZ",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1234,7 +1234,7 @@
 					"points": 1
 				},
 				{
-					"id": "sCEYaz_7M_ljtJcVC",
+					"id": "sZQiGq8zYt_Usr8UR",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1262,7 +1262,7 @@
 					"points": 1
 				},
 				{
-					"id": "sktaMv40xzrw44U4C",
+					"id": "sdoiYjy7LlDKZQtbw",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1292,7 +1292,7 @@
 					"points": 1
 				},
 				{
-					"id": "sK2kR2q3YDqqkqNFa",
+					"id": "sj3TxpbOWCS1yqquL",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1425,7 +1425,7 @@
 					"points": 1
 				},
 				{
-					"id": "sycgk3IMl3bi-Gile",
+					"id": "s60nHOHkWDdQaRnfE",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1597,7 +1597,7 @@
 					"points": 1
 				},
 				{
-					"id": "s8S9m0EgWojQMyHiI",
+					"id": "sAIWeimKn63nwyAOA",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Rogue 3.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Rogue 3.gct
@@ -355,7 +355,7 @@
 							}
 						},
 						{
-							"id": "tmRizvmd91Nziq8aZ",
+							"id": "tOJl_b1iB-wJ3TBa1",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -473,7 +473,7 @@
 							}
 						},
 						{
-							"id": "tNR6WXBZPsaTF8CpI",
+							"id": "t3h9xNY9RtvO_3Wcc",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -870,7 +870,7 @@
 					"points": 1
 				},
 				{
-					"id": "sUzHynZxbyv4__mYe",
+					"id": "sPNxQpL5tMiwdWcOz",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1156,7 +1156,7 @@
 					"points": 1
 				},
 				{
-					"id": "sKwkQXyV68WekJF8w",
+					"id": "s99N2_tCKS6g6a--E",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1234,7 +1234,7 @@
 					"points": 1
 				},
 				{
-					"id": "sCEYaz_7M_ljtJcVC",
+					"id": "sSMNSLP9LKyPsRGo_",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1262,7 +1262,7 @@
 					"points": 1
 				},
 				{
-					"id": "sktaMv40xzrw44U4C",
+					"id": "sEIIS2PY-3ntGkZov",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1292,7 +1292,7 @@
 					"points": 1
 				},
 				{
-					"id": "sK2kR2q3YDqqkqNFa",
+					"id": "sZf77x6RY-7Gjk2AK",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1425,7 +1425,7 @@
 					"points": 1
 				},
 				{
-					"id": "sycgk3IMl3bi-Gile",
+					"id": "sxaVLV7cqPBVsONbZ",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1597,7 +1597,7 @@
 					"points": 1
 				},
 				{
-					"id": "s8S9m0EgWojQMyHiI",
+					"id": "sww0xrApc2nJi7MM2",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",

--- a/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Rogue.gct
+++ b/Library/Pyramid Magazine/Pyramid 113/Five Easy Pieces/Rogue.gct
@@ -440,7 +440,7 @@
 							}
 						},
 						{
-							"id": "tNR6WXBZPsaTF8CpI",
+							"id": "tMgacW62tNI0ZLxNE",
 							"source": {
 								"library": "richardwilkes/gcs_master_library",
 								"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Traits.adq",
@@ -709,7 +709,7 @@
 					"points": 1
 				},
 				{
-					"id": "sUzHynZxbyv4__mYe",
+					"id": "sKfeIFvZbMu1-uhE5",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -995,7 +995,7 @@
 					"points": 1
 				},
 				{
-					"id": "sKwkQXyV68WekJF8w",
+					"id": "smEXWgn6If8gZBi7x",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1073,7 +1073,7 @@
 					"points": 1
 				},
 				{
-					"id": "sCEYaz_7M_ljtJcVC",
+					"id": "sDJRWsPpoG97Arex3",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1101,7 +1101,7 @@
 					"points": 1
 				},
 				{
-					"id": "sktaMv40xzrw44U4C",
+					"id": "sKB1ySAxi73tWtJCa",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1131,7 +1131,7 @@
 					"points": 1
 				},
 				{
-					"id": "sK2kR2q3YDqqkqNFa",
+					"id": "sNFu9UphlXGzYYUn1",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1264,7 +1264,7 @@
 					"points": 1
 				},
 				{
-					"id": "sycgk3IMl3bi-Gile",
+					"id": "smp5a20uO7EqgNW3I",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",
@@ -1436,7 +1436,7 @@
 					"points": 1
 				},
 				{
-					"id": "s8S9m0EgWojQMyHiI",
+					"id": "sJN678wqArp9pXgkd",
 					"source": {
 						"library": "richardwilkes/gcs_master_library",
 						"path": "Dungeon Fantasy RPG/Dungeon Fantasy RPG Skills.skl",


### PR DESCRIPTION
Doing some data analysis I identified a large number of records using duplicate TID values. These seem to be caused by something like copy/paste of the files or file data.

This group of duplicates were tested to, on the dupe group level, all have the same TID, all use the same Source, have zero Sources referencing them, and all be identical. The repair help minted new TIDs for all dupe group members using the toolbox TID code so they are identical to what GCS would create.